### PR TITLE
Support scala_import and java_import in bazel MBT importer

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
@@ -16,6 +16,7 @@ import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.mbt.MbtBuild
+import scala.meta.internal.metals.mbt.MbtDependencyModule
 import scala.meta.internal.process.ExitCodes
 import scala.meta.io.AbsolutePath
 
@@ -101,12 +102,40 @@ abstract class BazelMbtImporter(
         runTargets,
         targetsXmlDump.ruleOutputsByTarget,
       )
-      deps = queryDeps(targets.toSet, targets, targetsXmlDump)
-      externalDeps = targetsXmlDump.externalDepsByTarget(targets)
+      targetSet = targets.toSet
+      deps = queryDeps(targetSet, targets, targetsXmlDump)
+      reachableLabelsByTarget = targetsXmlDump.reachableLabels(targets)
+      externalDeps =
+        targetsXmlDump.externalDepsByTarget(reachableLabelsByTarget)
       externalDepModules = BazelMavenJsonImporter.matchExternalDeps(
         externalDeps,
         dependencyModules,
         mavenHubs,
+      )
+      importTargets =
+        targetSet.filter(targetsXmlDump.jarLabelsByImportTarget.contains)
+      _ = scribe.info(s"bazel-mbt: import targets: $importTargets")
+      importTargetJarLabels = importTargets.map { target =>
+        target -> resolvedJarLabels(
+          target,
+          targetsXmlDump.jarLabelsByImportTarget,
+          targetsXmlDump.ruleOutputsByTarget,
+        )
+      }.toMap
+      importJarModules = buildImportJarModules(
+        importTargetJarLabels,
+        targetsXmlDump.sourcesJarByImportTarget,
+        bazelBin,
+      )
+      importDepModules = buildImportModuleIdsByTarget(
+        targets,
+        importTargetJarLabels,
+        reachableLabelsByTarget,
+      )
+      allDependencyModules = dependencyModules ++ importJarModules
+      allExternalDepModules = mergeDepsModuleMaps(
+        externalDepModules,
+        importDepModules,
       )
       scalaVersionFromDeps <- queryScalaVersionFromDeps()
       effectiveScalaVersion <- scalaVersionFromDeps match {
@@ -120,10 +149,10 @@ abstract class BazelMbtImporter(
         scalacOptions,
         javacOptions,
         deps,
-        externalDepModules,
+        allExternalDepModules,
         runTargets,
         classDirectories,
-        dependencyModules,
+        allDependencyModules,
         effectiveScalaVersion,
         genSrcOutputsByTarget,
       )
@@ -207,6 +236,123 @@ abstract class BazelMbtImporter(
   ): Map[String, List[String]] = {
     orderedTargets.map { target =>
       target -> targetsXml.depsByTarget.getOrElse(target, Nil).filter(targetSet)
+    }.toMap
+  }
+
+  private def buildImportJarModules(
+      importTargetJarLabels: Map[String, List[String]],
+      sourcesJarByTarget: Map[String, Option[String]],
+      bazelBin: Option[Path],
+  ): Seq[MbtDependencyModule] = {
+    val seen = scala.collection.mutable.Set.empty[String]
+    importTargetJarLabels.toSeq.sortBy(_._1).flatMap {
+      case (target, jarLabels) =>
+        // unlike "jars", "srcjar" argument is not a list — attach it to the first jar only
+        val sourcesUri =
+          if (jarLabels.nonEmpty)
+            sourcesJarByTarget
+              .get(target)
+              .flatten
+              .flatMap(
+                resolveJarUri(_, bazelBin)
+              )
+          else None
+        jarLabels.zipWithIndex.flatMap { case (jarLabel, i) =>
+          moduleIdFromJarLabel(jarLabel) match {
+            case None =>
+              scribe.warn(
+                s"bazel-mbt: could not derive module id for jar label $jarLabel"
+              )
+              None
+            case Some(moduleId) if seen.contains(moduleId) => None
+            case Some(moduleId) =>
+              seen += moduleId
+              resolveJarUri(jarLabel, bazelBin).map { jar =>
+                MbtDependencyModule(
+                  id = moduleId,
+                  jar = jar,
+                  sources = if (i == 0) sourcesUri.orNull else null,
+                )
+              }
+          }
+        }
+    }
+  }
+
+  private def buildImportModuleIdsByTarget(
+      targets: List[String],
+      importTargetJarLabels: Map[String, List[String]],
+      reachableLabelsByTarget: Map[String, List[String]],
+  ): Map[String, List[String]] = {
+    val ownModuleIds = importTargetJarLabels.map { case (target, jarLabels) =>
+      target -> jarLabels.flatMap(moduleIdFromJarLabel).distinct
+    }
+    targets.map { target =>
+      val transitiveIds = reachableLabelsByTarget
+        .getOrElse(target, Nil)
+        .flatMap(ownModuleIds.getOrElse(_, Nil))
+      target -> (ownModuleIds.getOrElse(target, Nil) ++ transitiveIds).distinct
+    }.toMap
+  }
+
+  /**
+   * A `java_import`/`scala_import`'s `jars` attribute can point at a
+   * genrule or a raw file. We try to return the outputted jar of that genrule,
+   * or, if it doesn't exist, we return it as if it was a raw file.
+   */
+  private def resolvedJarLabels(
+      target: String,
+      jarLabelsByTarget: Map[String, List[String]],
+      ruleOutputsByTarget: Map[String, List[String]],
+  ): List[String] =
+    jarLabelsByTarget.getOrElse(target, Nil).map { label =>
+      ruleOutputsByTarget
+        .getOrElse(label, Nil)
+        .find(isClassJarOutput)
+        .getOrElse(label)
+    }
+
+  private def moduleIdFromJarLabel(label: String): Option[String] =
+    BazelMbtBuildSupport.fileLabelToWorkspaceRelativePath(label).map {
+      relative =>
+        val lastSlash = relative.lastIndexOf('/')
+        if (lastSlash >= 0) {
+          val pkg = relative.substring(0, lastSlash).replace('/', '.')
+          val fileName = relative.substring(lastSlash + 1)
+          s"$pkg:$fileName:local"
+        } else {
+          s"root:$relative:local"
+        }
+    }
+
+  private def resolveJarUri(
+      label: String,
+      bazelBin: Option[Path],
+  ): Option[String] = {
+    BazelMbtBuildSupport.fileLabelToWorkspaceRelativePath(label).flatMap {
+      relative =>
+        val candidate = projectRoot.resolve(relative)
+        if (Files.exists(candidate.toNIO)) Some(candidate.toURI.toString)
+        else {
+          val generatedCandidate = bazelBin.map(_.resolve(relative))
+          generatedCandidate.filter(Files.exists(_)) match {
+            case Some(path) => Some(path.toUri.toString)
+            case None =>
+              scribe.warn(
+                s"bazel-mbt: could not resolve jar for label $label"
+              )
+              None
+          }
+        }
+    }
+  }
+
+  private def mergeDepsModuleMaps(
+      maps: Map[String, List[String]]*
+  ): Map[String, List[String]] = {
+    val allKeys = maps.flatMap(_.keySet).toSet
+    allKeys.map { key =>
+      key -> maps.flatMap(_.getOrElse(key, Nil)).distinct.toList
     }.toMap
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
@@ -106,7 +106,7 @@ object BazelQuery {
   private val ruleKinds: List[String] =
     List(
       "scala_library", "java_library", "scala_binary", "java_binary",
-      "scala_test", "java_test",
+      "scala_test", "java_test", "scala_import", "java_import",
     )
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelTargetsXmlDump.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelTargetsXmlDump.scala
@@ -90,14 +90,43 @@ class BazelTargetsXmlDump(xmlDump: String) {
     } yield name).toSet
   }
 
-  def externalDepsByTarget(targets: List[String]): Map[String, List[String]] = {
-    reachableLabels(targets).map { case (target, deps) =>
+  def externalDepsByTarget(
+      reachableLabelsByTarget: Map[String, List[String]]
+  ): Map[String, List[String]] =
+    reachableLabelsByTarget.map { case (target, deps) =>
       target -> deps.filter(isExternalDep)
     }
+
+  lazy val jarLabelsByImportTarget: Map[String, List[String]] = {
+    val targetLabels = for {
+      rule <- root \\ "rule"
+      target = (rule \ "@name").text
+      if target.nonEmpty && isImportRule(rule)
+    } yield target -> labelsFromRuleAttribute(rule, Some("jars")).toList
+    targetLabels.toMap
+  }
+
+  // These are -sources.jar entries meant for IDEs, not the .srcjar files used for compilation,
+  // even though rules_scala calls them "srcjar"
+  lazy val sourcesJarByImportTarget: Map[String, Option[String]] = {
+    val targetLabels = for {
+      rule <- root \\ "rule"
+      target = (rule \ "@name").text
+      if target.nonEmpty && isScalaImportRule(rule)
+    } yield target -> labelsFromRuleAttribute(rule, Some("srcjar")).headOption
+    targetLabels.toMap
   }
 
   private def isExternalDep(label: String): Boolean =
     label.startsWith("@") && !label.startsWith("@@")
+
+  private def isImportRule(rule: scala.xml.Node): Boolean = {
+    val cls = (rule \ "@class").text
+    cls == "java_import" || cls == "scala_import"
+  }
+
+  private def isScalaImportRule(rule: scala.xml.Node): Boolean =
+    (rule \ "@class").text == "scala_import"
 
   private def isFilegroupRule(rule: scala.xml.Node): Boolean =
     (rule \ "@class").text == "filegroup"
@@ -114,7 +143,7 @@ class BazelTargetsXmlDump(xmlDump: String) {
     labels.flatMap(label => expand(label, Set.empty)).distinct
   }
 
-  private def reachableLabels(
+  def reachableLabels(
       rootLabels: List[String]
   ): Map[String, List[String]] =
     rootLabels.map { root =>

--- a/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
@@ -773,6 +773,122 @@ class BazelMbtLspSuite
     } yield ()
   }
 
+  private def scalaImportBazelWorkspaceLayout: String =
+    """|/.bazelproject
+       |targets:
+       |    //...
+       |
+       |/third_party/BUILD
+       |load("@rules_scala//scala:scala_import.bzl", "scala_import")
+       |
+       |scala_import(
+       |    name = "mylib",
+       |    jars = ["mylib.jar"],
+       |    srcjar = "mylib-sources.jar",
+       |    visibility = ["//visibility:public"],
+       |)
+       |
+       |java_import(
+       |    name = "myother",
+       |    jars = ["myother.jar"],
+       |    visibility = ["//visibility:public"],
+       |)
+       |
+       |/third_party/mylib.jar
+       |
+       |/third_party/mylib-sources.jar
+       |
+       |/third_party/myother.jar
+       |
+       |/app/BUILD
+       |load("@rules_scala//scala:scala.bzl", "scala_library")
+       |
+       |scala_library(
+       |    name = "app",
+       |    srcs = ["App.scala"],
+       |    deps = ["//third_party:mylib", "//third_party:myother"],
+       |)
+       |
+       |/app/App.scala
+       |package app
+       |
+       |class App
+       |""".stripMargin
+
+  test("bazel-import-mbt-scala-import") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        BazelBuildLayout(
+          scalaImportBazelWorkspaceLayout,
+          V.scala213,
+          bazelVersion,
+        ),
+        runAdditionalCommands = { workspace =>
+          def writeEmptyJar(path: AbsolutePath): Unit = {
+            val jos = new java.util.jar.JarOutputStream(
+              new java.io.FileOutputStream(path.toString),
+              new java.util.jar.Manifest(),
+            )
+            jos.close()
+          }
+          writeEmptyJar(workspace.resolve("third_party/mylib.jar"))
+          writeEmptyJar(workspace.resolve("third_party/mylib-sources.jar"))
+          writeEmptyJar(workspace.resolve("third_party/myother.jar"))
+        },
+      )
+      _ <- server.headServer.connectionProvider.buildServerPromise.future
+      mbtFile = workspace.resolve(".metals/mbt.json").readText
+      _ = assertNoDiff(
+        escapeMbtFile(mbtFile),
+        s"""|{
+            |  "dependencyModules": [
+            |    {
+            |      "id": "third_party:mylib.jar:local",
+            |      "jar": "<jar-path>",
+            |      "sources": "<sources-path>"
+            |    },
+            |    {
+            |      "id": "third_party:myother.jar:local",
+            |      "jar": "<jar-path>"
+            |    }
+            |  ],
+            |  "namespaces": {
+            |    "//third_party": {
+            |      "sources": [],
+            |      "scalacOptions": [],
+            |      "javacOptions": [],
+            |      "dependencyModules": [
+            |        "third_party:mylib.jar:local",
+            |        "third_party:myother.jar:local"
+            |      ],
+            |      "scalaVersion": "2.13.18",
+            |      "dependsOn": [],
+            |      "classDirectories": []
+            |    },
+            |    "//app": {
+            |      "sources": [
+            |        "app/App.scala"
+            |      ],
+            |      "scalacOptions": [],
+            |      "javacOptions": [],
+            |      "dependencyModules": [
+            |        "third_party:mylib.jar:local",
+            |        "third_party:myother.jar:local"
+            |      ],
+            |      "scalaVersion": "2.13.18",
+            |      "dependsOn": [
+            |        "//third_party"
+            |      ],
+            |      "classDirectories": []
+            |    }
+            |  },
+            |  "uncheckedSources": []
+            |}""".stripMargin,
+      )
+    } yield ()
+  }
+
   test("bazel-import-mbt-workspace-namespace-choice") {
     client.selectedServer = Messages.ChooseBuildServer.mbt
     cleanWorkspace()


### PR DESCRIPTION
This adds support in bazel mbt automatic importer for targets like:
```scala
scala_import(
    name = "foo",
    jars = [
        "lib/foo.jar", # labels (like :someGenRule) are also supported
    ],
)
```
For scala_import, `srcjar` (actually referring to `-sources.jar`, for IDEs) is supported (`java_import` doesn't have such a field). 