### PR TITLE
Add `textDocument/declaration` support for Java and fix overload resolution in go-to-definition

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -1440,16 +1440,12 @@ class Compilers(
   def declaration(
       params: TextDocumentPositionParams,
       token: CancelToken,
-  ): Future[DefinitionResult] = {
-    val path = params.getTextDocument.getUri.toAbsolutePath
-    if (path.isJavaFilename)
-      definition(
-        params = params,
-        token = token,
-        Compilers.DefinitionMode.Declaration,
-      )
-    else Future.successful(DefinitionResult.empty)
-  }
+  ): Future[DefinitionResult] =
+    definition(
+      params = params,
+      token = token,
+      Compilers.DefinitionMode.Declaration,
+    )
 
   def typeDefinition(
       params: TextDocumentPositionParams,
@@ -1501,9 +1497,9 @@ class Compilers(
       val defResult =
         mode match {
           case Compilers.DefinitionMode.Definition =>
-            pc.definition(CompilerOffsetParamsUtils.fromPos(pos, token))
+            pc.definition(paramsWithOutline)
           case Compilers.DefinitionMode.Declaration =>
-            pc.declaration(CompilerOffsetParamsUtils.fromPos(pos, token))
+            pc.declaration(paramsWithOutline)
           case Compilers.DefinitionMode.TypeDefinition =>
             pc.typeDefinition(paramsWithOutline)
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -1430,14 +1430,36 @@ class Compilers(
       params: TextDocumentPositionParams,
       token: CancelToken,
   ): Future[DefinitionResult] = {
-    definition(params = params, token = token, findTypeDef = false)
+    definition(
+      params = params,
+      token = token,
+      Compilers.DefinitionMode.Definition,
+    )
+  }
+
+  def declaration(
+      params: TextDocumentPositionParams,
+      token: CancelToken,
+  ): Future[DefinitionResult] = {
+    val path = params.getTextDocument.getUri.toAbsolutePath
+    if (path.isJavaFilename)
+      definition(
+        params = params,
+        token = token,
+        Compilers.DefinitionMode.Declaration,
+      )
+    else Future.successful(DefinitionResult.empty)
   }
 
   def typeDefinition(
       params: TextDocumentPositionParams,
       token: CancelToken,
   ): Future[DefinitionResult] = {
-    definition(params = params, token = token, findTypeDef = true)
+    definition(
+      params = params,
+      token = token,
+      Compilers.DefinitionMode.TypeDefinition,
+    )
   }
 
   def info(
@@ -1467,7 +1489,7 @@ class Compilers(
   private def definition(
       params: TextDocumentPositionParams,
       token: CancelToken,
-      findTypeDef: Boolean,
+      mode: Compilers.DefinitionMode,
   ): Future[DefinitionResult] =
     withPCAndAdjustLsp(params) { (pc, pos, adjust) =>
       val paramsWithOutline = CompilerOffsetParamsUtils.fromPos(
@@ -1477,9 +1499,14 @@ class Compilers(
       )
 
       val defResult =
-        if (findTypeDef) pc.typeDefinition(paramsWithOutline)
-        else
-          pc.definition(CompilerOffsetParamsUtils.fromPos(pos, token))
+        mode match {
+          case Compilers.DefinitionMode.Definition =>
+            pc.definition(CompilerOffsetParamsUtils.fromPos(pos, token))
+          case Compilers.DefinitionMode.Declaration =>
+            pc.declaration(CompilerOffsetParamsUtils.fromPos(pos, token))
+          case Compilers.DefinitionMode.TypeDefinition =>
+            pc.typeDefinition(paramsWithOutline)
+        }
 
       for {
         c <- defResult.asScala
@@ -2237,6 +2264,13 @@ class Compilers(
 }
 
 object Compilers {
+
+  private sealed trait DefinitionMode
+  private object DefinitionMode {
+    case object Definition extends DefinitionMode
+    case object Declaration extends DefinitionMode
+    case object TypeDefinition extends DefinitionMode
+  }
 
   sealed trait PresentationCompilerKey
   object PresentationCompilerKey {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1276,6 +1276,13 @@ abstract class MetalsLspService(
       result.map(_.locations)
     }
 
+  override def declaration(
+      position: TextDocumentPositionParams
+  ): CompletableFuture[util.List[Location]] =
+    CancelTokens.future { token =>
+      compilers.declaration(position, token).map(_.locations)
+    }
+
   override def typeDefinition(
       position: TextDocumentPositionParams
   ): CompletableFuture[util.List[Location]] =

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -549,6 +549,11 @@ class WorkspaceLspService(
   ): CompletableFuture[ju.List[Location]] =
     getServiceFor(position.getTextDocument().getUri()).definition(position)
 
+  override def declaration(
+      position: TextDocumentPositionParams
+  ): CompletableFuture[ju.List[Location]] =
+    getServiceFor(position.getTextDocument().getUri()).declaration(position)
+
   override def typeDefinition(
       position: TextDocumentPositionParams
   ): CompletableFuture[ju.List[Location]] =
@@ -1578,6 +1583,7 @@ class WorkspaceLspService(
         capabilities.setSemanticTokensProvider(semanticTokenOptions)
         capabilities.setCodeLensProvider(new lsp4j.CodeLensOptions(false))
         capabilities.setDefinitionProvider(true)
+        capabilities.setDeclarationProvider(true)
         capabilities.setTypeDefinitionProvider(true)
         capabilities.setImplementationProvider(true)
         capabilities.setHoverProvider(true)

--- a/metals/src/main/scala/scala/meta/metals/lsp/DelegatingScalaService.scala
+++ b/metals/src/main/scala/scala/meta/metals/lsp/DelegatingScalaService.scala
@@ -69,6 +69,10 @@ class DelegatingScalaService(
       position: TextDocumentPositionParams
   ): CompletableFuture[util.List[Location]] = underlying.definition(position)
 
+  override def declaration(
+      position: TextDocumentPositionParams
+  ): CompletableFuture[util.List[Location]] = underlying.declaration(position)
+
   override def typeDefinition(
       position: TextDocumentPositionParams
   ): CompletableFuture[util.List[Location]] =

--- a/metals/src/main/scala/scala/meta/metals/lsp/TextDocumentService.scala
+++ b/metals/src/main/scala/scala/meta/metals/lsp/TextDocumentService.scala
@@ -38,6 +38,11 @@ trait TextDocumentService {
       position: TextDocumentPositionParams
   ): CompletableFuture[util.List[Location]]
 
+  @JsonRequest("textDocument/declaration")
+  def declaration(
+      position: TextDocumentPositionParams
+  ): CompletableFuture[util.List[Location]]
+
   @JsonRequest("textDocument/typeDefinition")
   def typeDefinition(
       position: TextDocumentPositionParams

--- a/mtags-interfaces/src/main/java/scala/meta/pc/DefinitionResult.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/DefinitionResult.java
@@ -1,9 +1,24 @@
 package scala.meta.pc;
 
+import java.util.Collections;
 import java.util.List;
 import org.eclipse.lsp4j.Location;
 
 public interface DefinitionResult {
+  static DefinitionResult empty() {
+    return new DefinitionResult() {
+      @Override
+      public String symbol() {
+        return "";
+      }
+
+      @Override
+      public List<Location> locations() {
+        return Collections.emptyList();
+      }
+    };
+  }
+
   String symbol();
 
   List<Location> locations();

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -90,6 +90,11 @@ public abstract class PresentationCompiler {
   /** Returns the definition of the symbol at the given position. */
   public abstract CompletableFuture<DefinitionResult> definition(OffsetParams params);
 
+  /** Returns the declaration of the symbol at the given position. */
+  public CompletableFuture<DefinitionResult> declaration(OffsetParams params) {
+    return CompletableFuture.completedFuture(DefinitionResult.empty());
+  }
+
   /** Returns location of the expression's type definition at the given position. */
   public abstract CompletableFuture<DefinitionResult> typeDefinition(OffsetParams params);
 

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -92,7 +92,7 @@ public abstract class PresentationCompiler {
 
   /** Returns the declaration of the symbol at the given position. */
   public CompletableFuture<DefinitionResult> declaration(OffsetParams params) {
-    return CompletableFuture.completedFuture(DefinitionResult.empty());
+    return definition(params);
   }
 
   /** Returns location of the expression's type definition at the given position. */

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDefinitionProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDefinitionProvider.scala
@@ -5,6 +5,8 @@ import javax.lang.model.`type`.ExecutableType
 import javax.lang.model.`type`.TypeMirror
 import javax.lang.model.`type`.TypeVariable
 import javax.lang.model.element.Element
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.TypeElement
 
 import scala.jdk.CollectionConverters._
@@ -29,6 +31,12 @@ import org.eclipse.{lsp4j => l}
 trait DefinitionProcessor {
   def transformElement(element: Element): Option[Element]
 }
+trait CompileDefinitionProcessor extends DefinitionProcessor {
+  def transformElement(
+      element: Element,
+      compile: JavaSourceCompile
+  ): Option[Element]
+}
 object NoopDefinitionProcessor extends DefinitionProcessor {
   def transformElement(element: Element): Option[Element] =
     Option(element)
@@ -45,6 +53,64 @@ object TypeDefinitionProcessor extends DefinitionProcessor {
       case _ => None // Primitive types have no definition
     }
 }
+object DeclarationDefinitionProcessor extends CompileDefinitionProcessor {
+  def transformElement(element: Element): Option[Element] =
+    NoopDefinitionProcessor.transformElement(element)
+
+  def transformElement(
+      element: Element,
+      compile: JavaSourceCompile
+  ): Option[Element] =
+    Option(element)
+      .flatMap {
+        case method: ExecutableElement
+            if method.getKind() == ElementKind.METHOD =>
+          topmostOverriddenMethod(method, compile)
+        case _ => None
+      }
+      .orElse(transformElement(element))
+
+  private def topmostOverriddenMethod(
+      method: ExecutableElement,
+      compile: JavaSourceCompile
+  ): Option[ExecutableElement] = {
+    val elements = compile.task.getElements()
+    val types = compile.task.getTypes()
+
+    def asTypeElement(e: Element): Option[TypeElement] = e match {
+      case t: TypeElement => Some(t)
+      case _ => None
+    }
+
+    def directlyOverridden(
+        m: ExecutableElement
+    ): Option[ExecutableElement] =
+      for {
+        owner <- asTypeElement(m.getEnclosingElement())
+        parent <- types
+          .directSupertypes(owner.asType())
+          .asScala
+          .view
+          .flatMap(st => asTypeElement(types.asElement(st)))
+          .flatMap(_.getEnclosedElements().asScala)
+          .collectFirst {
+            case c: ExecutableElement
+                if c.getKind() == ElementKind.METHOD &&
+                  elements.overrides(m, c, owner) =>
+              c
+          }
+      } yield parent
+
+    @scala.annotation.tailrec
+    def loop(m: ExecutableElement): ExecutableElement =
+      directlyOverridden(m) match {
+        case Some(parent) => loop(parent)
+        case None => m
+      }
+
+    directlyOverridden(method).map(loop)
+  }
+}
 
 class JavaDefinitionProvider(
     compiler: JavaMetalsCompiler,
@@ -52,22 +118,32 @@ class JavaDefinitionProvider(
     processor: DefinitionProcessor = NoopDefinitionProcessor
 ) {
 
+  private def transformElement(
+      element: Element,
+      compile: JavaSourceCompile
+  ): Option[Element] =
+    processor match {
+      case compileProcessor: CompileDefinitionProcessor =>
+        compileProcessor.transformElement(element, compile)
+      case _ =>
+        processor.transformElement(element)
+    }
+
   def definition(): DefinitionResult = {
     val compileAndNode = compiler.nodeAtPosition(params)
     val result: Option[DefinitionResult] = for {
       (compile, node) <- compileAndNode
       trees = Trees.instance(compile.task)
-      element <- processor
-        .transformElement(trees.getElement(node))
+      element <- transformElement(trees.getElement(node), compile)
         .orElse(Option(trees.getElement(node)))
     } yield {
       val sourcePositions = trees.getSourcePositions()
-      val source = definitionSource(node, trees, element)
+      val source = definitionSource(compile, node, trees, element)
       source match {
         case Sourcepath(all @ (firstPath :: _)) =>
           val locations = for {
             p <- all.iterator
-            pElement <- processor.transformElement(trees.getElement(p)).toList
+            pElement <- transformElement(trees.getElement(p), compile).toList
             defn <- sourceDefinition(
               compile,
               sourcePositions,
@@ -153,6 +229,7 @@ class JavaDefinitionProvider(
   }
 
   private def definitionSource(
+      compile: JavaSourceCompile,
       node: TreePath,
       trees: Trees,
       element: Element
@@ -173,7 +250,7 @@ class JavaDefinitionProvider(
                 val ambiguousElements = (for {
                   elem <- c.getEnclosedElements().asScala.iterator
                   if elem.getSimpleName().toString() == elementName
-                  processed <- processor.transformElement(elem).toList
+                  processed <- transformElement(elem, compile).toList
                 } yield processed).distinct.toList
                 val ambiguousPaths = for {
                   member <- ambiguousElements

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDefinitionProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDefinitionProvider.scala
@@ -8,6 +8,7 @@ import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.TypeElement
+import javax.lang.model.util.Types
 
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
@@ -124,7 +125,8 @@ class JavaDefinitionProvider(
         .orElse(Option(trees.getElement(node)).map(List(_)))
     } yield {
       val sourcePositions = trees.getSourcePositions()
-      val source = definitionSource(compile, node, trees, elements)
+      val types = compile.task.getTypes()
+      val source = definitionSource(compile, node, trees, elements, types)
       source match {
         case Sourcepath(all @ (firstPath :: _)) =>
           val locations = for {
@@ -214,11 +216,29 @@ class JavaDefinitionProvider(
     }
   }
 
+  private def matchesSignature(
+      target: Element,
+      candidate: Element,
+      types: Types
+  ): Boolean =
+    (target, candidate) match {
+      case (a: ExecutableElement, b: ExecutableElement) =>
+        val paramsA = a.getParameters().asScala.toList
+        val paramsB = b.getParameters().asScala.toList
+        paramsA.size == paramsB.size &&
+        paramsA.zip(paramsB).forall { case (pa, pb) =>
+          types.isSameType(pa.asType(), pb.asType())
+        }
+      case (_: ExecutableElement, _) | (_, _: ExecutableElement) => false
+      case _ => true
+    }
+
   private def definitionSource(
       compile: JavaSourceCompile,
       node: TreePath,
       trees: Trees,
-      elements: List[Element]
+      elements: List[Element],
+      types: Types
   ): DefinitionSource = {
     val paths = elements.flatMap(e => Option(trees.getPath(e)))
     if (paths.nonEmpty) return Sourcepath(paths)
@@ -231,11 +251,19 @@ class JavaDefinitionProvider(
             parentElement match {
               case c: TypeElement =>
                 val elementName = element.getSimpleName().toString()
-                val ambiguousElements = (for {
+                val candidateElements = (for {
                   elem <- c.getEnclosedElements().asScala.iterator
                   if elem.getSimpleName().toString() == elementName
                   processed <- processor.transformElement(elem, compile)
-                } yield processed).distinct.toList
+                } yield (
+                  matchesSignature(element, elem, types),
+                  processed
+                )).toList
+                val (matched, fallback) = candidateElements.partition(_._1)
+                val ambiguousElements =
+                  (if (matched.nonEmpty) matched else fallback)
+                    .map(_._2)
+                    .distinct
                 val ambiguousPaths = for {
                   member <- ambiguousElements
                   path <- Option(trees.getPath(member)).toList

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDefinitionProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDefinitionProvider.scala
@@ -29,22 +29,25 @@ import org.eclipse.{lsp4j => l}
 // textDocument/definition implementation by only doing a minor transform on
 // resolved javac elements.
 trait DefinitionProcessor {
-  def transformElement(element: Element): Option[Element]
-}
-trait CompileDefinitionProcessor extends DefinitionProcessor {
   def transformElement(
       element: Element,
       compile: JavaSourceCompile
-  ): Option[Element]
+  ): List[Element]
 }
 object NoopDefinitionProcessor extends DefinitionProcessor {
-  def transformElement(element: Element): Option[Element] =
-    Option(element)
+  def transformElement(
+      element: Element,
+      compile: JavaSourceCompile
+  ): List[Element] =
+    Option(element).toList
 }
 object TypeDefinitionProcessor extends DefinitionProcessor {
-  def transformElement(element: Element): Option[Element] =
+  def transformElement(
+      element: Element,
+      compile: JavaSourceCompile
+  ): List[Element] =
     // Instead of returning the resolved element, return the element of its type.
-    Option(element).flatMap(e => processType(e.asType()))
+    Option(element).flatMap(e => processType(e.asType())).toList
   private def processType(tpe: TypeMirror): Option[Element] =
     tpe match {
       case d: DeclaredType => Some(d.asElement())
@@ -53,27 +56,25 @@ object TypeDefinitionProcessor extends DefinitionProcessor {
       case _ => None // Primitive types have no definition
     }
 }
-object DeclarationDefinitionProcessor extends CompileDefinitionProcessor {
-  def transformElement(element: Element): Option[Element] =
-    NoopDefinitionProcessor.transformElement(element)
-
+object DeclarationDefinitionProcessor extends DefinitionProcessor {
   def transformElement(
       element: Element,
       compile: JavaSourceCompile
-  ): Option[Element] =
-    Option(element)
-      .flatMap {
-        case method: ExecutableElement
-            if method.getKind() == ElementKind.METHOD =>
-          topmostOverriddenMethod(method, compile)
-        case _ => None
-      }
-      .orElse(transformElement(element))
+  ): List[Element] = {
+    val overridden = element match {
+      case method: ExecutableElement
+          if method.getKind() == ElementKind.METHOD =>
+        topmostOverriddenMethods(method, compile)
+      case _ => Nil
+    }
+    if (overridden.nonEmpty) overridden
+    else NoopDefinitionProcessor.transformElement(element, compile)
+  }
 
-  private def topmostOverriddenMethod(
+  private def topmostOverriddenMethods(
       method: ExecutableElement,
       compile: JavaSourceCompile
-  ): Option[ExecutableElement] = {
+  ): List[ExecutableElement] = {
     val elements = compile.task.getElements()
     val types = compile.task.getTypes()
 
@@ -82,33 +83,26 @@ object DeclarationDefinitionProcessor extends CompileDefinitionProcessor {
       case _ => None
     }
 
-    def directlyOverridden(
-        m: ExecutableElement
-    ): Option[ExecutableElement] =
+    def directlyOverridden(m: ExecutableElement): List[ExecutableElement] =
       for {
-        owner <- asTypeElement(m.getEnclosingElement())
-        parent <- types
-          .directSupertypes(owner.asType())
-          .asScala
-          .view
-          .flatMap(st => asTypeElement(types.asElement(st)))
-          .flatMap(_.getEnclosedElements().asScala)
-          .collectFirst {
-            case c: ExecutableElement
-                if c.getKind() == ElementKind.METHOD &&
-                  elements.overrides(m, c, owner) =>
-              c
-          }
-      } yield parent
+        owner <- asTypeElement(m.getEnclosingElement()).toList
+        supertype <- types.directSupertypes(owner.asType()).asScala.toList
+        superOwner <- asTypeElement(types.asElement(supertype)).toList
+        candidates <- superOwner.getEnclosedElements().asScala.collect {
+          case c: ExecutableElement
+              if c.getKind() == ElementKind.METHOD &&
+                elements.overrides(m, c, owner) =>
+            c
+        }
+      } yield candidates
 
-    @scala.annotation.tailrec
-    def loop(m: ExecutableElement): ExecutableElement =
+    def topmost(m: ExecutableElement): List[ExecutableElement] =
       directlyOverridden(m) match {
-        case Some(parent) => loop(parent)
-        case None => m
+        case Nil => List(m)
+        case parents => parents.flatMap(topmost)
       }
 
-    directlyOverridden(method).map(loop)
+    directlyOverridden(method).flatMap(topmost).distinct
   }
 }
 
@@ -118,32 +112,24 @@ class JavaDefinitionProvider(
     processor: DefinitionProcessor = NoopDefinitionProcessor
 ) {
 
-  private def transformElement(
-      element: Element,
-      compile: JavaSourceCompile
-  ): Option[Element] =
-    processor match {
-      case compileProcessor: CompileDefinitionProcessor =>
-        compileProcessor.transformElement(element, compile)
-      case _ =>
-        processor.transformElement(element)
-    }
-
   def definition(): DefinitionResult = {
     val compileAndNode = compiler.nodeAtPosition(params)
     val result: Option[DefinitionResult] = for {
       (compile, node) <- compileAndNode
       trees = Trees.instance(compile.task)
-      element <- transformElement(trees.getElement(node), compile)
-        .orElse(Option(trees.getElement(node)))
+      elements <- Some(
+        processor.transformElement(trees.getElement(node), compile)
+      )
+        .filter(_.nonEmpty)
+        .orElse(Option(trees.getElement(node)).map(List(_)))
     } yield {
       val sourcePositions = trees.getSourcePositions()
-      val source = definitionSource(compile, node, trees, element)
+      val source = definitionSource(compile, node, trees, elements)
       source match {
         case Sourcepath(all @ (firstPath :: _)) =>
           val locations = for {
             p <- all.iterator
-            pElement <- transformElement(trees.getElement(p), compile).toList
+            pElement <- processor.transformElement(trees.getElement(p), compile)
             defn <- sourceDefinition(
               compile,
               sourcePositions,
@@ -232,13 +218,11 @@ class JavaDefinitionProvider(
       compile: JavaSourceCompile,
       node: TreePath,
       trees: Trees,
-      element: Element
+      elements: List[Element]
   ): DefinitionSource = {
-    Option(trees.getPath(element)) match {
-      case Some(path) =>
-        return Sourcepath(List(path))
-      case _ =>
-    }
+    val paths = elements.flatMap(e => Option(trees.getPath(e)))
+    if (paths.nonEmpty) return Sourcepath(paths)
+    val element = elements.head
 
     node.getLeaf() match {
       case _: JCFieldAccess =>
@@ -250,7 +234,7 @@ class JavaDefinitionProvider(
                 val ambiguousElements = (for {
                   elem <- c.getEnclosedElements().asScala.iterator
                   if elem.getSimpleName().toString() == elementName
-                  processed <- transformElement(elem, compile).toList
+                  processed <- processor.transformElement(elem, compile)
                 } yield processed).distinct.toList
                 val ambiguousPaths = for {
                   member <- ambiguousElements

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPresentationCompiler.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPresentationCompiler.scala
@@ -182,6 +182,15 @@ case class JavaPresentationCompiler(
     }
   }
 
+  override def declaration(
+      params: OffsetParams
+  ): CompletableFuture[DefinitionResult] = {
+    request(params, DefinitionResultImpl.empty) { pc =>
+      new JavaDefinitionProvider(pc, params, DeclarationDefinitionProcessor)
+        .definition()
+    }
+  }
+
   override def typeDefinition(
       params: OffsetParams
   ): CompletableFuture[DefinitionResult] =

--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/DefinitionResultImpl.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/DefinitionResultImpl.scala
@@ -13,6 +13,5 @@ case class DefinitionResultImpl(
 ) extends DefinitionResult
 
 object DefinitionResultImpl {
-  def empty: DefinitionResult =
-    DefinitionResultImpl("", ju.Collections.emptyList())
+  def empty: DefinitionResult = DefinitionResult.empty()
 }

--- a/tests/javapc/src/test/scala/definition/DeclarationSuite.scala
+++ b/tests/javapc/src/test/scala/definition/DeclarationSuite.scala
@@ -103,4 +103,37 @@ class DeclarationSuite extends BaseJavaDefinitionSuite {
        |         ^^^^^^^^^
        |""".stripMargin,
   )
+
+  check(
+    "overridden-multiple-supertypes",
+    """|interface Walker {
+       |    void move();
+       |}
+       |
+       |interface Swimmer {
+       |    void move();
+       |}
+       |
+       |class Duck implements Walker, Swimmer {
+       |    @Override
+       |    public void move() {
+       |        System.out.println("Waddle");
+       |    }
+       |}
+       |
+       |class A {
+       |    public static void main(String args[]){
+       |        Duck duck = new Duck();
+       |        duck.mo@@ve();
+       |    }
+       |}
+       |""".stripMargin,
+    """|Definition.java:3:10: info: definition
+       |    void move();
+       |         ^^^^
+       |Definition.java:7:10: info: definition
+       |    void move();
+       |         ^^^^
+       |""".stripMargin,
+  )
 }

--- a/tests/javapc/src/test/scala/definition/DeclarationSuite.scala
+++ b/tests/javapc/src/test/scala/definition/DeclarationSuite.scala
@@ -1,0 +1,106 @@
+package definition
+
+import scala.meta.internal.metals.CompilerOffsetParams
+import scala.meta.pc.DefinitionResult
+
+import tests.pc.BaseJavaDefinitionSuite
+
+class DeclarationSuite extends BaseJavaDefinitionSuite {
+
+  override def doDefinitionRequest(
+      params: CompilerOffsetParams
+  ): DefinitionResult =
+    presentationCompiler.declaration(params).get()
+
+  check(
+    "local-variable",
+    """|class A {
+       |    public static void main(String args[]){
+       |        int x = 42;
+       |        int y = @@x;
+       |    }
+       |}
+       |""".stripMargin,
+    """|Definition.java:4:13: info: definition
+       |        int x = 42;
+       |            ^
+       |""".stripMargin,
+  )
+
+  check(
+    "field-declaration-not-assignment",
+    """|class A {
+       |    int x;
+       |
+       |    A() {
+       |        x = 5;
+       |    }
+       |
+       |    int value() {
+       |        return @@x;
+       |    }
+       |}
+       |""".stripMargin,
+    """|Definition.java:3:9: info: definition
+       |    int x;
+       |        ^
+       |""".stripMargin,
+  )
+
+  check(
+    "overridden-interface-method",
+    """|interface Animal {
+       |    void makeSound();
+       |}
+       |
+       |class Dog implements Animal {
+       |    public void makeSound() {
+       |        System.out.println("Woof");
+       |    }
+       |}
+       |
+       |class A {
+       |    public static void main(String args[]){
+       |        Dog dog = new Dog();
+       |        dog.ma@@keSound();
+       |    }
+       |}
+       |""".stripMargin,
+    """|Definition.java:3:10: info: definition
+       |    void makeSound();
+       |         ^^^^^^^^^
+       |""".stripMargin,
+  )
+
+  check(
+    "overridden-multi-level-hierarchy",
+    """|interface Animal {
+       |    void makeSound();
+       |}
+       |
+       |abstract class Mammal implements Animal {
+       |    public void makeSound() {
+       |        System.out.println("Generic mammal sound");
+       |    }
+       |}
+       |
+       |class Dog extends Mammal {
+       |    @Override
+       |    public void makeSound() {
+       |        System.out.println("Woof");
+       |    }
+       |}
+       |
+       |class A {
+       |    public static void main(String args[]){
+       |        Dog dog = new Dog();
+       |        dog.ma@@keSound();
+       |    }
+       |}
+       |""".stripMargin,
+    """|Definition.java:3:10: info: definition
+       |    void makeSound();
+       |         ^^^^^^^^^
+       |""".stripMargin,
+  )
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Language Server Protocol support for the "Go to Declaration" feature, enabling IDE integration for navigating to symbol declarations in both Scala and Java projects.

* **Tests**
  * Added comprehensive test suite for Java declaration resolution, covering local variables, fields, overridden methods, and multi-level class hierarchies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->