### PR TITLE
[MBT] Wrap Bazel target names in quotes when necessary. Add unit tests.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
@@ -36,8 +36,42 @@ object BazelQuery {
     BazelQuery(query, outputMode = Label)
   }
 
+  private val reservedKeywords: Set[String] =
+    Set("except", "in", "intersect", "let", "set", "union")
+
+  private val unquotedWordChars: Set[Char] =
+    (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')).toSet ++
+      Set('*', '/', '@', '.', '-', '_', ':', '$', '~', '[', ']')
+
+  private def needsQuoting(target: String): Boolean =
+    reservedKeywords.contains(target) || target.headOption.exists {
+      case '-' | '*' => true
+      case _ =>
+        val allowPlus = target.startsWith("@@")
+        !target.forall { c =>
+          unquotedWordChars.contains(c) || (c == '+' && allowPlus)
+        }
+    }
+
+  private def quoteTarget(target: String): Option[String] =
+    if (needsQuoting(target)) {
+      val hasDouble = target.contains('"')
+      val hasSingle = target.contains('\'')
+      if (hasDouble && hasSingle) {
+        scribe.warn(
+          s"bazel-mbt: skipping target '$target' because it contains both single and double quotes, " +
+            "which cannot be represented in Bazel query language"
+        )
+        None
+      } else if (hasDouble)
+        Some(s"'$target'")
+      else
+        Some(s""""$target"""")
+    } else Some(target)
+
   def fullInformationQuery(targets: List[String]): BazelQuery = {
-    val query = s"deps(set(${targets.mkString(" ")}))"
+    val escaped = targets.flatMap(quoteTarget)
+    val query = s"deps(set(${escaped.mkString(" ")}))"
     BazelQuery(query, outputMode = Xml)
   }
 

--- a/tests/unit/src/test/scala/tests/mbt/BazelQuerySuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/BazelQuerySuite.scala
@@ -1,0 +1,157 @@
+package tests.mbt
+
+import scala.meta.internal.metals.mbt.importer.BazelQuery
+
+import munit.FunSuite
+
+class BazelQuerySuite extends FunSuite {
+
+  test("parse-special-characters-bazel-query") {
+    val targets = List(
+      "//core:example_lib",
+      "//test/name_encoding:a1%3D=%3D%2Bagg",
+    )
+    val query = BazelQuery.fullInformationQuery(targets)
+
+    assertEquals(
+      query.query,
+      """deps(set(//core:example_lib "//test/name_encoding:a1%3D=%3D%2Bagg"))""",
+    )
+  }
+
+  test("normal-labels-are-not-quoted") {
+    val targets = List(
+      "//foo:bar",
+      "//foo/bar:baz",
+      "@repo//pkg:target",
+    )
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      "deps(set(//foo:bar //foo/bar:baz @repo//pkg:target))",
+    )
+  }
+
+  test("external-repo-labels-with-plus-are-not-quoted") {
+    val targets = List("@@rules_scala+//scala:scala")
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      "deps(set(@@rules_scala+//scala:scala))",
+    )
+  }
+
+  test("target-with-equals-sign-is-quoted") {
+    val targets = List("//pkg:name=value")
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      """deps(set("//pkg:name=value"))""",
+    )
+  }
+
+  test("target-with-plus-sign-is-quoted") {
+    val targets = List("//pkg:name+value")
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      """deps(set("//pkg:name+value"))""",
+    )
+  }
+
+  test("target-with-percent-sign-is-quoted") {
+    val targets = List("//pkg:a1%3D")
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      """deps(set("//pkg:a1%3D"))""",
+    )
+  }
+
+  test("word-starting-with-hyphen-is-quoted") {
+    val targets = List("-starts_hyphen")
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      """deps(set("-starts_hyphen"))""",
+    )
+  }
+
+  test("label-with-hyphen-in-target-name-is-not-quoted") {
+    val targets = List("//pkg:-target")
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      "deps(set(//pkg:-target))",
+    )
+  }
+
+  test("target-with-double-quote-uses-single-quotes") {
+    val targets = List("""//pkg:has"quote""")
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      """deps(set('//pkg:has"quote'))""",
+    )
+  }
+
+  test("target-with-single-quote-uses-double-quotes") {
+    val targets = List("//pkg:has'quote")
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      """deps(set("//pkg:has'quote"))""",
+    )
+  }
+
+  test("target-with-both-quotes-is-skipped") {
+    val targets = List(
+      "//foo:ok",
+      """//pkg:has"both'quotes""",
+      "//bar:also_ok",
+    )
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      "deps(set(//foo:ok //bar:also_ok))",
+    )
+  }
+
+  test("target-with-parentheses-is-quoted") {
+    val targets = List("//pkg:name(variant)")
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      """deps(set("//pkg:name(variant)"))""",
+    )
+  }
+
+  test("empty-targets-list") {
+    val targets = List.empty[String]
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(query.query, "deps(set())")
+  }
+
+  test("mixed-quoted-and-unquoted-targets") {
+    val targets = List(
+      "//core:lib",
+      "//test:a1%3D=%3D%2Bagg",
+      "@repo//pkg:target",
+      "//pkg:name+value",
+    )
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      """deps(set(//core:lib "//test:a1%3D=%3D%2Bagg" @repo//pkg:target "//pkg:name+value"))""",
+    )
+  }
+
+  test("reserved-keywords") {
+    val targets = List("except", "in", "intersect", "let", "set", "union")
+    val query = BazelQuery.fullInformationQuery(targets)
+    assertEquals(
+      query.query,
+      """deps(set("except" "in" "intersect" "let" "set" "union"))""",
+    )
+  }
+}


### PR DESCRIPTION
https://github.com/scalameta/metals/issues/8445
Updated Bazel target names to be wrapped in quotes when required.
Added unit tests.

https://bazel.build/query/language#lexical-syntax
https://bazel.build/concepts/labels#target-names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Bazel target label handling by properly quoting and escaping special characters, reserved keywords, and quotes in query strings.

* **Tests**
  * Added comprehensive test coverage for Bazel query target label formatting across various edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->