### PR TITLE
Send real document version in rename edits instead of null

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Buffers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Buffers.scala
@@ -13,10 +13,20 @@ import scala.meta.io.AbsolutePath
 case class Buffers(
     map: TrieMap[AbsolutePath, String] = TrieMap.empty
 ) {
+  private val versions = TrieMap.empty[AbsolutePath, Int]
+
   def open: Iterable[AbsolutePath] = map.keys
   def put(key: AbsolutePath, value: String): Unit = map.put(key, value)
+  def put(key: AbsolutePath, value: String, version: Int): Unit = {
+    map.put(key, value)
+    versions.put(key, version)
+  }
+  def version(key: AbsolutePath): Option[Int] = versions.get(key)
   def get(key: AbsolutePath): Option[String] = map.get(key)
-  def remove(key: AbsolutePath): Unit = map.remove(key)
+  def remove(key: AbsolutePath): Unit = {
+    map.remove(key)
+    versions.remove(key)
+  }
   def contains(key: AbsolutePath): Boolean = map.contains(key)
 
   def tokenEditDistance(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -761,7 +761,11 @@ abstract class MetalsLspService(
     // Update md5 fingerprint from file contents on disk
     fingerprints.add(path, FileIO.slurp(path, charset))
     // Update in-memory buffer contents from LSP client
-    buffers.put(path, params.getTextDocument.getText)
+    buffers.put(
+      path,
+      params.getTextDocument.getText,
+      params.getTextDocument.getVersion(),
+    )
 
     val optVersion =
       Option.when(initializeParams.supportsVersionedWorkspaceEdits)(
@@ -858,7 +862,10 @@ abstract class MetalsLspService(
       case None => CompletableFuture.completedFuture(())
       case Some(change) =>
         val path = params.getTextDocument.getUri.toAbsolutePath
-        buffers.put(path, change.getText)
+        Option(params.getTextDocument.getVersion()) match {
+          case Some(version) => buffers.put(path, change.getText, version)
+          case None => buffers.put(path, change.getText)
+        }
         diagnostics.didChange(path)
         compilers.didChange(path, false)
         referencesProvider.didChange(path, change.getText)

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -411,8 +411,14 @@ final class RenameProvider(
       openedEdits: Map[AbsolutePath, List[TextEdit]]
   ): List[LSPEither[TextDocumentEdit, ResourceOperation]] = {
     openedEdits.map { case (file, edits) =>
-      val textId = new VersionedTextDocumentIdentifier()
-      textId.setUri(file.toURI.toString())
+      val textId = buffers.version(file) match {
+        case Some(version) =>
+          new VersionedTextDocumentIdentifier(file.toURI.toString(), version)
+        case None =>
+          val id = new VersionedTextDocumentIdentifier()
+          id.setUri(file.toURI.toString())
+          id
+      }
       val editsAsEither =
         edits.map(e => LSPEither.forLeft[TextEdit, SnippetTextEdit](e)).asJava
       val ed = new TextDocumentEdit(textId, editsAsEither)

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1668,6 +1668,29 @@ final case class TestingServer(
     }
   }
 
+  /**
+   * Like [[rename]] but returns the raw [[WorkspaceEdit]] so tests can inspect
+   * the `documentChanges` directly, e.g. to assert document versions (#1665).
+   * `query` is the full file content with a single `@@` cursor marker.
+   */
+  def renameToEdit(
+      filename: String,
+      query: String,
+      newName: String,
+  ): Future[WorkspaceEdit] = {
+    for {
+      (_, params) <- offsetParams(filename, query, workspace)
+      prepare <- fullServer.prepareRename(params).asScala
+      renameParams = new RenameParams
+      _ = renameParams.setNewName(newName)
+      _ = renameParams.setPosition(params.getPosition())
+      _ = renameParams.setTextDocument(params.getTextDocument())
+      renames <-
+        if (prepare != null) fullServer.rename(renameParams).asScala
+        else Future.successful(new WorkspaceEdit)
+    } yield renames
+  }
+
   private def renameFile(file: String, renames: WorkspaceEdit) = {
     renames
       .getDocumentChanges()

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -1,6 +1,7 @@
 package tests
 
 import scala.meta.internal.metals.InitializationOptions
+import scala.meta.internal.metals.MetalsEnrichments._
 
 class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
 
@@ -948,6 +949,59 @@ class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
        |""".stripMargin,
     newName = "Foo",
   )
+
+  // https://github.com/scalameta/metals/issues/1665
+  // The rename response must carry the real document version for files that are
+  // open in the editor, not `null`.
+  test("versioned-document-edit") {
+    cleanWorkspace()
+    val file = "a/src/main/scala/a/Main.scala"
+    val code =
+      """|package a
+         |object Main {
+         |  val toRename = 123
+         |  val usage = toRename + 1
+         |}
+         |""".stripMargin
+    val query =
+      """|package a
+         |object Main {
+         |  val toR@@ename = 123
+         |  val usage = toRename + 1
+         |}
+         |""".stripMargin
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{"a": {"scalaVersion": "${BuildInfo.scalaVersion}"}}
+            |/$file
+            |$code""".stripMargin
+      )
+      _ <- server.didOpen(file)
+      _ <- server.didChange(file)(identity[String])
+      _ <- server.didSave(file)
+      _ = assertNoDiagnostics()
+      edit <- server.renameToEdit(file, query, "renamed")
+    } yield {
+      val versions = Option(edit.getDocumentChanges())
+        .map(_.asScala.toList)
+        .getOrElse(Nil)
+        .collect {
+          case either if either.isLeft =>
+            either.getLeft().getTextDocument().getVersion()
+        }
+      assert(
+        versions.nonEmpty,
+        s"expected at least one TextDocumentEdit, got ${edit.getDocumentChanges()}",
+      )
+      versions.foreach { version =>
+        assert(
+          version != null,
+          "expected a non-null document version for the open file (see #1665)",
+        )
+      }
+    }
+  }
 
   override protected def libraryDependencies: List[String] =
     List("org.scalatest::scalatest:3.2.12", "io.circe::circe-generic:0.14.1")


### PR DESCRIPTION
Fixes #1665.

## Problem

`textDocument/rename` responses always set the `VersionedTextDocumentIdentifier` version to `null`. Per the LSP spec, `null` should only mean "the file isn't open in the editor and the on-disk content is master." For files that *are* open we actually know the version and should send it, so version-checking clients (the original report was Neovim) don't reject the edit when the buffer changed between the rename request and applying the edit.

## Changes

- `Buffers` now tracks a per-document version alongside the text (`put(path, text, version)`, `version(path)`), cleared on `remove`.
- `didOpen` / `didChange` store the version; `didClose` clears it via the existing `buffers.remove`.
- `RenameProvider.documentEdits` builds `VersionedTextDocumentIdentifier(uri, version)` for open buffers (mirroring `PackageProvider`), falling back to the null-version form for files that are only on disk — which stays spec-correct.

The version is always populated when the document is open and known (not gated on the `documentChanges` capability), since rename already emits `documentChanges` unconditionally.

## Notes

- The `didChange` path null-guards the version because lsp4j models `VersionedTextDocumentIdentifier.getVersion()` as a boxed `Integer` (it's `null` if a client omits it); `TextDocumentItem.getVersion()` (didOpen) is a primitive `int`. This is intentional lsp4j behavior, not a workaround - metals is already on the latest lsp4j (1.0.0).
- Unrelated to this change: `RenameProvider` always emits `documentChanges` rather than falling back to `changes` for clients without the capability. That's by design - it also emits `RenameFile` resource operations, which `changes` can't represent - so it's not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Language server now systematically tracks and maintains file version metadata during document operations.

**Bug Fixes**
- Rename edits now include accurate document version information, ensuring proper handling of concurrent document modifications and correct synchronization between editor and language server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->