### PR TITLE
feat: discover individual JUnit 5 tests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -542,11 +542,12 @@ object TestFrameworkSymbolRegistry {
   private lazy val junitSymbols: Map[String, TestFramework] = Set(
     JunitTestFinder.junitBaseClassSymbol,
     JunitTestFinder.junitAnnotationSymbol,
+    JunitTestFinder.junit5AnnotationSymbol,
   ).map(_ -> TestFramework.JUnit).toMap
 
   private lazy val testngSymbols: Map[String, TestFramework] = {
     val testngFinder = new TestNGTestFinder()
-    Set(testngFinder.expectedAnnotationSymbol)
+    testngFinder.expectedAnnotationSymbols
       .map(_ -> TestFramework.TestNG)
       .toMap
   }
@@ -584,7 +585,7 @@ object TestFrameworkUtils {
 
   def from(framework: Option[String]): TestFramework = framework
     .map {
-      case "JUnit" => TestFramework.JUnit
+      case "JUnit" | "Jupiter" => TestFramework.JUnit
       case "munit" => TestFramework.munit
       case "ScalaTest" => TestFramework.ScalaTest
       case "weaver-cats-effect" => WeaverTestFramework

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/AnnotationTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/AnnotationTestFinder.scala
@@ -11,7 +11,7 @@ import scala.meta.internal.semanticdb.TypeRef
 import scala.meta.io.AbsolutePath
 
 trait AnnotationTestFinder {
-  def expectedAnnotationSymbol: String
+  def expectedAnnotationSymbols: Set[String]
 
   def findTests(
       doc: TextDocument,
@@ -24,7 +24,7 @@ trait AnnotationTestFinder {
       symbol.kind == SymbolInformation.Kind.METHOD && symbol.annotations
         .exists(_.tpe match {
           case TypeRef(_, annotationSymbol, _) =>
-            annotationSymbol == expectedAnnotationSymbol
+            expectedAnnotationSymbols.contains(annotationSymbol)
           case _ => false
         })
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/AnnotationTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/AnnotationTestFinder.scala
@@ -1,7 +1,5 @@
 package scala.meta.internal.metals.testProvider.frameworks
 
-import scala.reflect.NameTransformer
-
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.testProvider.TestCaseEntry
 import scala.meta.internal.mtags
@@ -13,6 +11,8 @@ import scala.meta.io.AbsolutePath
 trait AnnotationTestFinder {
   def expectedAnnotationSymbols: Set[String]
 
+  def encode(annotationSymbol: String, displayName: String): String
+
   def findTests(
       doc: TextDocument,
       path: AbsolutePath,
@@ -20,34 +20,39 @@ trait AnnotationTestFinder {
   ): Vector[TestCaseEntry] = {
     val uri = path.toURI
 
-    def isMethodWithTestAnnotation(symbol: SymbolInformation) = {
-      symbol.kind == SymbolInformation.Kind.METHOD && symbol.annotations
-        .exists(_.tpe match {
-          case TypeRef(_, annotationSymbol, _) =>
-            expectedAnnotationSymbols.contains(annotationSymbol)
-          case _ => false
-        })
+    def isMethodWithTestAnnotation(
+        symbol: SymbolInformation
+    ): Option[String] = {
+      if (symbol.kind != SymbolInformation.Kind.METHOD) None
+      else
+        symbol.annotations
+          .flatMap(_.tpe match {
+            case TypeRef(_, annotationSymbol, _)
+                if expectedAnnotationSymbols.contains(annotationSymbol) =>
+              Some(annotationSymbol)
+            case _ => None
+          })
+          .headOption
     }
 
-    def isValid(symbol: SymbolInformation): Boolean =
-      isMethodWithTestAnnotation(symbol) && symbol.symbol.startsWith(
-        suiteSymbol.value
-      )
+    def validAnnotation(symbol: SymbolInformation): Option[String] =
+      if (symbol.symbol.startsWith(suiteSymbol.value))
+        isMethodWithTestAnnotation(symbol)
+      else None
 
     doc.symbols
-      .collect {
-        case symbol if isValid(symbol) =>
-          doc
-            .toLocation(uri, symbol.symbol)
-            .map { location =>
-              val encodedName =
-                NameTransformer.encode(symbol.displayName) + "()"
-              TestCaseEntry(
-                encodedName,
-                symbol.displayName,
-                location,
-              )
-            }
+      .map(symbol => validAnnotation(symbol).map(symbol -> _))
+      .collect { case Some((symbol, annotSymbol)) =>
+        doc
+          .toLocation(uri, symbol.symbol)
+          .map { location =>
+            val encodedName = encode(annotSymbol, symbol.displayName)
+            TestCaseEntry(
+              encodedName,
+              symbol.displayName,
+              location,
+            )
+          }
       }
       .flatten
       .toVector

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/AnnotationTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/AnnotationTestFinder.scala
@@ -40,7 +40,8 @@ trait AnnotationTestFinder {
           doc
             .toLocation(uri, symbol.symbol)
             .map { location =>
-              val encodedName = NameTransformer.encode(symbol.displayName)
+              val encodedName =
+                NameTransformer.encode(symbol.displayName) + "()"
               TestCaseEntry(
                 encodedName,
                 symbol.displayName,

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/JunitTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/JunitTestFinder.scala
@@ -1,11 +1,15 @@
 package scala.meta.internal.metals.testProvider.frameworks
 
 class JunitTestFinder extends AnnotationTestFinder {
-  override def expectedAnnotationSymbol: String =
-    JunitTestFinder.junitAnnotationSymbol
+  override def expectedAnnotationSymbols: Set[String] =
+    Set(
+      JunitTestFinder.junitAnnotationSymbol,
+      JunitTestFinder.junit5AnnotationSymbol,
+    )
 }
 
 object JunitTestFinder {
   val junitAnnotationSymbol = "org/junit/Test#"
+  val junit5AnnotationSymbol = "org/junit/jupiter/api/Test#"
   val junitBaseClassSymbol = "junit/framework/TestCase#"
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/JunitTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/JunitTestFinder.scala
@@ -1,11 +1,19 @@
 package scala.meta.internal.metals.testProvider.frameworks
 
+import scala.reflect.NameTransformer
+
 class JunitTestFinder extends AnnotationTestFinder {
   override def expectedAnnotationSymbols: Set[String] =
     Set(
       JunitTestFinder.junitAnnotationSymbol,
       JunitTestFinder.junit5AnnotationSymbol,
     )
+
+  override def encode(annotationSymbol: String, displayName: String): String =
+    if (annotationSymbol == JunitTestFinder.junit5AnnotationSymbol)
+      NameTransformer.encode(displayName) + "()"
+    else
+      NameTransformer.encode(displayName)
 }
 
 object JunitTestFinder {

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/TestNGTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/TestNGTestFinder.scala
@@ -1,7 +1,12 @@
 package scala.meta.internal.metals.testProvider.frameworks
 
+import scala.reflect.NameTransformer
+
 class TestNGTestFinder extends AnnotationTestFinder {
   override def expectedAnnotationSymbols: Set[String] = Set(
     "org/testng/annotations/Test#"
   )
+
+  override def encode(annotationSymbol: String, displayName: String): String =
+    NameTransformer.encode(displayName)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/TestNGTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/TestNGTestFinder.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.metals.testProvider.frameworks
 
 class TestNGTestFinder extends AnnotationTestFinder {
-  override def expectedAnnotationSymbol: String = "org/testng/annotations/Test#"
+  override def expectedAnnotationSymbols: Set[String] = Set(
+    "org/testng/annotations/Test#"
+  )
 }

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -307,6 +307,9 @@ object QuickBuild {
     ),
     "org.scalameta::munit" -> Config.TestFramework.munit,
     "junit:junit" -> Config.TestFramework.JUnit,
+    "com.github.sbt.junit:jupiter-interface" -> Config.TestFramework(
+      List("com.github.sbt.junit.jupiter.sbt.JupiterFramework")
+    ),
     "com.disneystreaming::weaver-cats" -> Config.TestFramework(
       List("weaver.framework.CatsEffect")
     ),

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -68,6 +68,45 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
   )
 
   testDiscover(
+    "single-junit5",
+    List(
+      "org.junit.jupiter:junit-jupiter-api:5.10.2",
+      "com.github.sbt.junit:jupiter-interface:0.19.0",
+    ),
+    s"""|
+        |/app/src/main/scala/NoPackage.scala
+        |import org.junit.jupiter.api.Test
+        |class NoPackage {
+        |  @Test
+        |  def test1 = ()
+        |}
+        |""".stripMargin,
+    List(
+      "app/src/main/scala/NoPackage.scala"
+    ),
+    () => {
+      List(
+        rootBuildTargetUpdate(
+          "app",
+          targetUri,
+          List[TestExplorerEvent](
+            AddTestSuite(
+              "NoPackage",
+              "NoPackage",
+              "_empty_/NoPackage#",
+              QuickLocation(
+                classUriFor("app/src/main/scala/NoPackage.scala"),
+                (1, 6, 1, 15),
+              ).toLsp,
+              canResolveChildren = true,
+            )
+          ).asJava,
+        )
+      )
+    },
+  )
+
+  testDiscover(
     "single-munit",
     List("org.scalameta::munit:0.7.29"),
     s"""|
@@ -232,6 +271,58 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       )
     },
     () => Some(classUriFor("app/src/main/scala/JunitTestSuite.scala")),
+  )
+
+  testDiscover(
+    "test-cases-junit5",
+    List(
+      "org.junit.jupiter:junit-jupiter-api:5.10.2",
+      "com.github.sbt.junit:jupiter-interface:0.19.0",
+    ),
+    s"""|
+        |/app/src/main/scala/Junit5TestSuite.scala
+        |import org.junit.jupiter.api.Test
+        |class Junit5TestSuite {
+        |  @Test
+        |  def test1 = ()
+        |  @Test
+        |  def test2 = ()
+        |}
+        |""".stripMargin,
+    List("app/src/main/scala/Junit5TestSuite.scala"),
+    () => {
+      List(
+        rootBuildTargetUpdate(
+          "app",
+          targetUri,
+          List[TestExplorerEvent](
+            AddTestCases(
+              "Junit5TestSuite",
+              "Junit5TestSuite",
+              List(
+                TestCaseEntry(
+                  "test1()",
+                  "test1",
+                  QuickLocation(
+                    classUriFor("app/src/main/scala/Junit5TestSuite.scala"),
+                    (3, 6, 3, 11),
+                  ).toLsp,
+                ),
+                TestCaseEntry(
+                  "test2()",
+                  "test2",
+                  QuickLocation(
+                    classUriFor("app/src/main/scala/Junit5TestSuite.scala"),
+                    (5, 6, 5, 11),
+                  ).toLsp,
+                ),
+              ).asJava,
+            )
+          ).asJava,
+        )
+      )
+    },
+    () => Some(classUriFor("app/src/main/scala/Junit5TestSuite.scala")),
   )
 
   testDiscover(
@@ -528,6 +619,55 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
               className,
               List(
                 TestCaseEntry(
+                  "test1",
+                  QuickLocation(classUriFor(file), (3, 6, 3, 11)).toLsp,
+                )
+              ).asJava,
+            ),
+          ).asJava,
+        )
+      )
+    },
+  )
+
+  checkEvents(
+    "check-basic-events-junit5",
+    List(
+      "org.junit.jupiter:junit-jupiter-api:5.10.2",
+      "com.github.sbt.junit:jupiter-interface:0.19.0",
+    ),
+    s"""|
+        |/app/src/main/scala/Junit5TestSuite.scala
+        |import org.junit.jupiter.api.Test
+        |class Junit5TestSuite {
+        |  @Test
+        |  def test1 = ()
+        |}
+        |""".stripMargin,
+    file = "app/src/main/scala/Junit5TestSuite.scala",
+    expected = () => {
+      val fcqn = "Junit5TestSuite"
+      val className = "Junit5TestSuite"
+      val symbol = "_empty_/Junit5TestSuite#"
+      val file = "app/src/main/scala/Junit5TestSuite.scala"
+      List(
+        rootBuildTargetUpdate(
+          "app",
+          targetUri,
+          List[TestExplorerEvent](
+            AddTestSuite(
+              fcqn,
+              className,
+              symbol,
+              QuickLocation(classUriFor(file), (1, 6, 1, 21)).toLsp,
+              canResolveChildren = true,
+            ),
+            AddTestCases(
+              fcqn,
+              className,
+              List(
+                TestCaseEntry(
+                  "test1()",
                   "test1",
                   QuickLocation(classUriFor(file), (3, 6, 3, 11)).toLsp,
                 )


### PR DESCRIPTION
With sbt (and soon bloop), the bsp can recognize JUnit5 tests suites. For detecting individual tests, scala meta only supported the JUnit4 annotation. This commit adds support for the JUnit5 annotation as well.

Note: I did not add any unit tests as they are executed with bloop, which I think just landed Junit5 support, but probably not yet included here? At least I was not able to get tests running and then figured it was probably because of that.

Related to #7036.

It is able to detect now individual test cases:
<img width="1455" height="493" alt="Screenshot 2026-06-06 at 20 57 54" src="https://github.com/user-attachments/assets/c1ada487-92f9-46aa-bf35-6af247da4151" />

But as can be seen, compared to other test frameworks it is not able to report which tests succeeded and which didn't.

On a separate note, the whole test result still looks weird.
<img width="694" height="213" alt="Screenshot 2026-06-06 at 21 00 23" src="https://github.com/user-attachments/assets/a4ab4ff4-5c59-4a6d-b6b1-9cdb49c985b9" />
E.g. it mixes suites with individual tests and doesn't show where these individual tests are located.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JUnit 5 (Jupiter) test annotation support alongside existing JUnit 4 handling.
  * Improved test discovery to recognize multiple annotation symbols per framework.
  * Updated JUnit and JUnit 5 framework resolution so both map correctly for test handling.
* **Testing**
  * Expanded test discovery coverage for JUnit 5 suites, test cases, and explorer event payloads.
* **Chores**
  * Extended QuickBuild framework detection to support the Jupiter interface library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->