### PR TITLE
bugfix: Don't truncate debug console output when the JVM exits

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -8,6 +8,7 @@ import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -78,19 +79,18 @@ private[debug] final class DebugProxy(
 
   lazy val listen: Future[ExitStatus] = {
     scribe.info(s"Starting debug proxy for [$sessionName]")
-    listenToServer()
-    listenToClient()
+    // Reading from the server (debug adapter) blocks until the adapter has sent
+    // everything (including the debuggee's final output) and closed the
+    // connection. Reading from the client blocks until the client disconnects.
+    val serverListening = Future(server.onReceived(handleServerMessage))
+    val clientListening = Future(client.listen(handleClientMessage))
+    DebugProxy.teardownOnExit(
+      serverListening,
+      clientListening,
+      drainTimeout = 5.seconds,
+    )(() => cancel())
 
     exitStatus.future
-  }
-
-  private def listenToClient(): Unit = {
-    Future(client.listen(handleClientMessage)).andThen { case _ => cancel() }
-  }
-
-  private def listenToServer(): Unit = {
-    Future(server.onReceived(handleServerMessage))
-      .andThen { case _ => cancel() }
   }
 
   private val initialized = Promise[Unit]()
@@ -363,6 +363,33 @@ private[debug] object DebugProxy {
   sealed trait ExitStatus
   case object Terminated extends ExitStatus
   case object Restarted extends ExitStatus
+
+  /**
+   * Wires up proxy teardown so that no debuggee output is lost when the session
+   * ends (see #2043).
+   *
+   * The client (e.g. VS Code) disconnects as soon as it sees the `terminated`
+   * event, which can happen before the adapter has finished forwarding the
+   * debuggee's final output. So when the client side finishes we must wait for
+   * the server side to drain all remaining output before tearing down, rather
+   * than cancelling immediately. The server side, on the other hand, only
+   * finishes once it has read everything from the adapter, so it is always safe
+   * to cancel as soon as it completes. The `drainTimeout` bounds the wait in
+   * case the server never reaches EOF (e.g. when terminating a process that does
+   * not exit on its own).
+   */
+  def teardownOnExit(
+      serverListening: Future[Unit],
+      clientListening: Future[Unit],
+      drainTimeout: FiniteDuration,
+  )(cancel: () => Unit)(implicit ec: ExecutionContext): Unit = {
+    serverListening.onComplete(_ => cancel())
+    clientListening.onComplete { _ =>
+      serverListening
+        .withTimeout(drainTimeout, Some("draining debuggee output"))
+        .onComplete(_ => cancel())
+    }
+  }
 
   trait DebugMode
   object DebugMode {

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -136,6 +136,7 @@ object TestGroups {
     "tests.worksheets.Issue7090LspSuite",
     "tests.parsing.BloopDiagnosticsParserSuite",
     "tests.codeactions.RemoveInfixLspSuite",
+    "scala.meta.internal.metals.debug.tests.DebugProxyTeardownSuite",
   )
 
   val numberOfShards = 4

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/debug/tests/DebugProxyTeardownSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/debug/tests/DebugProxyTeardownSuite.scala
@@ -1,0 +1,76 @@
+package scala.meta.internal.metals.debug.tests
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Promise
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration._
+
+import scala.meta.internal.metals.debug.DebugProxy
+
+import tests.BaseSuite
+
+/**
+ * Regression tests for the debug proxy teardown ordering that fixes
+ * https://github.com/scalameta/metals/issues/2043, where output produced right
+ * before the JVM exits was dropped from the debug console because the proxy tore
+ * down (closing the adapter connection) as soon as the client disconnected,
+ * before the trailing output had been drained.
+ */
+class DebugProxyTeardownSuite extends BaseSuite {
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  test("client-disconnect-waits-for-server-drain") {
+    val server = Promise[Unit]()
+    val client = Promise[Unit]()
+    val cancels = new AtomicInteger(0)
+    val cancelled = Promise[Unit]()
+
+    DebugProxy.teardownOnExit(server.future, client.future, 10.seconds) { () =>
+      cancels.incrementAndGet()
+      cancelled.trySuccess(())
+    }
+
+    // The client (e.g. VS Code) disconnects first, on the `terminated` event.
+    client.success(())
+
+    // Teardown must NOT happen while the server is still draining output.
+    intercept[TimeoutException](Await.result(cancelled.future, 300.millis))
+    assertEquals(cancels.get(), 0)
+
+    // Once the server reaches EOF (all output forwarded), teardown proceeds.
+    server.success(())
+    Await.result(cancelled.future, 5.seconds)
+    assert(cancels.get() >= 1)
+  }
+
+  test("server-eof-cancels-immediately") {
+    val server = Promise[Unit]()
+    val client = Promise[Unit]() // client never disconnects
+    val cancelled = Promise[Unit]()
+
+    DebugProxy.teardownOnExit(server.future, client.future, 10.seconds) { () =>
+      cancelled.trySuccess(())
+    }
+
+    // Server EOF means everything has been read, so teardown is safe right away.
+    server.success(())
+    Await.result(cancelled.future, 5.seconds)
+  }
+
+  test("client-disconnect-cancels-after-timeout-when-server-never-drains") {
+    val server = Promise[Unit]() // never completed (e.g. process won't exit)
+    val client = Promise[Unit]()
+    val cancelled = Promise[Unit]()
+
+    DebugProxy.teardownOnExit(server.future, client.future, 300.millis) { () =>
+      cancelled.trySuccess(())
+    }
+
+    client.success(())
+    // The timeout bounds the wait so teardown still happens.
+    Await.result(cancelled.future, 5.seconds)
+  }
+}


### PR DESCRIPTION
Fixes #2043.

## Problem
When a debuggee prints a lot to stdout and then exits, the **Debug Console** drops the trailing output - the program runs fine and the full output still shows in the Output tab / Metals trace, but the console is cut off. Maintainers traced it to the output proxy terminating too early: the trace shows `Canceling debug proxy for [...]` in the middle of the output.

## Cause
In `DebugProxy`, the client-reader and server-reader loops run concurrently and whichever finishes first calls `cancel()`, which closes **both** sockets. When the debuggee exits, the client (e.g. VS Code) disconnects as soon as it sees the `terminated` event — which can happen before the adapter has finished forwarding the debuggee's final output. `cancel()` then closes the adapter (server) socket mid-stream, so the trailing output never reaches the console.

## Fix
Order the teardown so output is always drained first (`DebugProxy.teardownOnExit`):
- when the **client** disconnects, wait for the **server** side to finish draining before cancelling, bounded by a 5s timeout (so a process that never exits can't deadlock teardown)
- the **server**-EOF path still cancels immediately, since reaching EOF means all output has already been read and forwarded
- the restart path is unchanged.

## Tests
Added `DebugProxyTeardownSuite`, a deterministic unit test of the teardown ordering: a client disconnect must not cancel until the server has drained (or the timeout fires). Verified it fails if the fix is reverted. Existing `DebugProtocolSuite` and `DebugProtocolCancelationSuite` still pass.

An end-to-end DAP test was attempted but the harness can't reproduce the race (the test client receives `terminated` last and shuts down gracefully, so output is delivered regardless), so the regression is guarded at the unit level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown of debug sessions with better resource cleanup and timeout handling.

* **Tests**
  * Added comprehensive tests for debug session shutdown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->