### PR TITLE
bugfix: Expand implicit materializer macros in the presentation compiler

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -91,8 +91,9 @@ class MetalsGlobal(
      * The benefits of disabling blackbox macros are
      * - we insure ourselves from misbehaving macro library that mess up with compiler APIs
      * - we avoid potentially expensive computation during macro expansion
-     * It's safe to disable blackbox macros because they don't affect typing, meaning
-     * they cannot change the results from completions/signatureHelp/hover.
+     * Blackbox macros cannot refine their declared return type, so for term-position
+     * expansions they don't affect typing and skipping them cannot change the results
+     * from completions/signatureHelp/hover.
      *
      * Here are basic benchmark numbers running completions in Exprs.scala from fastparse,
      * a 150 line source file where a scope completion triggers 80 macros.
@@ -105,6 +106,19 @@ class MetalsGlobal(
      *
      * We don't use `analyser.addMacroPlugin()` to disable blackbox macros because benchmarks show that
      * macro plugins add ~10ms overhead compared to overriding this method directly.
+     *
+     * However, while searching for an implicit a blackbox macro DOES affect typing: it is
+     * an implicit materializer whose successful expansion is what makes the implicit
+     * available, and that in turn drives type inference of the enclosing call. Skipping it
+     * makes the implicit unresolvable, so an inferred `val` whose type depends on such a
+     * materialized instance ends up with an error type and offers no completions/hover
+     * (e.g. caliban's `val api = graphQL(RootResolver(queries))`, see
+     * https://github.com/scalameta/metals/issues/2289). We therefore only skip blackbox
+     * macros outside of an implicit search, mirroring how the compiler itself guards the
+     * `-Ymacro-expand:discard` shortcut with `!isSearchingForImplicitParam`
+     * (scala.tools.nsc.typechecker.Macros#MacroExpander). We test `openImplicits` directly
+     * rather than `context.isSearchingForImplicitParam` because the latter does not exist
+     * in 2.11.
      */
     override def pluginsMacroExpand(
         typer: Typer,
@@ -112,7 +126,10 @@ class MetalsGlobal(
         mode: Mode,
         pt: Type
     ): Tree = {
-      if (standardIsBlackbox(expandee.symbol)) expandee
+      if (
+        standardIsBlackbox(expandee.symbol) &&
+        typer.context.openImplicits.isEmpty
+      ) expandee
       else super.pluginsMacroExpand(typer, expandee, mode, pt)
     }
   }

--- a/tests/cross/src/test/scala/tests/pc/Issue2289CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/Issue2289CompletionSuite.scala
@@ -1,0 +1,54 @@
+package tests.pc
+
+import coursierapi.Dependency
+import tests.BaseCompletionSuite
+
+/**
+ * Regression test for https://github.com/scalameta/metals/issues/2289
+ *
+ * When the type of a `val` is inferred through an implicit instance materialized
+ * by a (blackbox) macro - here caliban's `Schema` derivation - the presentation
+ * compiler used to skip that macro expansion, the implicit search failed and the
+ * `val` ended up with an error type, so no completions/hover were offered. With an
+ * explicit type annotation it worked. See `MetalsGlobal#pluginsMacroExpand`.
+ */
+class Issue2289CompletionSuite extends BaseCompletionSuite {
+
+  override def extraDependencies(scalaVersion: String): Seq[Dependency] = {
+    val binaryVersion = createBinaryVersion(scalaVersion)
+    Seq(
+      Dependency.of("com.github.ghostdogpr", s"caliban_$binaryVersion", "3.1.2")
+    )
+  }
+
+  // The reproduction only type-checks under Scala 2.13 (caliban 3.x's auto
+  // derivation does not resolve `Schema` on 2.12, even with the batch compiler),
+  // so this is the version where the PC-specific regression is observable.
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScalaVersion(!_.startsWith("2.13")))
+
+  override def beforeAll(): Unit = ()
+
+  private val preamble =
+    """|import caliban._
+       |import caliban.schema.Schema.auto._
+       |
+       |object Main {
+       |  case class Character(name: String, age: Option[Int])
+       |  def getCharacters: List[Character] = List()
+       |  case class Queries(characters: List[Character])
+       |  val queries = Queries(getCharacters)
+       |""".stripMargin
+
+  checkItems(
+    "inferred-type-from-implicit-macro",
+    preamble +
+      "  val api = graphQL(RootResolver(queries))\n  api.re@@\n}\n",
+    items => {
+      val labels = items.map(_.getLabel())
+      // `render` / `renderCompact` are members of the inferred `GraphQL[_]` type
+      labels.exists(_.startsWith("render")) &&
+      labels.exists(_.startsWith("renderCompact"))
+    }
+  )
+}


### PR DESCRIPTION
## Fixes #2289 (Scala 2)

### Root cause
`MetalsGlobal#pluginsMacroExpand` skips expansion of all blackbox macros (for performance and reliability), on the assumption that blackbox macros don't affect typing. That holds for term-position expansions, but not for blackbox **implicit materializers**: their expansion is what makes the implicit available, which in turn drives type inference of the enclosing call.

For caliban's `val api = graphQL(RootResolver(queries))`, the result type parameter `R` of `graphQL[R]` is inferred from the implicitly derived `Schema[R, Queries]`. Skipping that materializer leaves the implicit unresolved, so the inferred `val` gets an error type and offers no completions or hover — while the same code with an explicit type annotation works.

### Fix
Only skip blackbox macros when not inside an implicit search (`context.openImplicits.isEmpty`), mirroring how the compiler itself guards the `-Ymacro-expand:discard` shortcut with `!isSearchingForImplicitParam`. We test `openImplicits` directly because `isSearchingForImplicitParam` does not exist on 2.11.

### Note
This fixes the Scala 2 presentation compiler only. Scala 3 exhibits the same symptom through a different mechanism (Mirror-based derivation in the interactive compiler), so #2289 is not fully resolved by this PR — the Scala 3 case still needs a separate fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed completion and hover functionality when working with implicit macro-expanded types in Scala 2.13 projects.

* **Tests**
  * Added regression test for Caliban GraphQL schema completions to prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->