### PR TITLE
bugfix: Prefer a custom .bsp build server over a stray .bloop directory

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -52,11 +52,14 @@ final class BuildTools(
   def isAutoConnectable(
       maybeProjectRoot: Option[AbsolutePath] = None
   ): Boolean = {
-    maybeProjectRoot
-      .map(isBloop)
-      .getOrElse(
-        isBloop
-      ) || (isBsp && all.isEmpty) || (isBsp && explicitChoiceMade())
+    val bloopAvailable = maybeProjectRoot.map(isBloop).getOrElse(isBloop)
+    // A custom `.bsp/<name>.json` is an explicit directive to use that build
+    // server. Don't auto-connect to Bloop just because a (possibly stale)
+    // `.bloop` directory is also present — fall through to the normal selection
+    // flow so the custom server is used (or the user is asked when a supported
+    // build tool is also detected). See https://github.com/scalameta/metals/issues/2420
+    (bloopAvailable && !(hasCustomBsp && !explicitChoiceMade())) ||
+    (isBsp && all.isEmpty) || (isBsp && explicitChoiceMade())
   }
   def isBloop(root: AbsolutePath): Boolean = hasJsonFile(root.resolve(".bloop"))
   def bloopProject: Option[AbsolutePath] = searchForBuildTool(isBloop)
@@ -151,6 +154,9 @@ final class BuildTools(
   def isInBsp(path: AbsolutePath): Boolean =
     path.isFile && path.parent.filename == ".bsp" &&
       path.filename.endsWith(".json")
+
+  /** True if a `.bsp/<name>.json` for a server we don't recognize is present. */
+  def hasCustomBsp: Boolean = customBsps.nonEmpty
 
   private def customBsps: List[BspOnly] = {
     val bspFolders =

--- a/tests/unit/src/test/scala/tests/BillLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillLspSuite.scala
@@ -53,6 +53,19 @@ class BillLspSuite extends BaseLspSuite("bill") {
     testRoundtripCompilation()
   }
 
+  test("stale-bloop-prefers-custom-bsp") {
+    cleanWorkspace()
+    Bill.installWorkspace(workspace)
+    // A leftover/committed `.bloop` directory must not override the explicit
+    // custom `.bsp/bill.json`. Without the fix this auto-connects to Bloop and
+    // Bill never initializes, so Bill's round-trip diagnostics below would be
+    // absent. See https://github.com/scalameta/metals/issues/2420
+    val bloop = workspace.resolve(".bloop")
+    bloop.createDirectories()
+    bloop.resolve("bla.json").writeText("{}")
+    testRoundtripCompilation()
+  }
+
   test("reconnect-manual") {
     cleanWorkspace()
     Bill.installWorkspace(workspace)


### PR DESCRIPTION
Fixes #2420.

### Problem

When a workspace has a custom `.bsp/<name>.json` (a non-Bloop server the project explicitly declares) **and** a `.bloop/` directory, Metals silently auto-connects to Bloop and never considers the custom server — no prompt, no discoverability. `isBloop` short-circuits `isAutoConnectable`, so `BspConnector.resolve` returns `ResolvedBloop` before the `.bsp` entry is ever read. A leftover/committed `.bloop` thus overrides the project's explicit choice.

### Fix

Stop letting `isBloop` short-circuit auto-connect when a **custom** `.bsp/<name>.json` is present and no server was explicitly chosen — these workspaces fall through to the normal selection flow, which uses the custom server (or prompts when a supported build tool is also detected).

- Only servers Metals doesn't recognize (`customBsps`) trigger this — `.bsp/sbt.json`, `.bsp/mill.json`, etc. are unaffected.
- A deliberate prior choice still wins: `explicitChoiceMade()` disables the guard, so an explicitly selected Bloop is never overridden.

This closes the last gap in #2420; the other custom-`.bsp` cases already behaved correctly (lone custom `.bsp` connects directly; custom `.bsp` next to a supported build tool prompts).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom BSP server configurations are now properly respected; Bloop auto-connection no longer interferes when a custom BSP is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->