### PR TITLE
bugfix: Don't offer already-in-scope types in import completions

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -48,6 +48,7 @@ class MetalsGlobal(
     with completions.Completions
     with completions.ArgCompletions
     with completions.FilenameCompletions
+    with completions.ImportCompletions
     with completions.InterpolatorCompletions
     with completions.MatchCaseCompletions
     with completions.NewCompletions

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -611,6 +611,12 @@ trait Completions { this: MetalsGlobal =>
           editRange,
           text
         )
+      case (_: Import) :: _ if isImportPrefixPosition(pos, text) =>
+        // Cursor is on the import prefix (`import Inner@@`), a scope
+        // completion. A cursor on a selector (`import a.Outer.Inner@@`,
+        // `import scala.Foo@@`) is left to the default member completion and
+        // not filtered.
+        ImportCompletion(pos)
       case _ =>
         inferCompletionPosition(
           pos,

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ImportCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ImportCompletions.scala
@@ -1,0 +1,48 @@
+package scala.meta.internal.pc.completions
+
+import scala.meta.internal.pc.MetalsGlobal
+
+trait ImportCompletions { this: MetalsGlobal =>
+
+  /**
+   * True when the cursor sits on an import *prefix* (`import Inner@@`) rather
+   * than on a selector (`import a.Outer.Inner@@`, `import a.{Inner@@}`).
+   *
+   * Decided from the source text, since how each Scala version's parser shapes
+   * an incomplete import tree (member vs scope, qualifier position) is not
+   * stable across 2.11/2.12/2.13. A prefix has no qualifier separator (`.` or
+   * `{`) between the start of the statement and the cursor.
+   */
+  def isImportPrefixPosition(pos: Position, text: String): Boolean = {
+    val uptoCursor = text.substring(0, math.min(pos.point, text.length))
+    val statementStart =
+      math.max(uptoCursor.lastIndexOf('\n'), uptoCursor.lastIndexOf(';')) + 1
+    val segment = uptoCursor.substring(statementStart)
+    !segment.contains('.') && !segment.contains('{')
+  }
+
+  /**
+   * A completion on an import prefix, example `import Inner@@`.
+   *
+   * Only used when the cursor is on the import prefix (a scope completion);
+   * selector completions such as `import a.Outer.Inner@@` are handled by the
+   * default member completion, see `completionPositionUnsafe`.
+   */
+  case class ImportCompletion(pos: Position) extends CompletionPosition {
+    // context at the import position (includes preceding imports in the block)
+    private lazy val importContext = doLocateImportContext(pos)
+
+    override def isCandidate(member: Member): Boolean = {
+      val sym = member.sym
+      // Keep packages, objects/modules and anything not already in scope.
+      // Drop only *pure types* (class/trait/type alias) that are already in
+      // scope, re-importing those is redundant. Objects/packages stay because
+      // you may still select a member (`import Inner.A`).
+      sym.hasPackageFlag ||
+      !sym.isType ||
+      sym.isModuleClass ||
+      !importContext.symbolIsInScope(sym)
+    }
+  }
+
+}

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -599,6 +599,21 @@ class CompletionSuite extends BaseCompletionSuite {
     "Inner a.Outer"
   )
 
+  // `import scala.Function22@@` is a selector completion (cursor past the `.`),
+  // so the prefix-only filter must not run and the already-in-scope
+  // `Function22` type is still offered. Guards #2546 against hiding selector
+  // type completions.
+  check(
+    "import-selector-in-scope-2546",
+    """
+      |package a
+      |object Main {
+      |  import scala.Function22@@
+      |}
+      |""".stripMargin,
+    "Function22 scala"
+  )
+
   check(
     "duplicate2",
     """

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -573,13 +573,30 @@ class CompletionSuite extends BaseCompletionSuite {
       |""".stripMargin,
     "",
     compat = Map(
-      "3" -> "Inner a.Outer",
-      /* TODO Seems that changes in 2.13.5 made this pop up and this
-       * might have been a bug in presentation compiler that we were using
-       * https://github.com/scalameta/metals/issues/2546
+      /* The already-in-scope type is correctly filtered out on Scala 2.
+       * On Scala 3 the presentation compiler lives in the dotty repo
+       * (`dotty.tools.pc`) and still offers it, so this needs a separate
+       * fix there. https://github.com/scalameta/metals/issues/2546
        */
-      "2.13" -> "Inner a.Outer"
+      "3" -> "Inner a.Outer"
     )
+  )
+
+  check(
+    "import-object-in-scope-2546",
+    """
+      |package a
+      |object Main {
+      |  import a.Outer.Inner
+      |  import Inner@@
+      |}
+      |object Outer {
+      |  object Inner {
+      |    object A
+      |  }
+      |}
+      |""".stripMargin,
+    "Inner a.Outer"
   )
 
   check(


### PR DESCRIPTION
Resolves #2546 only for Scala 2. Scala 3's presentation compiler lives in dotty, the `"3"` compat entry on the `duplicate` test stays, and a separate dotty change is needed to close the issue there.


Notes:
- Objects and packages are kept — you may still want to select a member (`import Inner.A`).
- Only an unqualified import prefix (`import Inner@@`) is filtered; selector completions (`import a.Outer.Inner@@`, `import scala.Foo@@`) are detected from the source text and left to the default member completion, so they are never filtered. This is stable across 2.11/2.12/2.13, whose parsers shape an incomplete import differently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import completions: the editor now recognizes import-prefix positions and offers contextual, scope-filtered suggestions when typing import statements.

* **Tests**
  * Added and updated tests covering import completion scenarios and cross-version behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->