### PR TITLE
chore: Update Bloop to 2.1.0

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -357,7 +357,7 @@ final class BloopServers(
                 scribe
                   .debug("Unexpected error while deleting the BSP socket", e)
             }
-          BspConnectionAddress.UnixDomainSocket(socketPath.toFile)
+          BspConnectionAddress.UnixDomainSocket(socketPath)
         },
         bspStdout = bloopLogger.bloopBspStdout,
         bspStderr = bloopLogger.bloopBspStderr,

--- a/project/V.scala
+++ b/project/V.scala
@@ -25,7 +25,7 @@ object V {
 
   val betterMonadicFor = "0.3.1"
 
-  val bloop = "2.0.19"
+  val bloop = "2.1.0"
 
   val bloopConfig = "2.3.3"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Bloop build server to version 2.1.0
  * Refined Unix domain socket address handling for improved compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->