### PR TITLE
bugfix: Use fallback compiler for mbt references

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -2108,12 +2108,22 @@ class Compilers(
     debugItem
   }
 
+  /**
+   * Batch the semanticdb text documents for the given sources.
+   *
+   * @param sources list of sources to process
+   * @param cancelToken cancel token to cancel the operation
+   * @param timeout timeout after which partial results may be returned
+   * @param useFallbackCompiler  use fallback compiler to avoid starting many presentation compilers
+   * @param shouldPruneSemanticdb whether to prune semanticdb, set if only interested in public symbols
+   * @return Future[s.TextDocuments] containing the semanticdb text documents
+   */
   def batchSemanticdbTextDocuments(
       sources: Seq[AbsolutePath],
       cancelToken: CancelToken,
       timeout: Duration,
+      useFallbackCompiler: Boolean,
       shouldPruneSemanticdb: Boolean = false,
-      useFallbackCompiler: Boolean = true,
   ): Future[s.TextDocuments] = {
     def getCompiler(path: AbsolutePath): Option[PresentationCompiler] =
       if (useFallbackCompiler && path.isScalaOrJava)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -2113,10 +2113,17 @@ class Compilers(
       cancelToken: CancelToken,
       timeout: Duration,
       shouldPruneSemanticdb: Boolean = false,
+      useFallbackCompiler: Boolean = true,
   ): Future[s.TextDocuments] = {
+    def getCompiler(path: AbsolutePath): Option[PresentationCompiler] =
+      if (useFallbackCompiler && path.isScalaOrJava)
+        Some(fallbackCompiler(path))
+      else
+        loadCompiler(path)
+
     val futures = for {
       (pc, paths) <- sources
-        .flatMap(s => loadCompiler(s).map(pc => (pc, s)))
+        .flatMap(s => getCompiler(s).map(pc => (pc, s)))
         .groupBy(_._1)
     } yield {
       val params = paths.map { case (_, s) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -721,6 +721,7 @@ final class BuildTargetClasses(
               EmptyCancelToken,
               Duration.ofSeconds(120),
               shouldPruneSemanticdb = true,
+              useFallbackCompiler = true,
             )
             .recover { case e =>
               scribe.error(s"Error parsing semanticdb text documents: $e", e)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -720,8 +720,8 @@ final class BuildTargetClasses(
               batch,
               EmptyCancelToken,
               Duration.ofSeconds(120),
-              shouldPruneSemanticdb = true,
               useFallbackCompiler = true,
+              shouldPruneSemanticdb = true,
             )
             .recover { case e =>
               scribe.error(s"Error parsing semanticdb text documents: $e", e)

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtReferenceProvider.scala
@@ -1,6 +1,8 @@
 package scala.meta.internal.metals.mbt
 
 import java.time.Duration
+import java.util.concurrent.CancellationException
+import java.util.concurrent.TimeoutException
 
 import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
@@ -47,7 +49,10 @@ class MbtReferenceProvider(
     workDoneProgress: WorkDoneProgress,
     metrics: MonitoringClient,
 )(implicit ec: ExecutionContext) {
-  private val cache = new TextDocumentCache()
+  // Use fallback compiler to avoid starting many per-build-target presentation
+  // compilers. The fallback compiler includes all sources and dependencies
+  // from MBT.
+  private val cache = new TextDocumentCache(useFallbackCompiler = true)
 
   // When looking for usages of a method, we don't visit supermethods from these
   // types because it would result in a ton of noisy results. This list should
@@ -513,7 +518,11 @@ class MbtReferenceProvider(
   // keep this in-memory cache here. Ideally, when we build the shared
   // abstraction, it will also be powered by a persistent cache, and it's able
   // to deal with adjusting positions in stale payloads, etc.
-  private class TextDocumentCache() {
+  // When useFallbackCompiler is true, all files are indexed using the fallback
+  // compiler instead of per-build-target compilers. This avoids starting many
+  // presentation compilers when MBT is available and provides all sources and
+  // dependencies through the fallback compiler.
+  private class TextDocumentCache(useFallbackCompiler: Boolean) {
     private val cache = TrieMap.empty[AbsolutePath, s.TextDocument]
     def indexSingle(path: AbsolutePath): s.TextDocument = {
       index(Seq(path)).documents.headOption.getOrElse {
@@ -537,17 +546,32 @@ class MbtReferenceProvider(
       if (toIndex.isEmpty) {
         s.TextDocuments(documents = docs.toSeq)
       } else {
-        val result = Await
-          .result(
-            compilers.batchSemanticdbTextDocuments(
-              toIndex,
-              EmptyCancelToken,
-              // intentionally smaller than the default PC timeout of 20s
-              Duration.ofSeconds(15),
-            ),
-            timeout,
-          )
-          .documents
+        def fetchDocs(maxRetries: Int): Seq[s.TextDocument] = {
+          try {
+            Await
+              .result(
+                compilers.batchSemanticdbTextDocuments(
+                  toIndex,
+                  EmptyCancelToken,
+                  // intentionally smaller than the default PC timeout of 20s
+                  Duration.ofSeconds(15),
+                  useFallbackCompiler = useFallbackCompiler,
+                ),
+                timeout,
+              )
+              .documents
+          } catch {
+            case _: CancellationException if maxRetries > 0 =>
+              fetchDocs(maxRetries - 1)
+            case e @ (_: CancellationException | _: TimeoutException) =>
+              scribe.warn(
+                s"references: indexing ${toIndex.size} documents failed.",
+                e,
+              )
+              throw e
+          }
+        }
+        val result = fetchDocs(maxRetries = 3)
         result.foreach { doc =>
           doc.uri.toAbsolutePathSafe.foreach { path =>
             cache.put(path, doc)

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -181,6 +181,17 @@ class MbtWorkspaceSymbolProvider(
       }
     }
   }
+  // `documentsKeys` is effectively `documents.keys.par` but without the
+  // overhead to copy the keys into a parallel collection at query time.  Make
+  // sure to call updateDocumentsKeys() when you add or remove a document.
+  @volatile private var documentsKeys = ParArray.empty[AbsolutePath]
+  private val isIndexRead = new AtomicBoolean(false)
+
+  // Maps SemanticDB package symbol (for example, "scala/collection/") to all
+  // the files that directly belong to that package. This index powers repo-wide
+  // -sourcepath imports for JavaPruneCompilerFileManager. It's important to manually
+  private val documentsByPackage: TrieMap[String, ConcurrentSkipListSet[Path]] =
+    TrieMap.empty[String, ju.concurrent.ConcurrentSkipListSet[Path]]
 
   // The source of truth for what files belong to the workspace, and their attached indexed data.
   // DO NOT update this map directly since have a couple derivative collections.
@@ -188,28 +199,12 @@ class MbtWorkspaceSymbolProvider(
   // - onDidChange(file: AbsolutePath): Unit
   // - onDidDelete(file: AbsolutePath): Unit
   // - onDidChangeSymbols(params: OnDidChangeSymbolsParams): Unit
-  private lazy val documents: TrieMap[AbsolutePath, IndexedDocument] =
+  private val documents: TrieMap[AbsolutePath, IndexedDocument] =
     readIndex()
-  def readInitialIndexForTestingPurposes(): Unit = {
-    // Just trigger the lazy val initialization without doing other expensive
-    // work that is not necessary for tests or benchmarks.
-    documents.size
-  }
 
   def allFiles(): List[AbsolutePath] = {
     documents.keys.toList
   }
-
-  // `documentsKeys` is effectively `documents.keys.par` but without the
-  // overhead to copy the keys into a parallel collection at query time.  Make
-  // sure to call updateDocumentsKeys() when you add or remove a document.
-  @volatile private var documentsKeys = ParArray.empty[AbsolutePath]
-
-  // Maps SemanticDB package symbol (for example, "scala/collection/") to all
-  // the files that directly belong to that package. This index powers repo-wide
-  // -sourcepath imports for JavaPruneCompilerFileManager. It's important to manually
-  private val documentsByPackage: TrieMap[String, ConcurrentSkipListSet[Path]] =
-    TrieMap.empty[String, ju.concurrent.ConcurrentSkipListSet[Path]]
 
   def onReindex(): IndexingStats = try {
     if (isIndexing.compareAndSet(false, true)) {
@@ -953,7 +948,6 @@ class MbtWorkspaceSymbolProvider(
     newValue
   }
 
-  private val isIndexRead = new AtomicBoolean(false)
   // Reads .metals/index.mbt, which is a serialized Mbt.Index protobuf payload,
   // into memory and converts it into TrieMap[AbsolutePath, IndexedDocument].
   // For a very large repo (>100k Scala/Java files), this file still only takes


### PR DESCRIPTION
Otherwise, we would quickly go over the limit of PCs and start cancelling them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and retry logic for compiler operations to better handle timeout and cancellation scenarios.

* **Refactor**
  * Enhanced compiler selection mechanism for improved semantic document processing.
  * Optimized index initialization for faster startup performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->