### PR TITLE
[MBT] [Gradle] Add support for testFixtures source set

### DIFF
--- a/gradle-extractor/src/main/scala/gradleinfo/GradleInfoExtractor.scala
+++ b/gradle-extractor/src/main/scala/gradleinfo/GradleInfoExtractor.scala
@@ -45,6 +45,9 @@ object GradleInfoExtractor {
   private final case class SourceSetDirectories(
       classDirectories: List[String] = Nil,
       testClassDirectory: List[String] = Nil,
+      testFixturesClassDirectories: List[String] = Nil,
+      testFixturesSources: List[String] = Nil,
+      testFixturesProjectDeps: List[String] = Nil,
   )
 
   private object SourceSetDirectories {
@@ -107,12 +110,23 @@ object GradleInfoExtractor {
           |    if (sourceSets != null) {
           |      def main = sourceSets.findByName('main')
           |      def test = sourceSets.findByName('test')
+          |      def testFixtures = sourceSets.findByName('testFixtures')
           |      def outputs = [:]
           |      if (main != null) {
           |        outputs['classDirectories'] = main.output.classesDirs.files.collect { it.absolutePath }
           |      }
           |      if (test != null) {
           |        outputs['testClassDirectory'] = test.output.classesDirs.files.collect { it.absolutePath }
+          |      }
+          |      if (testFixtures != null) {
+          |        outputs['testFixturesClassDirectories'] = testFixtures.output.classesDirs.files.collect { it.absolutePath }
+          |        outputs['testFixturesSources'] = testFixtures.allSource.srcDirs.findAll { it.exists() }.collect { it.absolutePath }
+          |        def tfConfig = project.configurations.findByName('testFixturesImplementation')
+          |        if (tfConfig != null) {
+          |          outputs['testFixturesProjectDeps'] = tfConfig.dependencies
+          |            .findAll { it instanceof org.gradle.api.artifacts.ProjectDependency }
+          |            .collect { it.name }
+          |        }
           |      }
           |      if (!outputs.isEmpty()) {
           |        result[project.path] = outputs
@@ -221,6 +235,29 @@ object GradleInfoExtractor {
         )
         .getOrElse(Nil)
 
+    val testFixturesClassDirectories: Seq[String] =
+      sourceSetsMap
+        .get(projectPath)
+        .map(
+          _.testFixturesClassDirectories
+            .map(d => relativize(java.nio.file.Paths.get(d)))
+        )
+        .getOrElse(Nil)
+
+    val testFixturesSources: Seq[String] =
+      sourceSetsMap
+        .get(projectPath)
+        .map(
+          _.testFixturesSources.map(d => relativize(java.nio.file.Paths.get(d)))
+        )
+        .getOrElse(Nil)
+
+    val testFixturesProjectDeps: Seq[String] =
+      sourceSetsMap
+        .get(projectPath)
+        .map(_.testFixturesProjectDeps)
+        .getOrElse(Nil)
+
     val (externalDeps, projectDeps) = classifyDependencies(m)
 
     ModuleReport(
@@ -238,6 +275,9 @@ object GradleInfoExtractor {
       externalDependencies =
         externalDeps.sortBy(d => (d.group, d.name, d.version, d.scope)),
       projectDependencies = projectDeps.sortBy(d => (d.targetModule, d.scope)),
+      testFixturesSources = testFixturesSources,
+      testFixturesClassDirectories = testFixturesClassDirectories,
+      testFixturesProjectDeps = testFixturesProjectDeps,
     )
   }
   private def classifyDependencies(

--- a/gradle-extractor/src/main/scala/gradleinfo/Report.scala
+++ b/gradle-extractor/src/main/scala/gradleinfo/Report.scala
@@ -48,6 +48,9 @@ final case class ModuleReport(
     testSourceDirectories: Seq[String],
     externalDependencies: Seq[ExternalDependency],
     projectDependencies: Seq[ProjectDependency],
+    testFixturesSources: Seq[String] = Nil,
+    testFixturesClassDirectories: Seq[String] = Nil,
+    testFixturesProjectDeps: Seq[String] = Nil,
 )
 
 /** Top-level information about the Gradle build. */
@@ -76,6 +79,12 @@ final case class ProjectReport(
         sources = dep.source.orNull,
       )
     }
+
+    val modulesWithTestFixtures = modules.collect {
+      case m
+          if m.testFixturesSources.nonEmpty || m.testFixturesClassDirectories.nonEmpty =>
+        m.name
+    }.toSet
 
     val namespaces = modules.flatMap { m =>
       val mainDepIds = m.externalDependencies
@@ -107,6 +116,9 @@ final case class ProjectReport(
           None
         else {
           val testDeps = m.name :: testDependsOn.toList
+          val fixtureDeps = testDeps
+            .filter(modulesWithTestFixtures)
+            .map(dep => s"$dep:testFixtures")
           Some(
             s"${m.name}:test" -> MbtNamespaceJson(
               sources = m.testSourceDirectories,
@@ -115,7 +127,7 @@ final case class ProjectReport(
               dependencyModules = testDepIds,
               scalaVersion = null,
               javaHome = javaHome,
-              dependsOn = testDeps,
+              dependsOn = (testDeps ++ fixtureDeps).distinct,
               classDirectories = m.testClassDirectory,
               projectPath = m.projectPath,
               configurations = null,
@@ -123,7 +135,26 @@ final case class ProjectReport(
           )
         }
 
-      Seq(Some(mainNamespace), testNamespace).flatten
+      val testFixturesNamespace =
+        Option.when(
+          m.testFixturesSources.nonEmpty || m.testFixturesClassDirectories.nonEmpty
+        )(
+          s"${m.name}:testFixtures" -> MbtNamespaceJson(
+            sources = m.testFixturesSources,
+            scalacOptions = Seq.empty,
+            javacOptions = Seq.empty,
+            dependencyModules = testDepIds,
+            scalaVersion = null,
+            javaHome = javaHome,
+            dependsOn =
+              (m.name +: (mainDependsOn ++ m.testFixturesProjectDeps)).distinct,
+            classDirectories = m.testFixturesClassDirectories,
+            projectPath = m.projectPath,
+            configurations = null,
+          )
+        )
+
+      Seq(Some(mainNamespace), testNamespace, testFixturesNamespace).flatten
     }.toMap
 
     val build = MbtBuildJson(


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/8442
Fixes https://github.com/scalameta/metals/issues/8453

Tested on https://github.com/apache/kafka/commit/e4b9bbd9f96b014f8072925fbfb4c42b185889dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extracting test fixtures source set information
  * Generated reports now include test fixtures source directories and class directories
  * Test fixtures namespaces automatically generated for modules containing test fixtures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->