### PR TITLE
bugfix: Fix potential null pointer exception

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -945,10 +945,6 @@ class MbtWorkspaceSymbolProvider(
   ): ParArray[AbsolutePath] = {
     val newValue = ParArray.fromSpecific(documentsIndex.keysIterator)
     documentsKeys = newValue
-    // update the document keys is the last step when indexing, as it prepares
-    // the parallel array for the next workspace symbol search, it's the right moment
-    // to notify others that the indexing is done.
-    onIndexingDone()
     newValue
   }
 


### PR DESCRIPTION
It seems with the recent changes we might get null pointer if we restart compilers after reading protobuf. Since we restart on reindexing anyway, it's fine to remove it.