### PR TITLE
Don't suggest upgrading to legacy Scala 2.11.12 when already on it

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -975,11 +975,13 @@ object Messages {
     ): String = {
       val using = usingString(usingNow)
       val recommended = recommendationString(usingNow)
-      val uses211 = usingNow.exists(
-        ScalaVersions.scalaBinaryVersionFromFullVersion(_) == "2.11"
+      val canUpgradeTo211 = usingNow.exists(version =>
+        ScalaVersions.scalaBinaryVersionFromFullVersion(version) == "2.11" &&
+          SemVer.isLaterVersion(version, BuildInfo.scala211)
       )
       val deprecatedAleternative =
-        if (uses211) s" or alternatively to legacy Scala ${BuildInfo.scala211}"
+        if (canUpgradeTo211)
+          s" or alternatively to legacy Scala ${BuildInfo.scala211}"
         else ""
       val isAre = if (usingNow.size == 1) "is" else "are"
       val descriptionString = description.map(s => s"$s ").getOrElse("")

--- a/tests/unit/src/test/scala/tests/MessagesSuite.scala
+++ b/tests/unit/src/test/scala/tests/MessagesSuite.scala
@@ -45,4 +45,12 @@ class MessagesSuite extends BaseSuite {
         s" Please upgrade to Scala version ${V.scala212} or alternatively to legacy Scala ${V.scala211}.",
     )
   }
+
+  test("unsupported-legacy-211") {
+    assertDiffEqual(
+      Messages.UnsupportedScalaVersion.message(Set(V.scala211)),
+      s"You are using Scala version ${V.scala211}, which is not supported in this version of Metals." +
+        s" Please upgrade to Scala version ${V.scala212}.",
+    )
+  }
 }


### PR DESCRIPTION
The UnsupportedScalaVersion warning appended `" or alternatively to legacy Scala 2.11.12"` whenever any in-use version was binary 2.11. For a project already on 2.11.12 (the legacy version itself) this produced the nonsensical "Please upgrade to Scala version 2.12.21 or alternatively to legacy Scala 2.11.12." — telling the user to upgrade to the version they are already using.

Only suggest the legacy 2.11 fallback when it would be a real upgrade, i.e. when a 2.11 version older than BuildInfo.scala211 is in use.

To reproduce import https://github.com/bazel-contrib/rules_scala repository as MBT