### PR TITLE
fix: retry completions when the qualifier loses its type to error recovery

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -5,6 +5,7 @@ import java.{util => ju}
 
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.PcQueryContext
@@ -553,12 +554,9 @@ class CompletionProvider(
           )
       }
     }
-    try {
-      val completions = completionsAt(pos) match {
-        case CompletionResult.NoResults =>
-          new DynamicFallbackCompletions(pos).print()
-        case r => r
-      }
+    def matchResults(
+        completions: CompletionResult
+    ): (CompletionListKind, String, List[Member]) = {
       val kind = completions match {
         case _: CompletionResult.ScopeMembers =>
           CompletionListKind.Scope
@@ -568,38 +566,78 @@ class CompletionProvider(
           CompletionListKind.None
       }
       val isTypeMember = kind == CompletionListKind.Type
-      params.checkCanceled()
-
       val query = completions.name.toString
       val queryStartsWithLowercase = query.headOption.forall(_.isLower)
-      val matchingResults = completions.matchingResults { entered => name =>
+      val matching = completions.matchingResults { entered => name =>
         if (isTypeMember) CompletionFuzzy.matchesSubCharacters(entered, name)
         else if (queryStartsWithLowercase)
           CompletionFuzzy.matches(entered, name, forgivingFirstChar = true)
         else CompletionFuzzy.matches(entered, name)
       }
-
-      val latestParentTrees = getLastVisitedParentTrees(pos)
-      val completion = completionPosition(
-        pos,
-        source,
-        params.text(),
-        editRange,
-        completions,
-        latestParentTrees
-      )
-      val items = filterInteresting(
-        matchingResults,
-        kind,
-        query,
-        pos,
-        completion,
-        editRange,
-        latestParentTrees,
-        params.text()
-      )
+      (kind, query, matching)
+    }
+    try {
+      val firstPass = completionsAt(pos) match {
+        case CompletionResult.NoResults =>
+          new DynamicFallbackCompletions(pos).print()
+        case r => r
+      }
       params.checkCanceled()
-      (items, completion, inferredIdentOffsets, editRange, query)
+      val noRestore: () => Unit = () => ()
+      val (completions, kind, query, matchingResults, restoreQualifier) = {
+        val (kind1, query1, matched1) = matchResults(firstPass)
+        val retried =
+          if (matched1.nonEmpty) None
+          else
+            retryWithRecoveredQualifier(pos).flatMap {
+              case (secondPass, restore) =>
+                // The qualifier is still grafted here; restore it on every
+                // path that does not hand `restore` over to the `finally`
+                // below.
+                try {
+                  val (kind2, query2, matched2) = matchResults(secondPass)
+                  if (matched2.isEmpty) {
+                    restore()
+                    None
+                  } else Some((secondPass, kind2, query2, matched2, restore))
+                } catch {
+                  case NonFatal(e) =>
+                    restore()
+                    throw e
+                }
+            }
+        retried.getOrElse((firstPass, kind1, query1, matched1, noRestore))
+      }
+
+      // Keep the recovered qualifier type grafted onto the cached tree until
+      // the whole pipeline below has run, then restore it: `completionPosition`
+      // and `filterInteresting` both re-derive the qualifier via
+      // `typedTreeAt(pos)` and would otherwise see the erroneous type again.
+      try {
+        val latestParentTrees = getLastVisitedParentTrees(pos)
+        val completion = completionPosition(
+          pos,
+          source,
+          params.text(),
+          editRange,
+          completions,
+          latestParentTrees
+        )
+        val items = filterInteresting(
+          matchingResults,
+          kind,
+          query,
+          pos,
+          completion,
+          editRange,
+          latestParentTrees,
+          params.text()
+        )
+        params.checkCanceled()
+        (items, completion, inferredIdentOffsets, editRange, query)
+      } finally {
+        restoreQualifier()
+      }
     } catch {
       case e: CyclicReference
           if e.getMessage.contains("illegal cyclic reference") =>
@@ -611,6 +649,113 @@ class CompletionProvider(
         expected(e)
       case e: StringIndexOutOfBoundsException =>
         expected(e)
+    }
+  }
+
+  /**
+   * Retries member completions on a `Select` whose qualifier lost its type to
+   * typer error recovery, e.g. `stream.pull.peek1@@` in
+   * `stream.pull.peek1.void.<...>.flatMap(...)`, where the trailing chain
+   * fails to typecheck once `_CURSOR_` is inserted even though the qualifier
+   * is fine in isolation. Re-typechecks an untyped copy of the qualifier and
+   * grafts the recovered type onto the cached tree before re-running
+   * `completionsAt`. The graft stays in place because the rest of the
+   * completion pipeline re-derives the qualifier via `typedTreeAt`; the
+   * caller must run the returned callback to restore the original tree.
+   *
+   * See https://github.com/scalameta/metals/issues/2634
+   */
+  private def retryWithRecoveredQualifier(
+      pos: Position
+  ): Option[(CompletionResult, () => Unit)] = {
+    getLastVisitedParentTrees(pos)
+      .collectFirst {
+        case Select(qual, name)
+            if name.containsName(CURSOR) &&
+              qual.tpe != null && qual.tpe.isErroneous =>
+          qual
+      }
+      .flatMap { qual =>
+        try {
+          untypedQualifierAt(pos)
+            .flatMap(retypeQualifier(qual, _))
+            .map(completeWithRetypedQualifier(pos, qual, _))
+        } catch {
+          // The compiler does not guard against ill-typed qualifiers in this
+          // code path (see the TODO in `interactive.Global#typeMembers`), so
+          // re-typechecking one can throw instead of reporting the error.
+          case NonFatal(e) =>
+            logger.warning(
+              s"unexpected error retrying completions with a recovered qualifier: $e"
+            )
+            None
+        }
+      }
+  }
+
+  /**
+   * The qualifier of the `Select` at the cursor, as parsed. The erroneous
+   * qualifier in the typechecked tree keeps its error symbol attached, which
+   * a re-typecheck would short-circuit on, so take an untyped copy from the
+   * parser instead.
+   */
+  private def untypedQualifierAt(pos: Position): Option[Tree] = {
+    val savedParents = lastVisitedParentTrees
+    try {
+      locateUntyped(pos) match {
+        case Select(qual, name) if name.containsName(CURSOR) => Some(qual)
+        case _ => None
+      }
+    } finally {
+      lastVisitedParentTrees = savedParents
+    }
+  }
+
+  private def retypeQualifier(qual: Tree, untypedQual: Tree): Option[Tree] = {
+    // The context stored for this position may come from the typer's failed
+    // silent attempt, where implicit resolution was disabled, while typing
+    // the qualifier may need implicit conversions (e.g. `stream.pull` goes
+    // through `fs2.Stream.InvariantOps`). Temporarily re-enable implicits.
+    val context = doLocateContext(qual.pos)
+    val savedImplicits = context.implicitsEnabled
+    val savedEnrichment = context.enrichmentEnabled
+    val retyped =
+      try {
+        context.implicitsEnabled = true
+        context.enrichmentEnabled = true
+        analyzer.newTyper(context).typedQualifier(untypedQual)
+      } finally {
+        context.implicitsEnabled = savedImplicits
+        context.enrichmentEnabled = savedEnrichment
+      }
+    if (retyped.tpe != null && !retyped.tpe.isErroneous) Some(retyped)
+    else None
+  }
+
+  /**
+   * Grafts `retyped`'s type and symbol onto the cached `qual` tree, re-runs
+   * `completionsAt`, and returns the result together with a callback that
+   * restores `qual` to its original (erroneous) state.
+   */
+  private def completeWithRetypedQualifier(
+      pos: Position,
+      qual: Tree,
+      retyped: Tree
+  ): (CompletionResult, () => Unit) = {
+    val savedType = qual.tpe
+    val savedSymbol = qual.symbol
+    val restore: () => Unit = () => {
+      qual.setSymbol(savedSymbol)
+      qual.setType(savedType)
+    }
+    try {
+      qual.setSymbol(retyped.symbol)
+      qual.setType(retyped.tpe)
+      (completionsAt(pos), restore)
+    } catch {
+      case NonFatal(e) =>
+        restore()
+        throw e
     }
   }
 

--- a/tests/cross/src/test/scala/tests/pc/Issue2634CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/Issue2634CompletionSuite.scala
@@ -1,0 +1,155 @@
+package tests.pc
+
+import coursierapi.Dependency
+import tests.BaseCompletionSuite
+
+/**
+ * Regression test for https://github.com/scalameta/metals/issues/2634
+ *
+ * Member completions on `stream.pull` (`fs2.Stream.ToPull`, an AnyVal value
+ * class) returned nothing when the selection occurred mid-chain and the rest
+ * of the chain failed to typecheck once the `_CURSOR_` instrumentation was
+ * inserted (e.g. a trailing `.flatMap(...)`). Removing the trailing call made
+ * completions work again.
+ */
+class Issue2634CompletionSuite extends BaseCompletionSuite {
+
+  override def extraDependencies(scalaVersion: String): Seq[Dependency] = {
+    val binaryVersion = createBinaryVersion(scalaVersion)
+    Seq(Dependency.of("co.fs2", s"fs2-core_$binaryVersion", "3.9.0"))
+  }
+
+  // The Scala 3 presentation compiler is a separate implementation living in
+  // the dotty repository and fs2 3.9.0 is not published for 2.11.
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3.and(IgnoreScala211))
+
+  private val preamble =
+    """|import cats.MonadThrow
+       |import cats.syntax.all._
+       |import fs2.Stream
+       |
+       |object Main {
+       |""".stripMargin
+
+  // Exact shape from the issue: cursor mid-chain, the trailing .flatMap makes
+  // the enclosing expression fail to typecheck once _CURSOR_ is inserted.
+  checkItems(
+    "topull-member-mid-chain-with-trailing-flatmap",
+    preamble +
+      """|  def onEmptyOrNonEmpty[F[_]: MonadThrow, A, B](stream: Stream[F, A])(onEmpty: F[B])(implicit SC: fs2.Compiler[F, F]): F[B] =
+         |    stream.pull.peek1@@.void.stream.compile.last.flatMap(_.getOrElse(onEmpty))
+         |}
+         |""".stripMargin,
+    items => items.map(_.getLabel()).exists(_.startsWith("peek1"))
+  )
+
+  // Control from the issue's "Additional context": same chain without the
+  // trailing .flatMap already worked in 2021 and must keep working.
+  checkItems(
+    "topull-member-no-trailing-call",
+    preamble +
+      """|  def control[F[_]: MonadThrow, A, B](stream: Stream[F, A])(onEmpty: F[B])(implicit SC: fs2.Compiler[F, F]) =
+         |    stream.pull.peek1@@.void.stream.compile.last
+         |}
+         |""".stripMargin,
+    items => items.map(_.getLabel()).exists(_.startsWith("peek1"))
+  )
+
+  checkItems(
+    "topull-member-empty-query",
+    preamble +
+      """|  def emptyQuery[F[_]: MonadThrow, A](stream: Stream[F, A]): Unit = {
+         |    stream.pull.@@
+         |  }
+         |}
+         |""".stripMargin,
+    items => {
+      val labels = items.map(_.getLabel())
+      // The full ToPull member set is recovered, not just `peek1`.
+      Seq("peek", "peek1", "uncons", "uncons1").forall(expected =>
+        labels.exists(_.startsWith(expected))
+      )
+    }
+  )
+
+  // The qualifier recovers but the query matches no member: the retry must
+  // give up gracefully (and restore the grafted tree, which the repeated
+  // request on the warm compiler would catch).
+  test("topull-member-unmatched-query") {
+    val code = preamble +
+      """|  def unmatched[F[_]: MonadThrow, A, B](stream: Stream[F, A])(onEmpty: F[B])(implicit SC: fs2.Compiler[F, F]): F[B] =
+         |    stream.pull.zzz@@.void.stream.compile.last.flatMap(_.getOrElse(onEmpty))
+         |}
+         |""".stripMargin
+    def labels(restart: Boolean): Seq[String] =
+      getItems(code, restart = restart).map(_.getLabel())
+    assert(!labels(restart = true).exists(_.startsWith("peek")))
+    assert(!labels(restart = false).exists(_.startsWith("peek")))
+  }
+
+  // The qualifier is genuinely ill-typed, so the re-typecheck cannot recover
+  // it either: completions stay empty instead of crashing.
+  checkItems(
+    "topull-member-unrecoverable-qualifier",
+    preamble +
+      """|  def unrecoverable[F[_]: MonadThrow, A, B](stream: Stream[F, A])(onEmpty: F[B])(implicit SC: fs2.Compiler[F, F]): F[B] =
+         |    doesNotExist.pull.peek1@@.void.stream.compile.last.flatMap(_.getOrElse(onEmpty))
+         |}
+         |""".stripMargin,
+    items => !items.map(_.getLabel()).exists(_.startsWith("peek1"))
+  )
+
+  // The cursor sits later in the chain, so the qualifier to recover is itself
+  // a longer expression that needs several implicit conversions
+  // (`Stream.InvariantOps` for `.pull`, cats' functor syntax for `.void`).
+  checkItems(
+    "topull-member-deeper-in-chain",
+    preamble +
+      """|  def deeper[F[_]: MonadThrow, A, B](stream: Stream[F, A])(onEmpty: F[B])(implicit SC: fs2.Compiler[F, F]): F[B] =
+         |    stream.pull.peek1.void.stream@@.compile.last.flatMap(_.getOrElse(onEmpty))
+         |}
+         |""".stripMargin,
+    items => items.map(_.getLabel()).exists(_.startsWith("stream"))
+  )
+
+  // The recovery temporarily grafts the re-typechecked qualifier type onto
+  // the cached typechecked tree and must restore it once the request is done.
+  // Re-running the same completion on the warm compiler reuses that cached
+  // tree (same source content, no restart), so a broken restore would corrupt
+  // the second request.
+  test("topull-member-recovery-is-repeatable") {
+    val code = preamble +
+      """|  def repeated[F[_]: MonadThrow, A, B](stream: Stream[F, A])(onEmpty: F[B])(implicit SC: fs2.Compiler[F, F]): F[B] =
+         |    stream.pull.peek1@@.void.stream.compile.last.flatMap(_.getOrElse(onEmpty))
+         |}
+         |""".stripMargin
+    def hasPeek1(restart: Boolean): Boolean =
+      getItems(code, restart = restart)
+        .map(_.getLabel())
+        .exists(_.startsWith("peek1"))
+    assert(hasPeek1(restart = true), "completions should recover `peek1`")
+    assert(
+      hasPeek1(restart = false),
+      "repeated completions on the warm compiler should recover `peek1` again"
+    )
+  }
+
+  // Applying a recovered completion mid-chain produces a usable edit, not just
+  // a label: completing `peek@@` to `peek1` leaves the rest of the chain intact.
+  checkEdit(
+    "topull-member-accepted-edit",
+    preamble +
+      """|  def accepted[F[_]: MonadThrow, A, B](stream: Stream[F, A])(onEmpty: F[B])(implicit SC: fs2.Compiler[F, F]): F[B] =
+         |    stream.pull.peek@@.void.stream.compile.last.flatMap(_.getOrElse(onEmpty))
+         |}
+         |""".stripMargin,
+    preamble +
+      """|  def accepted[F[_]: MonadThrow, A, B](stream: Stream[F, A])(onEmpty: F[B])(implicit SC: fs2.Compiler[F, F]): F[B] =
+         |    stream.pull.peek1.void.stream.compile.last.flatMap(_.getOrElse(onEmpty))
+         |}
+         |""".stripMargin,
+    assertSingleItem = false,
+    filter = _.startsWith("peek1")
+  )
+}

--- a/tests/cross/src/test/scala/tests/pc/Issue2634CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/Issue2634CompletionSuite.scala
@@ -44,6 +44,19 @@ class Issue2634CompletionSuite extends BaseCompletionSuite {
     items => items.map(_.getLabel()).exists(_.startsWith("peek1"))
   )
 
+  // The user is still mid-word, so the source itself contains an unresolved
+  // name (`pee`) and the qualifier is poisoned by error recovery regardless
+  // of the `_CURSOR_` instrumentation.
+  checkItems(
+    "topull-member-partial-prefix-mid-chain",
+    preamble +
+      """|  def partial[F[_]: MonadThrow, A, B](stream: Stream[F, A])(onEmpty: F[B])(implicit SC: fs2.Compiler[F, F]): F[B] =
+         |    stream.pull.pee@@.void.stream.compile.last.flatMap(_.getOrElse(onEmpty))
+         |}
+         |""".stripMargin,
+    items => items.map(_.getLabel()).exists(_.startsWith("peek1"))
+  )
+
   // Control from the issue's "Additional context": same chain without the
   // trailing .flatMap already worked in 2021 and must keep working.
   checkItems(


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/2634

### Problem

In Scala 2, member completions returned nothing at `peek1@@` in

```scala
stream.pull.peek1.void.stream.compile.last.flatMap(_.getOrElse(onEmpty))
```

while the same position completed fine without the trailing `.flatMap(...)`.
Still reproducible on 2.13.18 / 2.12.21 with fs2-core 3.9.0.

Tracing showed `completionsAt` classifies the position correctly
(`TypeMembers`, query `peek1`), but the typer's error recovery — triggered
by the `_CURSOR_` instrumentation breaking the enclosing chain — resets the
qualifier `stream.pull` to an error type in the cached typechecked tree, so
`typeMembers` collects zero members (scalac even has a TODO about this:
"guard with try/catch to deal with ill-typed qualifiers"). It was not the
`matchingResults` accessibility filter suspected back in 2021: the raw
member list is already empty.

### Fix

When the first pass yields no matching completions and the cursor sits in a
`Select` whose qualifier is error-typed:

1. take a pristine untyped copy of the qualifier from the parser (the
   typechecked one keeps its error symbol, which a re-typecheck would
   short-circuit on),
2. re-typecheck it with implicits explicitly enabled — the context stored
   for the position can come from the typer's failed silent attempt where
   implicits were disabled, and `.pull` itself needs the implicit
   `Stream.InvariantOps` conversion,
3. graft the recovered type onto the cached tree, re-run `completionsAt`,
   and keep the graft through `completionPosition`/`filterInteresting`
   (which re-derive the qualifier via `typedTreeAt`), restoring the
   original tree on every exit path.

The retry only fires when completions would otherwise be empty, so the
happy path is unaffected; recovered members still go through the compiler's
regular accessibility filtering and fuzzy matching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code completion recovery so completions reliably appear for ill-typed or partially-typed member chains by retrying with a recovered qualifier and preserving state after completion.

* **Tests**
  * Added a regression test suite covering mid-chain/type-recovery completion scenarios, repeatability on a warm compiler, and edit acceptance to guard against regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->