### PR TITLE
improvement: Improve BSP references when no MBT is available

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -2171,9 +2171,32 @@ class Compilers(
           shouldPruneSemanticdb = shouldPruneSemanticdb,
         ): VirtualFileParams
       }
-      pc.batchSemanticdbTextDocuments(params.asJava, timeout).asScala.map {
-        bytes =>
-          s.TextDocuments.parseFrom(bytes).documents
+      if (pc.supportsBatchSemanticdbTextDocuments()) {
+        pc.batchSemanticdbTextDocuments(params.asJava, timeout)
+          .asScala
+          .map(bytes => s.TextDocuments.parseFrom(bytes).documents)
+      } else {
+        val all = for {
+          param <- params
+          doc = pc.semanticdbTextDocument(param)
+        } yield doc.asScala
+        Future.sequence(all).map { docs =>
+          val targetRoot = buildTargets
+            .jvmTarget(
+              new BuildTargetIdentifier(pc.buildTargetId())
+            )
+            .flatMap(_.getTargetroot)
+            .getOrElse(workspace)
+
+          val parsedDocs = docs.map(d => s.TextDocument.parseFrom(d))
+          parsedDocs
+            .map { d =>
+              if (d.uri.startsWith("file:") || d.uri.startsWith("jar:"))
+                d
+              else
+                d.withUri(targetRoot.resolve(d.uri).toURI.toString())
+            }
+        }
       }
     }
     Future

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
@@ -48,6 +48,8 @@ case class JavaTarget(
 
   def targetroot: Option[AbsolutePath] = javac.targetroot
 
+  def getTargetroot: Option[AbsolutePath] = targetroot
+
   /**
    * If the build server supports lazy classpath resolution, we will
    * not get any classpath data eagerly and we should not

--- a/metals/src/main/scala/scala/meta/internal/metals/JvmTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JvmTarget.scala
@@ -27,6 +27,8 @@ trait JvmTarget {
 
   def classDirectory: String
 
+  def getTargetroot: Option[AbsolutePath]
+
   /**
    * This method collects jars from classpath defined in scalacOptions.
    *

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -591,6 +591,8 @@ abstract class MetalsLspService(
     mbtSymbolSearch,
     compilers,
     buffers,
+    semanticdbs,
+    buildTargets,
     time,
     languageClient,
     workDoneProgress,

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -160,6 +160,8 @@ case class ScalaTarget(
 
   def targetroot: AbsolutePath = scalac.targetroot(scalaVersion)
 
+  def getTargetroot: Option[AbsolutePath] = Some(targetroot)
+
   def scalaPlatform: ScalaPlatform = scalaInfo.getPlatform()
 
   private def jvmBuildTarget: Option[JvmBuildTarget] = Option(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtReferenceProvider.scala
@@ -17,6 +17,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.meta.infra.Event
 import scala.meta.infra.MonitoringClient
 import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Compilers
 import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -29,6 +30,7 @@ import scala.meta.internal.metals.WorkDoneProgress
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.noAdjustRange
 import scala.meta.internal.mtags.MD5
+import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.mtags.Symbol
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semanticdb.TypeRef
@@ -44,15 +46,14 @@ class MbtReferenceProvider(
     mbt: MbtWorkspaceSymbolProvider,
     compilers: Compilers,
     buffers: Buffers,
+    semanticdbs: () => Semanticdbs,
+    buildTargets: BuildTargets,
     time: Time,
     languageClient: MetalsLanguageClient,
     workDoneProgress: WorkDoneProgress,
     metrics: MonitoringClient,
 )(implicit ec: ExecutionContext) {
-  // Use fallback compiler to avoid starting many per-build-target presentation
-  // compilers. The fallback compiler includes all sources and dependencies
-  // from MBT.
-  private val cache = new TextDocumentCache(useFallbackCompiler = true)
+  private val cache = new TextDocumentCache()
 
   // When looking for usages of a method, we don't visit supermethods from these
   // types because it would result in a ton of noisy results. This list should
@@ -67,6 +68,22 @@ class MbtReferenceProvider(
   )
 
   private val groupSize = 100
+
+  private def isMbtMode: Boolean =
+    buildTargets.all.exists { target =>
+      buildTargets.buildServerOf(target.getId).exists(_.isMbt)
+    }
+
+  /**
+   * Groups candidate paths for indexing. In MBT mode, files are batched by a
+   * fixed size. In BSP mode, files are grouped by build target so each batch uses
+   * the correct per-target presentation compiler.
+   */
+  private def groupPathsForIndexing(
+      paths: Iterable[AbsolutePath]
+  ): Iterator[Seq[AbsolutePath]] =
+    if (isMbtMode) paths.iterator.grouped(groupSize)
+    else paths.toSeq.groupBy(buildTargets.inverseSources(_)).values.iterator
 
   /** Returns the length of the common path prefix between two paths. */
   private def commonPrefixLength(a: AbsolutePath, b: AbsolutePath): Int = {
@@ -254,7 +271,7 @@ class MbtReferenceProvider(
       var processedInRound = 0
       val totalInRound = candidates.size
       for {
-        paths <- candidates.iterator.grouped(groupSize)
+        paths <- groupPathsForIndexing(candidates)
         if !timer.hasElapsed(timeout)
         doc <- cache.index(paths).documents
       } {
@@ -452,7 +469,7 @@ class MbtReferenceProvider(
 
     // Process external candidates with progress reporting
     for {
-      candidates <- candidatesList.iterator.grouped(groupSize)
+      candidates <- groupPathsForIndexing(candidatesList)
       if !timer.hasElapsed(timeout)
     } {
       val docTimer = new Timer(time)
@@ -465,6 +482,7 @@ class MbtReferenceProvider(
       taskProgress.update(processedCandidates, totalCandidates)
     }
     if (timer.hasElapsed(timeout)) {
+      scribe.warn("references timed out, returning partial results")
       taskProgress.update(
         processedCandidates,
         totalCandidates,
@@ -516,7 +534,7 @@ class MbtReferenceProvider(
     }
     val isOverridenSymbol = overriddenSymbols.toSet
     (for {
-      paths <- candidates.iterator.grouped(groupSize)
+      paths <- groupPathsForIndexing(candidates)
       if !timer.hasElapsed(timeout)
       doc <- cache.index(paths).documents
       info <- doc.symbols.iterator
@@ -535,8 +553,9 @@ class MbtReferenceProvider(
   // When useFallbackCompiler is true, all files are indexed using the fallback
   // compiler instead of per-build-target compilers. This avoids starting many
   // presentation compilers when MBT is available and provides all sources and
-  // dependencies through the fallback compiler.
-  private class TextDocumentCache(useFallbackCompiler: Boolean) {
+  // dependencies through the fallback compiler. In BSP mode, SemanticDBs are
+  // tried first and per-target presentation compilers are used as a fallback.
+  private class TextDocumentCache {
     private val cache = TrieMap.empty[AbsolutePath, s.TextDocument]
     def indexSingle(path: AbsolutePath): s.TextDocument = {
       index(Seq(path)).documents.headOption.getOrElse {
@@ -546,9 +565,13 @@ class MbtReferenceProvider(
     }
     def index(paths: Seq[AbsolutePath]): s.TextDocuments = {
       val docs = Buffer.empty[s.TextDocument]
-      val toIndex = paths.filter { path =>
+      val pathsWithMd5 = paths.map { path =>
         val input = path.toInputFromBuffers(buffers)
         val md5 = MD5.compute(input.text)
+        path -> md5
+      }.toMap
+
+      val toIndex = pathsWithMd5.filter { case (path, md5) =>
         cache.get(path) match {
           case Some(doc) if doc.md5 == md5 =>
             docs += doc
@@ -560,39 +583,58 @@ class MbtReferenceProvider(
       if (toIndex.isEmpty) {
         s.TextDocuments(documents = docs.toSeq)
       } else {
-        def fetchDocs(maxRetries: Int): Seq[s.TextDocument] = {
-          try {
-            Await
-              .result(
-                compilers.batchSemanticdbTextDocuments(
-                  toIndex,
-                  EmptyCancelToken,
-                  // intentionally smaller than the default PC timeout of 20s
-                  Duration.ofSeconds(15),
-                  useFallbackCompiler = useFallbackCompiler,
-                ),
-                timeout,
-              )
-              .documents
-          } catch {
-            case _: CancellationException if maxRetries > 0 =>
-              fetchDocs(maxRetries - 1)
-            case e @ (_: CancellationException | _: TimeoutException) =>
-              scribe.warn(
-                s"references: indexing ${toIndex.size} documents failed.",
-                e,
-              )
-              throw e
+        val needCompiler = Buffer.empty[AbsolutePath]
+        for ((path, md5) <- toIndex) {
+          semanticdbs().textDocument(path).toOption match {
+            case Some(doc) if doc.md5 == md5 =>
+              // basic semanticdb uses relative uris
+              val docAdjusted = doc.withUri(path.toURI.toString)
+              docs += docAdjusted
+              cache.put(path, docAdjusted)
+            case _ =>
+              needCompiler += path
           }
         }
-        val result = fetchDocs(maxRetries = 3)
-        result.foreach { doc =>
-          doc.uri.toAbsolutePathSafe.foreach { path =>
-            cache.put(path, doc)
+        if (needCompiler.isEmpty) {
+          s.TextDocuments(documents = docs.toSeq)
+        } else {
+          def fetchDocs(maxRetries: Int): Seq[s.TextDocument] = {
+            try {
+              Await
+                .result(
+                  compilers.batchSemanticdbTextDocuments(
+                    needCompiler.toSeq,
+                    EmptyCancelToken,
+                    // intentionally smaller than the default PC timeout of 20s
+                    Duration.ofSeconds(15),
+                    useFallbackCompiler = isMbtMode,
+                  ),
+                  timeout,
+                )
+                .documents
+            } catch {
+              case _: CancellationException if maxRetries > 0 =>
+                fetchDocs(maxRetries - 1)
+              case e @ (_: CancellationException | _: TimeoutException) =>
+                scribe.warn(
+                  s"references: indexing ${needCompiler.size} documents failed.",
+                  e,
+                )
+                throw e
+            }
           }
+          val result = fetchDocs(maxRetries = 3)
+          result.foreach { doc =>
+            doc.uri.toAbsolutePathSafe match {
+              case Some(path) =>
+                cache.put(path, doc)
+              case None =>
+                scribe.warn(s"references: no path found for ${doc.uri}")
+            }
+          }
+          docs ++= result
+          s.TextDocuments(documents = docs.toSeq)
         }
-        docs ++= result
-        s.TextDocuments(documents = docs.toSeq)
       }
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -420,7 +420,7 @@ class MbtWorkspaceSymbolProvider(
         file,
         mtags(),
         buffers,
-        dialects.Scala213,
+        dialects.Scala3,
         enableProtoJavaPackage = enableProtoJavaPackage,
       )
     putDocument(file, mdoc, updateDocumentKeys = updateDocumentKeys)

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -218,6 +218,10 @@ public abstract class PresentationCompiler {
     return CompletableFuture.completedFuture(new byte[0]);
   }
 
+  public boolean supportsBatchSemanticdbTextDocuments() {
+    return false;
+  }
+
   /**
    * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for
    * the given source.

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -691,6 +691,7 @@ case class ScalaPresentationCompiler(
       processBatchParallel(params, timeout)
     }
   }
+  override def supportsBatchSemanticdbTextDocuments(): Boolean = true
 
   /**
    * Process a sequence of files with the given provider, respecting the timeout.

--- a/tests/unit/src/test/scala/tests/mbt/MbtReferenceSpec.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtReferenceSpec.scala
@@ -1,6 +1,60 @@
 package tests.mbt
 
-class MbtReferenceSuite extends BaseMbtReferenceSuite("mbt-reference") {
+import scala.meta.internal.metals.AutoImportBuildKind
+import scala.meta.internal.metals.InitializationOptions
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.mbt.MbtBuildServer
+
+import tests.BuildInfo
+import tests.TestingServer
+
+class MbtReferenceSuite extends MbtReferenceSpec {
+
+  override def withMbt: Boolean = true
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(
+      fallbackScalaVersion = Some(BuildInfo.scalaVersion),
+      preferredBuildServer = Some(MbtBuildServer.name),
+      automaticImportBuild = AutoImportBuildKind.All,
+    )
+}
+
+class BspReferenceSuite extends MbtReferenceSpec {
+
+  override def withMbt: Boolean = false
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(TestingServer.TestDefault)
+
+}
+
+abstract class MbtReferenceSpec extends BaseMbtReferenceSuite("mbt-reference") {
+
+  def withMbt: Boolean
+
+  def baseInit: String = if (withMbt) {
+    """|/.metals/mbt.json
+       |{}
+       |""".stripMargin
+  } else {
+    """|/metals.json
+       |{ "a": {} }
+       |""".stripMargin
+  }
+
+  def twoProjectsInit: String = if (withMbt) {
+    """|/.metals/mbt.json
+       |{}
+       |""".stripMargin
+  } else {
+    """|/metals.json
+       |{
+       |  "a": {},
+       |  "b": {"dependsOn": ["a"]}
+       |}
+       |""".stripMargin
+  }
 
   testLSP("field") {
     cleanWorkspace()
@@ -9,11 +63,7 @@ class MbtReferenceSuite extends BaseMbtReferenceSuite("mbt-reference") {
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {},
-           |  "b": {"dependsOn": ["a"]}
-           |}
+           |$twoProjectsInit
            |/$a
            |package a;
            |public class Upstream {
@@ -67,11 +117,7 @@ class MbtReferenceSuite extends BaseMbtReferenceSuite("mbt-reference") {
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {},
-           |  "b": {"dependsOn": ["a"]}
-           |}
+           |$twoProjectsInit
            |/$a
            |package a;
            |public class Upstream {
@@ -97,13 +143,19 @@ class MbtReferenceSuite extends BaseMbtReferenceSuite("mbt-reference") {
       _ <- server.assertReferencesSubquery(
         a,
         "hel@@lo",
-        """|a/src/main/scala/a/Upstream.java:3:24: reference
-           |  public static String hello() { return "Hello, World!"; }
-           |                       ^^^^^
-           |b/src/main/scala/b/B.java:5:35: reference
-           |    System.out.println(a.Upstream.hello());
-           |                                  ^^^^^
-           |""".stripMargin,
+        if (withMbt)
+          """|a/src/main/scala/a/Upstream.java:3:24: reference
+             |  public static String hello() { return "Hello, World!"; }
+             |                       ^^^^^
+             |b/src/main/scala/b/B.java:5:35: reference
+             |    System.out.println(a.Upstream.hello());
+             |                                  ^^^^^
+             |""".stripMargin
+        else // we don't include targets outside of the source set with BSP
+          """|a/src/main/scala/a/Upstream.java:3:24: reference
+             |  public static String hello() { return "Hello, World!"; }
+             |                       ^^^^^
+             |""".stripMargin,
       )
       // Asserts we find references that are not qualified
       _ <- server.assertReferencesSubquery(
@@ -127,10 +179,7 @@ class MbtReferenceSuite extends BaseMbtReferenceSuite("mbt-reference") {
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a;
            |public class Upstream {
@@ -206,10 +255,7 @@ class MbtReferenceSuite extends BaseMbtReferenceSuite("mbt-reference") {
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a;
            |public enum Fruit {
@@ -268,10 +314,7 @@ class MbtReferenceSuite extends BaseMbtReferenceSuite("mbt-reference") {
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a;
            |public record Point(int xx, int y) {
@@ -329,10 +372,7 @@ class MbtReferenceSuite extends BaseMbtReferenceSuite("mbt-reference") {
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a;
            |public class Upstream {
@@ -390,10 +430,7 @@ class MbtReferenceSuite extends BaseMbtReferenceSuite("mbt-reference") {
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a;
            |public abstract class Fruit {
@@ -480,10 +517,7 @@ class MbtReferenceSuite extends BaseMbtReferenceSuite("mbt-reference") {
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a;
            |public class Animal {

--- a/tests/unit/src/test/scala/tests/mbt/ScalaReferenceSpec.scala
+++ b/tests/unit/src/test/scala/tests/mbt/ScalaReferenceSpec.scala
@@ -1,7 +1,64 @@
 package tests.mbt
 
+import scala.meta.internal.metals.AutoImportBuildKind
+import scala.meta.internal.metals.InitializationOptions
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.mbt.MbtBuildServer
+
+import tests.BuildInfo
+import tests.TestingServer
+
 class MbtScalaReferenceSuite
-    extends BaseMbtReferenceSuite("mbt-scala-reference") {
+    extends BaseMbtReferenceSuite("mbt-scala-reference")
+    with ScalaReferenceSpec {
+
+  override def withMbt: Boolean = true
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(
+      fallbackScalaVersion = Some(BuildInfo.scalaVersion),
+      preferredBuildServer = Some(MbtBuildServer.name),
+      automaticImportBuild = AutoImportBuildKind.All,
+    )
+}
+
+class BspScalaReferenceSuite
+    extends BaseMbtReferenceSuite("scala-reference")
+    with ScalaReferenceSpec {
+
+  override def withMbt: Boolean = false
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(TestingServer.TestDefault)
+
+}
+
+trait ScalaReferenceSpec { this: BaseMbtReferenceSuite =>
+
+  def withMbt: Boolean
+
+  def baseInit: String = if (withMbt) {
+    """|/.metals/mbt.json
+       |{}
+       |""".stripMargin
+  } else {
+    """|/metals.json
+       |{ "a": {} }
+       |""".stripMargin
+  }
+
+  def twoProjectsInit: String = if (withMbt) {
+    """|/.metals/mbt.json
+       |{}
+       |""".stripMargin
+  } else {
+    """|/metals.json
+       |{
+       |  "a": {},
+       |  "b": {"dependsOn": ["a"]}
+       |}
+       |""".stripMargin
+  }
 
   testLSP("field") {
     cleanWorkspace()
@@ -10,11 +67,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {},
-           |  "b": {"dependsOn": ["a"]}
-           |}
+           |$twoProjectsInit
            |/$a
            |package a
            |object Upstream {
@@ -67,11 +120,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {},
-           |  "b": {"dependsOn": ["a"]}
-           |}
+           |$twoProjectsInit
            |/$a
            |package a
            |object Upstream {
@@ -130,10 +179,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a
            |class Upstream(i: Int) {
@@ -160,22 +206,22 @@ class MbtScalaReferenceSuite
       _ <- server.assertReferencesSubquery(
         a,
         "class Upstr@@eam",
-        """|a/src/main/scala/a/Downstream.scala:4:12: reference
-           |    val a: Upstream = new Upstream(1)
-           |           ^^^^^^^^
-           |a/src/main/scala/a/Downstream.scala:4:27: reference
-           |    val a: Upstream = new Upstream(1)
-           |                          ^^^^^^^^
-           |a/src/main/scala/a/Downstream.scala:5:9: reference
-           |    new Upstream(1, 2)
-           |        ^^^^^^^^
-           |a/src/main/scala/a/Downstream.scala:6:9: reference
-           |    new Upstream.Upstream2().magic()
-           |        ^^^^^^^^
-           |a/src/main/scala/a/Upstream.scala:2:7: reference
-           |class Upstream(i: Int) {
-           |      ^^^^^^^^
-           |""".stripMargin,
+        s"""|a/src/main/scala/a/Downstream.scala:4:12: reference
+            |    val a: Upstream = new Upstream(1)
+            |           ^^^^^^^^
+            |a/src/main/scala/a/Downstream.scala:4:27: reference
+            |    val a: Upstream = new Upstream(1)
+            |                          ^^^^^^^^
+            |a/src/main/scala/a/Downstream.scala:5:9: reference
+            |    new Upstream(1, 2)
+            |        ^^^^^^^^
+            |a/src/main/scala/a/Downstream.scala:6:9: reference
+            |    new Upstream.Upstream2().magic()
+            |        ^^^^^^^^
+            |a/src/main/scala/a/Upstream.scala:2:7: reference
+            |class Upstream(i: Int) {
+            |      ^^^^^^^^
+            |""".stripMargin,
       )
       _ <- server.assertReferencesSubquery(
         a,
@@ -198,10 +244,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a
            |case class Point(xx: Int, y: Int) {
@@ -256,10 +299,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a
            |case class Point(x: Int, y: Int)
@@ -298,10 +338,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a
            |sealed trait Fruit
@@ -354,10 +391,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a
            |class Upstream {
@@ -404,10 +438,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a
            |abstract class Fruit {
@@ -484,14 +515,22 @@ class MbtScalaReferenceSuite
     val a = "a/src/main/scala/a/Animal.scala"
     val b = "a/src/main/scala/a/Mammal.scala"
     val c = "b/src/main/scala/b/Animal.scala"
+    val init = if (withMbt) {
+      """|/.metals/mbt.json
+         |{}
+         |""".stripMargin
+    } else {
+      """|/metals.json
+         |{
+         |  "a": {},
+         |  "b": {"dependsOn": ["a"]}
+         |}
+         |""".stripMargin
+    }
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {},
-           |  "b": {"dependsOn": ["a"]}
-           |}
+           |$init
            |/$a
            |package a
            |trait Animal {
@@ -547,14 +586,22 @@ class MbtScalaReferenceSuite
     cleanWorkspace()
     val a = "a/src/main/scala/a/Utils.scala"
     val b = "b/src/main/scala/b/B.scala"
+    val init = if (withMbt) {
+      """|/.metals/mbt.json
+         |{}
+         |""".stripMargin
+    } else {
+      """|/metals.json
+         |{
+         |  "a": {},
+         |  "b": {"dependsOn": ["a"]}
+         |}
+         |""".stripMargin
+    }
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {},
-           |  "b": {"dependsOn": ["a"]}
-           |}
+           |$init
            |/$a
            |package a
            |object Utils {
@@ -600,10 +647,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a
            |object Extensions {
@@ -643,10 +687,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$a
            |package a
            |object Types {
@@ -680,14 +721,22 @@ class MbtScalaReferenceSuite
     cleanWorkspace()
     val a = "a/src/main/scala/a/Utils.scala"
     val b = "b/src/main/scala/b/B.scala"
+    val init = if (withMbt) {
+      """|/.metals/mbt.json
+         |{}
+         |""".stripMargin
+    } else {
+      """|/metals.json
+         |{
+         |  "a": {},
+         |  "b": {"dependsOn": ["a"]}
+         |}
+         |""".stripMargin
+    }
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {},
-           |  "b": {"dependsOn": ["a"]}
-           |}
+           |$init
            |/$a
            |package a
            |object Utils {
@@ -747,10 +796,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$javaFile
            |package a;
            |public class JavaUtils {
@@ -805,10 +851,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$scalaFile
            |package a
            |object ScalaUtils {
@@ -828,22 +871,42 @@ class MbtScalaReferenceSuite
       _ <- server.didOpenAndFocus(scalaFile)
       // references to Scala method from Java
       _ <- server
-        .assertReferencesSubquery( // TODO: test not working correctly on main-v2,
+        .assertReferencesSubquery(
           scalaFile,
-          "def hel@@lo()",
-          """|a/src/main/scala/a/ScalaUtils.scala:3:7: reference
-             |  def hello(): String = "Hello from Scala"
-             |      ^^^^^
-             |""".stripMargin,
+          "def hel@@lo()", {
+            if (withMbt) // bug with pure mbt implementation
+              """|a/src/main/scala/a/ScalaUtils.scala:3:7: reference
+                 |  def hello(): String = "Hello from Scala"
+                 |      ^^^^^
+                 |""".stripMargin
+            else
+              """|a/src/main/java/a/JavaUser.java:4:35: reference
+                 |    System.out.println(ScalaUtils.hello());
+                 |                                  ^^^^^
+                 |a/src/main/scala/a/ScalaUtils.scala:3:7: reference
+                 |  def hello(): String = "Hello from Scala"
+                 |      ^^^^^
+                 |""".stripMargin
+
+          },
         )
       // references to Scala val from Java
       _ <- server.assertReferencesSubquery(
         scalaFile,
         "val cou@@nt",
-        """|a/src/main/scala/a/ScalaUtils.scala:4:7: reference
-           |  val count: Int = 10
-           |      ^^^^^
-           |""".stripMargin,
+        if (withMbt)
+          """|a/src/main/scala/a/ScalaUtils.scala:4:7: reference
+             |  val count: Int = 10
+             |      ^^^^^
+             |""".stripMargin
+        else
+          """|a/src/main/java/a/JavaUser.java:5:35: reference
+             |    System.out.println(ScalaUtils.count());
+             |                                  ^^^^^
+             |a/src/main/scala/a/ScalaUtils.scala:4:7: reference
+             |  val count: Int = 10
+             |      ^^^^^
+             |""".stripMargin,
       )
     } yield ()
   }
@@ -856,10 +919,7 @@ class MbtScalaReferenceSuite
     for {
       _ <- initialize(
         s"""
-           |/metals.json
-           |{
-           |  "a": {}
-           |}
+           |$baseInit
            |/$scalaFile
            |package a
            |object ScalaUtils {


### PR DESCRIPTION
This includes a couple of connected improvements:
- with BSP we wouldn't use semanticdb even if it was available, now we use it if MD5 hashes match
- for Scala 3 the batchedSemanticdb method was unimplemented, we use the normal semanticdb method from the presentation compiler
- added tests that use both BSP and plain MBT
- change grouping for BSP to do it first by target in order to limit the amount of presentation compilers run
- 
Fixes https://github.com/scalameta/metals/issues/8474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced reference finding and implementation detection with improved fallback support and cross-project reference detection.
  * Improved SemanticDB caching mechanisms with validation and per-path verification.
  * Better build tool integration with improved support detection for batch operations.
  * Updated Scala dialect support for workspace symbol indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->