### PR TITLE
improvement: Add a command to discover all test suites

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -419,6 +419,7 @@ abstract class MetalsLspService(
     languageClient,
     getVisibleName,
     folder,
+    workDoneProgress,
   )
 
   protected lazy val codeLensProvider: CodeLensProvider = {
@@ -1757,6 +1758,9 @@ abstract class MetalsLspService(
 
   def discoverTestSuites(uri: Option[String]): Future[List[BuildTargetUpdate]] =
     testProvider.discoverTests(uri.map(_.toAbsolutePath))
+
+  def discoverAllTestSuites(): Future[List[BuildTargetUpdate]] =
+    testProvider.discoverAllTestSuites()
 
   def runScalafix(uri: String): Future[ApplyWorkspaceEditResponse] =
     scalafixProvider

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -178,7 +178,9 @@ object ServerCommands {
 
   /** If uri is null discover all test suites, otherwise discover testcases in file */
   final case class DiscoverTestParams(
-      @Nullable uri: String = null
+      @Nullable uri: String = null,
+      // Force the discovery of all test suites when in MBT mode
+      @Nullable forceAll: Boolean = false,
   )
   val DiscoverTestSuites = new ParametrizedCommand[DiscoverTestParams](
     "discover-tests",

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1151,6 +1151,11 @@ class WorkspaceLspService(
           .getOrElse(fallbackService)
           .decodeFile(uri)
           .asJavaObject
+      case ServerCommands.DiscoverTestSuites(params) if params.forceAll =>
+        Future
+          .sequence(folderServices.map(_.discoverAllTestSuites()))
+          .map(_.flatten.asJava)
+          .asJavaObject
       case ServerCommands.DiscoverTestSuites(params) =>
         Option(params.uri) match {
           case None =>

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -402,7 +402,11 @@ final class BuildTargetClasses(
 
     val futures = doc.symbols.flatMap { symbolInfo =>
       processTestAnnotations(symbolInfo, testClasses)
-      processTestClassHierarchy(symbolInfo, doc, path, testClasses)
+      // Only Scala files depend on inheritance for test frameworks
+      if (path.isJava)
+        None
+      else
+        processTestClassHierarchy(symbolInfo, doc, path, testClasses)
     }
 
     Future.sequence(futures).map(_ => testClasses.toList)

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -19,6 +19,7 @@ import scala.meta.internal.metals.ScalaTestSuites
 import scala.meta.internal.metals.SemanticdbFeatureProvider
 import scala.meta.internal.metals.TestUserInterfaceKind
 import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.WorkDoneProgress
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.codelenses.CodeLens
 import scala.meta.internal.metals.debug.BuildTargetClasses
@@ -57,6 +58,7 @@ final class TestSuitesProvider(
     client: MetalsLanguageClient,
     folderName: String,
     folderUri: AbsolutePath,
+    workDoneProgress: WorkDoneProgress,
 )(implicit ec: ExecutionContext)
     extends SemanticdbFeatureProvider
     with CodeLens {
@@ -234,27 +236,31 @@ final class TestSuitesProvider(
    *
    * @return Future that completes when discovery is done, containing the updated test suites
    */
-  def discoverAllTestSuites(): Future[List[BuildTargetUpdate]] = {
-    val targetIds = buildTargets.allBuildTargetIds.toList
-      .filter { id =>
-        buildTargets
-          .scalaTarget(id)
-          .forall(_.scalaInfo.getPlatform == ScalaPlatform.JVM)
-      }
-      .flatMap(buildTargets.info)
-      .filterNot(_.isSbtBuild)
-      .map(_.getId)
+  def discoverAllTestSuites(): Future[List[BuildTargetUpdate]] =
+    workDoneProgress.trackProgressFuture(
+      "Discovering test suites",
+      { progress =>
+        val targetIds = buildTargets.allBuildTargetIds.toList
+          .filter { id =>
+            buildTargets
+              .scalaTarget(id)
+              .forall(_.scalaInfo.getPlatform == ScalaPlatform.JVM)
+          }
+          .flatMap(buildTargets.info)
+          .filterNot(_.isSbtBuild)
+          .map(_.getId)
 
-    // First confirm all candidate test classes
-    buildTargetClasses
-      .confirmMbtTestClassCandidatesForTargets(targetIds)
-      .flatMap { _ =>
-        // Then refresh the test suites
-        refreshTestSuites(()).flatMap { _ =>
-          discoverTests(None)
-        }
-      }
-  }
+        // First confirm all candidate test classes
+        buildTargetClasses
+          .confirmMbtTestClassCandidatesForTargets(targetIds)
+          .flatMap { _ =>
+            // Then refresh the test suites
+            refreshTestSuites(()).flatMap { _ =>
+              discoverTests(None)
+            }
+          }
+      },
+    )
 
   /**
    * For test suites located in a given path,


### PR DESCRIPTION
This will try to resolve all test file candidates that we found intially.

This is only needed if user opens up the test explorer.