### PR TITLE
feat: add support for Codex CLI MCP config

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpConfig.scala
@@ -31,8 +31,20 @@ object McpConfig {
     val serverName = client.projectName(projectName)
 
     // Read existing config if it exists
-    val config = if (configFile.exists) configFile.readText else "{ }"
-    val newConfig = createConfig(config, port, serverName, client)
+    val config = if (configFile.exists) configFile.readText else ""
+    val newConfig = client.configFormat match {
+      case ClientConfigFormat.Json =>
+        val configInput = if (config.trim.isEmpty) "{ }" else config
+        createConfig(configInput, port, serverName, client)
+
+      case ClientConfigFormat.Toml =>
+        McpTomlConfig.upsertServer(
+          config,
+          client.serverField,
+          serverName,
+          mcpUrl(port),
+        )
+    }
     configFile.writeText(newConfig)
     client.extraExtensions
       .collect { case (id, ext) if activeClientExtensionIds(id) => ext }
@@ -75,19 +87,35 @@ object McpConfig {
         projectPath.resolve(s"${client.settingsPath}$name")
       }
       .filter(_.exists)
+
     configFiles.foreach { configFile =>
       val configContent = configFile.readText
-      val updatedConfig = removeMetalsEntry(configContent, projectName, client)
 
-      updatedConfig match {
-        case Failure(exception) =>
-          scribe.error(s"Error removing metals entry: $exception")
-        case Success(value) =>
-          if (isConfigEmpty(value, client)) {
-            configFile.delete()
-          } else {
-            configFile.writeText(gson.toJson(value))
+      client.configFormat match {
+        case ClientConfigFormat.Json =>
+          val updatedConfig =
+            removeMetalsEntry(configContent, projectName, client)
+
+          updatedConfig match {
+            case Failure(exception) =>
+              scribe.error(s"Error removing metals entry: $exception")
+            case Success(value) =>
+              if (isConfigEmpty(value, client)) {
+                configFile.delete()
+              } else {
+                configFile.writeText(gson.toJson(value))
+              }
           }
+
+        case ClientConfigFormat.Toml =>
+          val updatedConfig = McpTomlConfig.removeServer(
+            configContent,
+            client.serverField,
+            client.projectName(projectName),
+          )
+
+          if (updatedConfig.trim.isEmpty) configFile.delete()
+          else configFile.writeText(updatedConfig)
       }
     }
   }
@@ -103,7 +131,7 @@ object McpConfig {
       port: Int,
   ): Unit = {
     val (configFile, _) = resolveConfigFile(projectPath, client)
-    if (configFile.exists) {
+    if (configFile.exists && client.configFormat == ClientConfigFormat.Json) {
       val configContent = configFile.readText
       rewriteOldEndpoint(configContent, projectName, client, port) match {
         case Some(newContent) =>
@@ -203,7 +231,7 @@ object McpConfig {
     val serverConfig = new JsonObject()
     serverConfig.addProperty(
       "url",
-      s"http://localhost:$port${MetalsMcpServer.mcpEndpoint}",
+      mcpUrl(port),
     )
     editor.additionalProperties.foreach { case (key, value) =>
       value match {
@@ -232,23 +260,43 @@ object McpConfig {
       projectName: String,
       editor: Client = CursorEditor,
   ): Option[Int] = {
-    for {
-      config <- Try(
-        JsonParser.parseString(configInput).getAsJsonObject()
-      ).toOption
-      mcpServers <- config.getObjectOption(editor.serverField)
-      serverConfig <- mcpServers.getObjectOption(
-        editor.serverEntry.getOrElse(s"$projectName-metals")
-      )
-      url <- serverConfig.getStringOption("url")
-      // Handle both new /mcp and old /sse endpoints
-      normalizedUrl = url
-        .stripSuffix(MetalsMcpServer.mcpEndpoint)
-        .stripSuffix(oldEndpoint)
-      port <- Try(normalizedUrl.split(":").last.toInt).toOption
-    } yield port
+    editor.configFormat match {
+      case ClientConfigFormat.Json =>
+        for {
+          config <- Try(
+            JsonParser.parseString(configInput).getAsJsonObject()
+          ).toOption
+          mcpServers <- config.getObjectOption(editor.serverField)
+          serverConfig <- mcpServers.getObjectOption(
+            editor.projectName(projectName)
+          )
+          url <- serverConfig.getStringOption("url")
+          // Handle both new /mcp and old /sse endpoints
+          normalizedUrl = url
+            .stripSuffix(MetalsMcpServer.mcpEndpoint)
+            .stripSuffix(oldEndpoint)
+          port <- Try(normalizedUrl.split(":").last.toInt).toOption
+        } yield port
+
+      case ClientConfigFormat.Toml =>
+        McpTomlConfig.readPort(
+          input = configInput,
+          tableName = editor.serverField,
+          serverName = editor.projectName(projectName),
+        )
+    }
   }
 
+  private def mcpUrl(port: Int): String =
+    s"http://localhost:$port${MetalsMcpServer.mcpEndpoint}"
+
+}
+
+sealed trait ClientConfigFormat
+
+object ClientConfigFormat {
+  case object Json extends ClientConfigFormat
+  case object Toml extends ClientConfigFormat
 }
 
 case class Client(
@@ -261,6 +309,7 @@ case class Client(
     shouldCleanUpServerEntry: Boolean = false,
     extraExtensions: Map[String, Client] = Map.empty,
     rootProperties: List[(String, String)] = Nil,
+    configFormat: ClientConfigFormat = ClientConfigFormat.Json,
 ) {
   def projectName(project: String): String =
     serverEntry.getOrElse(s"$project-metals")
@@ -317,6 +366,17 @@ object Claude
       fileNames = List(".mcp.json"),
     )
 
+object Codex
+    extends Client(
+      names = List("codex", "Codex", "codex-cli"),
+      serverField = "mcp_servers",
+      additionalProperties = Nil,
+      serverEntry = Some("metals"),
+      settingsPath = ".codex/",
+      fileNames = List("config.toml"),
+      configFormat = ClientConfigFormat.Toml,
+    )
+
 object OpenCode
     extends Client(
       names = List("opencode", "OpenCode"),
@@ -341,5 +401,5 @@ object NoClient
 
 object Client {
   val allClients: List[Client] =
-    List(VSCodeEditor, KiloCodeEditor, CursorEditor, Claude, OpenCode)
+    List(VSCodeEditor, KiloCodeEditor, CursorEditor, Claude, Codex, OpenCode)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTomlConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTomlConfig.scala
@@ -1,0 +1,93 @@
+package scala.meta.internal.metals.mcp
+
+import java.net.URI
+
+import scala.util.Try
+
+object McpTomlConfig {
+  private val newline = System.lineSeparator()
+
+  def upsertServer(
+      input: String,
+      tableName: String,
+      serverName: String,
+      url: String,
+  ): String = {
+    val section = List(s"[$tableName.$serverName]", s"""url = "$url"""")
+    val lines = input.linesIterator.toList
+
+    val updated = sectionBounds(lines, tableName, serverName) match {
+      case Some((start, end)) =>
+        val suffix = lines.drop(end)
+        val separator = if (suffix.nonEmpty) List("") else Nil
+        (lines.take(start) ++ section ++ separator ++ suffix)
+      case None if lines.isEmpty => section
+      case None =>
+        val separator = if (lines.last.trim.isEmpty) Nil else List("")
+        lines ++ separator ++ section
+    }
+
+    updated.mkString(newline)
+  }
+
+  def removeServer(
+      input: String,
+      tableName: String,
+      serverName: String,
+  ): String = {
+    val lines = input.linesIterator.toList
+
+    val updated =
+      sectionBounds(lines, tableName, serverName) match {
+        case None => lines
+        case Some((start, end)) => lines.take(start) ++ lines.drop(end)
+      }
+
+    updated.mkString(newline)
+  }
+
+  def readPort(
+      input: String,
+      tableName: String,
+      serverName: String,
+  ): Option[Int] = {
+    val lines = input.linesIterator.toList
+    sectionBounds(lines, tableName, serverName).flatMap { case (start, end) =>
+      lines
+        .slice(start, end)
+        .collectFirst {
+          case line if line.takeWhile(_ != '=').trim == "url" =>
+            line.dropWhile(_ != '=').drop(1).trim
+        }
+        .map(stripQuotes)
+        .flatMap(url => Try(new URI(url).getPort).toOption)
+        .filter(_ > 0)
+    }
+  }
+
+  private def stripQuotes(value: String): String =
+    value.stripPrefix("\"").stripSuffix("\"")
+
+  private def sectionBounds(
+      lines: List[String],
+      tableName: String,
+      serverName: String,
+  ): Option[(Int, Int)] = {
+    val header = s"[$tableName.$serverName]"
+    val start = lines.indexWhere(_.trim == header)
+
+    if (start < 0) None
+    else {
+      val end = lines.zipWithIndex
+        .collectFirst {
+          case (line, index)
+              if index > start && line.trim
+                .startsWith("[") && line.trim.endsWith("]") =>
+            index
+        }
+        .getOrElse(lines.length)
+
+      Some((start, end))
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTomlConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTomlConfig.scala
@@ -65,8 +65,14 @@ object McpTomlConfig {
     }
   }
 
-  private def stripQuotes(value: String): String =
-    value.stripPrefix("\"").stripSuffix("\"")
+  private def stripQuotes(value: String): String = {
+    val trimmed = value.trim
+    if (trimmed.startsWith("\"") && trimmed.endsWith("\""))
+      trimmed.stripPrefix("\"").stripSuffix("\"")
+    else if (trimmed.startsWith("'") && trimmed.endsWith("'"))
+      trimmed.stripPrefix("'").stripSuffix("'")
+    else trimmed
+  }
 
   private def sectionBounds(
       lines: List[String],

--- a/tests/unit/src/test/scala/tests/mcp/McpConfigSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpConfigSuite.scala
@@ -238,6 +238,15 @@ class McpConfigSuite extends BaseSuite {
       """[mcp_servers.metals]
         |url = "http://localhost:1234/mcp"""".stripMargin,
     )
+
+    assertEquals(
+      McpConfig.readPort(projectPath, projectName, Codex),
+      Some(port),
+    )
+
+    McpConfig.deleteConfig(projectPath, projectName, Codex)
+
+    assert(!configFile.exists)
   }
 
   test("opencode-generate-config-file") {

--- a/tests/unit/src/test/scala/tests/mcp/McpConfigSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpConfigSuite.scala
@@ -6,6 +6,7 @@ import java.nio.file.Files
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.mcp.Claude
 import scala.meta.internal.metals.mcp.Client
+import scala.meta.internal.metals.mcp.Codex
 import scala.meta.internal.metals.mcp.CursorEditor
 import scala.meta.internal.metals.mcp.McpConfig
 import scala.meta.internal.metals.mcp.OpenCode
@@ -207,6 +208,35 @@ class McpConfigSuite extends BaseSuite {
         |    }
         |  }
         |}""".stripMargin,
+    )
+  }
+
+  test("codex-generate-config-file") {
+    val workspace = Files.createTempDirectory("metals-mcp-test")
+    val projectPath = AbsolutePath(workspace)
+    val port = 1234
+    val projectName = "test-project"
+
+    McpConfig.writeConfig(
+      port,
+      projectName,
+      projectPath,
+      client = Codex,
+      activeClientExtensionIds = Set.empty,
+    )
+
+    val configFile = projectPath.resolve(".codex/config.toml")
+    assert(configFile.exists)
+
+    val content = new String(
+      Files.readAllBytes(configFile.toNIO),
+      StandardCharsets.UTF_8,
+    )
+
+    assertNoDiff(
+      content,
+      """[mcp_servers.metals]
+        |url = "http://localhost:1234/mcp"""".stripMargin,
     )
   }
 

--- a/tests/unit/src/test/scala/tests/mcp/McpTomlConfigSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpTomlConfigSuite.scala
@@ -93,4 +93,15 @@ class McpTomlConfigSuite extends BaseSuite {
     )
   }
 
+  test("read-port-single-quoted-url") {
+    val input =
+      """[mcp_servers.metals]
+        |url='http://localhost:8080/mcp'""".stripMargin
+
+    assertEquals(
+      McpTomlConfig.readPort(input, "mcp_servers", "metals"),
+      Some(8080),
+    )
+  }
+
 }

--- a/tests/unit/src/test/scala/tests/mcp/McpTomlConfigSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpTomlConfigSuite.scala
@@ -2,8 +2,8 @@ package tests.mcp
 
 import scala.meta.internal.metals.mcp.McpTomlConfig
 
-import tests.BaseSuite
 import munit.TestOptions
+import tests.BaseSuite
 
 class McpTomlConfigSuite extends BaseSuite {
   def checkUpsert(

--- a/tests/unit/src/test/scala/tests/mcp/McpTomlConfigSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpTomlConfigSuite.scala
@@ -1,0 +1,96 @@
+package tests.mcp
+
+import scala.meta.internal.metals.mcp.McpTomlConfig
+
+import tests.BaseSuite
+import munit.TestOptions
+
+class McpTomlConfigSuite extends BaseSuite {
+  def checkUpsert(
+      name: TestOptions,
+      inputConfig: String,
+      port: Int,
+      expected: String,
+  ): Unit = {
+    test(name) {
+      val obtained = McpTomlConfig.upsertServer(
+        input = inputConfig,
+        tableName = "mcp_servers",
+        serverName = "metals",
+        url = s"http://localhost:$port/mcp",
+      )
+
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  checkUpsert(
+    name = "upsert-server-new",
+    inputConfig = "",
+    port = 1234,
+    expected = """[mcp_servers.metals]
+                 |url = "http://localhost:1234/mcp"""".stripMargin,
+  )
+
+  checkUpsert(
+    name = "upsert-server-existing",
+    inputConfig = """model = "gpt-5"
+                    |
+                    |[mcp_servers.metals]
+                    |url = "http://localhost:1234/mcp"
+                    |
+                    |[mcp_servers.other]
+                    |url = "http://localhost:9999/mcp"""".stripMargin,
+    port = 5678,
+    expected = """model = "gpt-5"
+                 |
+                 |[mcp_servers.metals]
+                 |url = "http://localhost:5678/mcp"
+                 |
+                 |[mcp_servers.other]
+                 |url = "http://localhost:9999/mcp"""".stripMargin,
+  )
+
+  def checkRemove(
+      name: TestOptions,
+      inputConfig: String,
+      expected: String,
+  ): Unit = {
+    test(name) {
+      val obtained = McpTomlConfig.removeServer(
+        input = inputConfig,
+        tableName = "mcp_servers",
+        serverName = "metals",
+      )
+
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  checkRemove(
+    name = "remove-server",
+    inputConfig = """model = "gpt-5"
+                    |
+                    |[mcp_servers.metals]
+                    |url = "http://localhost:1234/mcp"
+                    |
+                    |[mcp_servers.other]
+                    |url = "http://localhost:9999/mcp"""".stripMargin,
+    expected = """model = "gpt-5"
+                 |
+                 |[mcp_servers.other]
+                 |url = "http://localhost:9999/mcp"""".stripMargin,
+  )
+
+  test("read-port") {
+    val input =
+      """[mcp_servers.metals]
+        |url="http://localhost:8080/mcp?key=value"""".stripMargin
+
+    assertEquals(
+      McpTomlConfig.readPort(input, "mcp_servers", "metals"),
+      Some(8080),
+    )
+  }
+
+}


### PR DESCRIPTION
  ## Summary

  Adds Codex CLI as an MCP client.

  Codex uses a project-local `.codex/config.toml`, so this adds small TOML config support
  for the MCP server section Metals needs to manage.

  This follows up on the earlier closed PR #8158, with a smaller TOML-only implementation
  and no extra parser dependency.

  ## Changes

  - add Codex to the MCP client list
  - write Codex MCP config to `.codex/config.toml`
  - support reading/removing the Codex MCP server entry
  - skip old `/sse` endpoint rewrite for TOML configs
  - add tests for TOML config handling and Codex config generation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing MCP server settings in TOML format.
  * Introduced the Codex MCP client, including automatic generation and cleanup of `config.toml`.
* **Bug Fixes**
  * Improved writing/removing of MCP server entries for both JSON and TOML.
  * Enhanced port detection, including correct URL normalization and consistent extraction for each format.
* **Tests**
  * Added unit tests covering TOML edits and Codex config generation/verification/cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->