### PR TITLE
fix: Resolve double-encoded jar URIs for JDK sources when debugging on Windows

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -198,6 +198,18 @@ trait MtagsEnrichments extends ScalametaCommonEnrichments {
             .create(URIEncoderDecoder.encode(value))
             .toAbsolutePath(followSymlink)
         catch {
+          // A double-encoded jar URI (e.g. "%2520" for the space in
+          // "Program Files", as produced by the debug adapter on some Windows
+          // JDKs, see #3266) has every '%' escaped as "%25". Undo exactly that
+          // one layer ("%2520" -> "%20") so the jar file system receives a
+          // normally-encoded URI. We must not URL-decode the whole string here:
+          // that uses form semantics and would turn a literal '+' (e.g. in
+          // "jdk-21.0.3+9") into a space, breaking those paths.
+          case _: NoSuchFileException | _: FileSystemNotFoundException
+              if value.contains("%25") =>
+            URI
+              .create(value.replace("%25", "%"))
+              .toAbsolutePath(followSymlink)
           case _: NoSuchFileException | _: FileSystemNotFoundException =>
             withTryDecode(value.stripPrefix("jar:"))(
               new URI("jar", _, null).toAbsolutePath(followSymlink)

--- a/tests/unit/src/test/scala/tests/UriEncoderDecoderSuite.scala
+++ b/tests/unit/src/test/scala/tests/UriEncoderDecoderSuite.scala
@@ -1,5 +1,10 @@
 package tests
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
 import scala.meta.internal.metals.MetalsEnrichments.XtensionString
 import scala.meta.internal.mtags.URIEncoderDecoder
 
@@ -46,6 +51,59 @@ class UriEncoderDecoderSuite extends BaseSuite {
     // Should be NoSuchFileException instead of URI creation one
     intercept[java.nio.file.NoSuchFileException] {
       "jar:file:///C:/Program Files/Java/jdk-21.0.3+9/lib/src.zip!/java.base/java/lang/String.java".toAbsolutePath
+    }
+  }
+
+  test("double-encoded-jar-uri") {
+    // Regression for #3266: when stepping into a JDK source while debugging on
+    // an old Windows JDK, scala-debug-adapter returns a stack-frame source URI
+    // for src.zip that is double URL-encoded (%2520 == encoded %20 == encoded
+    // space in e.g. "Program Files"). Metals used to fail with
+    // FileSystemNotFoundException while creating the jar file system.
+    //
+    // Build a real src.zip under a directory whose name contains both a space
+    // and a '+' (as in a real JDK path like "jdk-21.0.3+9"), then double-encode
+    // the jar URI exactly as the buggy adapter does, and assert Metals resolves
+    // the *actual* entry (the user story: navigate into the JDK source), not
+    // merely that parsing no longer throws. The '+' guards against form-style
+    // decoding that would turn it into a space.
+    val dir =
+      Files.createTempDirectory("metals-3266").resolve("Program Files+1")
+    Files.createDirectories(dir)
+    val zip = dir.resolve("src.zip")
+    val entry = "java.base/java/io/PrintStream.java"
+    val content = "package java.io\nclass PrintStream\n"
+
+    val out = new ZipOutputStream(Files.newOutputStream(zip))
+    try {
+      out.putNextEntry(new ZipEntry(entry))
+      out.write(content.getBytes(StandardCharsets.UTF_8))
+      out.closeEntry()
+    } finally out.close()
+
+    // zip.toUri encodes the space as %20; replacing % with %25 reproduces the
+    // double encoding (%2520) seen in the issue.
+    val doubleEncoded =
+      "jar:" + zip.toUri.toString.replace("%", "%25") + "!/" + entry
+
+    val resolved = doubleEncoded.toAbsolutePath
+    val nio = resolved.toNIO
+    try {
+      assert(
+        Files.exists(nio),
+        s"expected the double-encoded jar entry to resolve, got $resolved",
+      )
+      assertEquals(nio.getFileName.toString, "PrintStream.java")
+      assertNoDiff(
+        new String(Files.readAllBytes(nio), StandardCharsets.UTF_8),
+        content,
+      )
+    } finally {
+      // The resolver leaves the jar file system open on purpose; close ours so
+      // the temp files can be cleaned up.
+      nio.getFileSystem.close()
+      Files.deleteIfExists(zip)
+      Files.deleteIfExists(dir)
     }
   }
 


### PR DESCRIPTION
Fixes #3266.

When stepping into a JDK class during a debug session on some Windows JDKs, scala-debug-adapter returns a stack-frame source URI for `src.zip` that is **double** URL-encoded, e.g.:

    jar:file:///C:/Program%2520Files/Java/jdk-18.0.1.1/lib/src.zip!/java.base/java/io/PrintStream.java

Here `%2520` is the encoding of `%20`, which is itself the encoded space in `Program Files`. Metals never undid this extra encoding layer, so it asked the jar file system for a path containing a literal `%20` and failed with `FileSystemNotFoundException` — the JDK source could not be opened.

## Fix

Undo the extra encoding layer (`%2520` → `%20`) and re-resolve.

Note the fix deliberately uses a targeted `replace("%25", "%")` rather than `URLDecoder.decode`: the latter's form-decoding semantics turn a literal `+` (as in `jdk-21.0.3+9`) into a space, which would break those paths — consistent with this file's existing caution around `+` in jar URIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved jar path resolution on Windows to handle double-encoded URIs correctly.

* **Tests**
  * Added regression test for double-encoded jar URI resolution with special characters in paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->