### PR TITLE
Fix MBT test discovery for suites with indirect test parent references

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -634,6 +634,54 @@ class MbtWorkspaceSymbolProvider(
   }
 
   /**
+   * BFS through the inheritance chain starting from the given symbols.
+   * Returns all files that transitively reference those symbols as parents.
+   *
+   * At each level, top-level traits and classes defined in the current
+   * frontier files are extracted from the MBT index and used as seeds for
+   * the next [[possibleReferences]] call. Already-visited paths are excluded
+   * to prevent cycles.
+   */
+  private def transitiveReferenceFiles(
+      references: Seq[String],
+      implementations: Seq[String],
+  ): Set[AbsolutePath] = {
+    val allMatchedPaths = scala.collection.mutable.HashSet.empty[AbsolutePath]
+    var frontier: Set[AbsolutePath] = possibleReferences(
+      MbtPossibleReferencesParams(
+        references = references,
+        implementations = implementations,
+      )
+    )
+
+    while (frontier.nonEmpty) {
+      allMatchedPaths ++= frontier
+
+      val nextBaseSymbols = frontier.flatMap { path =>
+        documents.get(path).toSeq.flatMap { doc =>
+          doc.symbols
+            .filter { sym =>
+              val kind = sym.getKind()
+              (kind == Semanticdb.SymbolInformation.Kind.TRAIT ||
+                kind == Semanticdb.SymbolInformation.Kind.CLASS) &&
+              Symbol(sym.getSymbol()).isToplevel
+            }
+            .map(_.getSymbol())
+        }
+      }.toSeq
+
+      frontier =
+        if (nextBaseSymbols.isEmpty) Set.empty
+        else
+          possibleReferences(
+            MbtPossibleReferencesParams(implementations = nextBaseSymbols)
+          ) -- allMatchedPaths
+    }
+
+    allMatchedPaths.toSet
+  }
+
+  /**
    * Extracts potential test class candidates from the MBT index without loading semanticdb.
    * Returns candidates that need to be confirmed via semanticdb before use.
    *
@@ -654,15 +702,13 @@ class MbtWorkspaceSymbolProvider(
       scala.collection.mutable.ArrayBuffer
         .empty[BuildTargetClasses.TestClassCandidate]
 
-    val pathsFromReferences = possibleReferences(
-      MbtPossibleReferencesParams(
-        references = annotationSymbols,
-        implementations = baseParentSymbols,
-      )
+    val allMatchedPaths = transitiveReferenceFiles(
+      references = annotationSymbols,
+      implementations = baseParentSymbols,
     )
 
     for {
-      path <- pathsFromReferences
+      path <- allMatchedPaths
       if filterPath(path)
       doc <- documents.get(path).toList
     } {

--- a/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
@@ -183,6 +183,58 @@ class MbtBuildServerLspSuite
     }
   }
 
+  test("mbt-indirect-test-discovery") {
+    cleanWorkspace()
+    val mbtJson = new MbtJsonBuilder(BuildInfo.scalaVersion)
+      .addScalaLibrary()
+      .addDependency("org.scalameta", "munit", "0.7.29")
+      .addNamespace("test", List("src/**"))
+      .build()
+    val baseTraitFile = "src/BaseSuite.scala"
+    val testFile = "src/IndirectTest.scala"
+
+    for {
+      _ <- initialize(
+        s"""|/.metals/mbt.json
+            |$mbtJson
+            |/$baseTraitFile
+            |package example
+            |
+            |trait BaseSuite extends munit.FunSuite
+            |/$testFile
+            |package example
+            |
+            |class IndirectTest extends BaseSuite {
+            |  test("ok") {}
+            |}
+            |""".stripMargin
+      )
+      _ = assertConnectedToBuildServer("MBT")
+      _ <- server.didOpen(baseTraitFile)
+      _ <- server.didOpen(testFile)
+      testSuites <- server.discoverTestSuites(List(testFile))
+    } yield {
+      val testEvents = testSuites.flatMap(_.events.asScala.toList)
+      assertNoDiff(
+        testEvents.mkString("\n"),
+        s"""|AddTestSuite(example.IndirectTest,IndirectTest,example/IndirectTest#,Location [
+            |  uri = "${workspace.toURI}src/IndirectTest.scala"
+            |  range = Range [
+            |    start = Position [
+            |      line = 2
+            |      character = 6
+            |    ]
+            |    end = Position [
+            |      line = 2
+            |      character = 18
+            |    ]
+            |  ]
+            |],true)
+            |""".stripMargin,
+      )
+    }
+  }
+
   test("mbt-junit-test-discovery") {
     cleanWorkspace()
     val mbtJson = new MbtJsonBuilder(BuildInfo.scalaVersion)


### PR DESCRIPTION
Part 1/2 for my MBT-related test fixes (split for easier review, and because part 2 is not ready yet, as I keep finding more stuff there).

Basically, the way discovery worked, stuff like:
```
final class FooSpec extends MySpecWithFixture {
// Some tests
}
trait MySpecWithFixture extends wordspec.FixtureAnyWordSpecLike with SomeOtherTrait
```
would not have FooSpec recognized as a test suite. We fix that here, but what we do not fix is the fact that `MySpecWithFixture` is (and also was previously) also recognized as a test suite, despite being empty. I don't have any ideas for a fix there, at first I thought filtering out traits might be ok, but I apparently some test runners exist that do handle traits there, and it would not be enough regardless - just something to think about in the future