### PR TITLE
bugfix: Scala 3 actionable diagnostics

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -12,6 +12,7 @@ import scala.meta.inputs.Input
 import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.PositionSyntax._
+import scala.meta.internal.metals.ScalacDiagnostic.DiagnosticData
 import scala.meta.internal.parsing.TokenEditDistance
 import scala.meta.io.AbsolutePath
 
@@ -473,7 +474,7 @@ final class Diagnostics(
       edit: TokenEditDistance,
   ): Option[Object] =
     diagnostic match {
-      case ScalacDiagnostic.ScalaDiagnostic(Left(textEdit)) =>
+      case DiagnosticData(DiagnosticData.LegacyTextEdit(textEdit)) =>
         edit
           .toRevised(
             textEdit,
@@ -481,7 +482,7 @@ final class Diagnostics(
             fallbackToNearest = false,
           )
           .map(_.toJsonObject)
-      case ScalacDiagnostic.ScalaDiagnostic(Right(scalaDiagnostic)) =>
+      case DiagnosticData(DiagnosticData.BspActions(scalaDiagnostic)) =>
         edit
           .toRevised(
             scalaDiagnostic,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals
 
-import java.lang.reflect.Type
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileAlreadyExistsException
@@ -56,11 +55,6 @@ import scala.meta.trees.Origin.Parsed
 
 import ch.epfl.scala.{bsp4j => b}
 import com.google.gson.Gson
-import com.google.gson.GsonBuilder
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
 import fansi.ErrorMode
 import io.undertow.server.HttpServerExchange
 import org.eclipse.lsp4j.TextDocumentIdentifier
@@ -914,52 +908,6 @@ object MetalsEnrichments
     def formatMessage(uri: String, hint: String): String = {
       val severity = d.getSeverity.toString.toLowerCase()
       s"$severity:$hint $uri:${d.getRange.getStart.getLine} ${d.getMessageAsString}"
-    }
-    def asTextEdit: Option[l.TextEdit] = {
-      decodeJson(d.getData, classOf[l.TextEdit])
-    }
-
-    /**
-     * Useful for decoded the diagnostic data since there are overlapping
-     * unrequired keys in the structure that causes issues when we try to
-     * deserialize the old top level text edit vs the newly nested actions.
-     */
-    object DiagnosticDataDeserializer
-        extends JsonDeserializer[Either[l.TextEdit, b.ScalaDiagnostic]] {
-      override def deserialize(
-          json: JsonElement,
-          typeOfT: Type,
-          context: JsonDeserializationContext,
-      ): Either[l.TextEdit, b.ScalaDiagnostic] = {
-        json match {
-          case o: JsonObject if o.has("actions") =>
-            Right(new Gson().fromJson(o, classOf[b.ScalaDiagnostic]))
-          case o => Left(new Gson().fromJson(o, classOf[l.TextEdit]))
-        }
-      }
-    }
-
-    def asScalaDiagnostic: Option[Either[l.TextEdit, b.ScalaDiagnostic]] = {
-      val gson = new GsonBuilder()
-        .registerTypeAdapter(
-          classOf[Either[l.TextEdit, b.ScalaDiagnostic]],
-          DiagnosticDataDeserializer,
-        )
-        .create()
-      d.getData() match {
-        case o: JsonObject =>
-          decodeJson(
-            o,
-            classOf[Either[l.TextEdit, b.ScalaDiagnostic]],
-            Some(gson),
-          )
-        case other =>
-          if (other != null)
-            scribe.warn(
-              s"Unexpected data type: ${d.getData().getClass().getName()}, data: ${d.getData()}"
-            )
-          None
-      }
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -1,32 +1,64 @@
 package scala.meta.internal.metals
 
+import java.util.Collections
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
 import scala.meta.internal.metals.MetalsEnrichments._
 
 import ch.epfl.scala.bsp4j
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
 import org.eclipse.{lsp4j => l}
 
 object ScalacDiagnostic {
 
-  object LegacyScalaAction {
-    def unapply(d: l.Diagnostic): Option[l.TextEdit] = d.asTextEdit
-  }
+  val gson: Gson =
+    new MessageJsonHandler(Collections.emptyMap()).getGson
 
-  object Scala3Diagnostic {
-    def unapply(
-        d: l.Diagnostic
-    ): Option[Seq[l.CodeAction]] =
+  sealed trait DiagnosticData
+  object DiagnosticData {
+
+    final case class LegacyTextEdit(textEdit: l.TextEdit) extends DiagnosticData
+
+    final case class BspActions(diagnostic: bsp4j.ScalaDiagnostic)
+        extends DiagnosticData
+
+    final case class PcActions(actions: Seq[l.CodeAction])
+        extends DiagnosticData
+
+    def unapply(d: l.Diagnostic): Option[DiagnosticData] =
       d.getData() match {
-        case list: Seq[_] =>
-          Some(list.collect { case a: l.CodeAction => a })
-        case _ => None
+        case obj: JsonObject if obj.has("actions") =>
+          decode(obj, classOf[bsp4j.ScalaDiagnostic]).map(BspActions(_))
+        case obj: JsonObject =>
+          decode(obj, classOf[l.TextEdit]).map(LegacyTextEdit(_))
+        case arr: JsonArray =>
+          Some(
+            PcActions(
+              arr.asScala.flatMap(decode(_, classOf[l.CodeAction])).toSeq
+            )
+          )
+        case null => None
+        case other =>
+          scribe.warn(
+            s"Unexpected diagnostic data type: ${other.getClass().getName()}, data: $other"
+          )
+          None
       }
-  }
 
-  object ScalaDiagnostic {
-    def unapply(
-        d: l.Diagnostic
-    ): Option[Either[l.TextEdit, bsp4j.ScalaDiagnostic]] =
-      d.asScalaDiagnostic
+    private def decode[A](json: JsonElement, cls: Class[A]): Option[A] =
+      Try(gson.fromJson(json, cls)) match {
+        case Success(value) => Option(value)
+        case Failure(error) =>
+          scribe.error(s"Failed to parse diagnostic data: $json", error)
+          None
+      }
   }
 
   object NotAMember {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ActionableDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ActionableDiagnostic.scala
@@ -4,7 +4,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.metals._
+import scala.meta.internal.metals.ScalacDiagnostic.DiagnosticData
 import scala.meta.pc.CancelToken
 
 import ch.epfl.scala.{bsp4j => b}
@@ -47,23 +47,18 @@ class ActionableDiagnostic() extends CodeAction {
 
     }
 
-    val codeActions = params
-      .getContext()
-      .getDiagnostics()
-      .asScala
-      .toSeq
-      .groupBy {
-        case ScalacDiagnostic.ScalaDiagnostic(action) =>
-          Some(action)
-        case _ => None
-      }
+    val diagnostics =
+      params.getContext().getDiagnostics().asScala.toSeq
+
+    val codeActions = diagnostics
+      .groupBy(DiagnosticData.unapply)
       .collect {
-        case (Some(Left(textEdit)), diags)
+        case (Some(DiagnosticData.LegacyTextEdit(textEdit)), diags)
             if params.getRange().overlapsWith(diags.head.getRange()) =>
           Seq(createActionableDiagnostic(diags.head, Left(textEdit)))
-        case (Some(Right(action)), diags)
+        case (Some(DiagnosticData.BspActions(scalaDiagnostic)), diags)
             if params.getRange().overlapsWith(diags.head.getRange()) =>
-          action
+          scalaDiagnostic
             .getActions()
             .asScala
             .toSeq
@@ -75,16 +70,12 @@ class ActionableDiagnostic() extends CodeAction {
       .flatten
       .sorted
 
-    val scala3CodeActions = params
-      .getContext()
-      .getDiagnostics()
-      .asScala
-      .toSeq
-      .flatMap {
-        case ScalacDiagnostic.Scala3Diagnostic(actions) =>
-          actions
-        case _ => Nil
-      }
+    val scala3CodeActions = diagnostics.flatMap {
+      case diagnostic @ DiagnosticData(DiagnosticData.PcActions(actions))
+          if params.getRange().overlapsWith(diagnostic.getRange()) =>
+        actions
+      case _ => Nil
+    }
 
     Future.successful(codeActions ++ scala3CodeActions)
   }

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -22,6 +22,7 @@ import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.PositionSyntax._
+import scala.meta.internal.metals.ScalacDiagnostic.gson
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.TextEdits
 import scala.meta.internal.metals.WorkspaceChoicePopup
@@ -38,6 +39,7 @@ import scala.meta.internal.metals.clients.language.StatusType
 import scala.meta.internal.tvp.TreeViewDidChangeParams
 import scala.meta.io.AbsolutePath
 
+import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams
 import org.eclipse.lsp4j.ApplyWorkspaceEditResponse
@@ -60,7 +62,9 @@ import org.eclipse.lsp4j.WorkDoneProgressCancelParams
 import org.eclipse.lsp4j.WorkDoneProgressCreateParams
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures
+import org.eclipse.{lsp4j => l}
 import tests.TestOrderings._
+import tests.TestingClient.normalizeData
 
 /**
  * Fake LSP client that responds to notifications/requests initiated by the server.
@@ -350,12 +354,15 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   override def telemetryEvent(`object`: Any): Unit = ()
   override def publishDiagnostics(params: PublishDiagnosticsParams): Unit = {
     val path = params.getUri.toAbsolutePath
-    diagnostics(path) = params.getDiagnostics.asScala.toSeq
+    val diags = params.getDiagnostics.asScala.toSeq
+      .tapEach(normalizeData)
+
+    diagnostics(path) = diags
     diagnosticsCount
       .getOrElseUpdate(path, new AtomicInteger())
       .incrementAndGet()
     diagnosticsPromises.get(path).foreach { case (promise, condition) =>
-      if (condition(params.getDiagnostics.asScala.toSeq)) {
+      if (condition(diags)) {
         diagnosticsPromises.remove(path)
         promise.trySuccess(())
       }
@@ -618,4 +625,19 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
     } else Future.unit
   }
 
+}
+object TestingClient {
+
+  /**
+   * Serializes a diagnostic's `data` to the gson tree it becomes once sent over
+   * the wire, so that in-process consumers (and tests) observe the same
+   * representation a real editor round-trips back to Metals. A no-op when the
+   * `data` is absent or already a gson tree.
+   */
+  def normalizeData(diagnostic: l.Diagnostic): Unit =
+    diagnostic.getData match {
+      case null => ()
+      case _: JsonElement => ()
+      case raw => diagnostic.setData(gson.toJsonTree(raw))
+    }
 }

--- a/tests/unit/src/test/scala/tests/codeactions/Scala3PcActionableDiagnosticLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/Scala3PcActionableDiagnosticLspSuite.scala
@@ -1,0 +1,88 @@
+package tests.codeactions
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.TextEdits
+import scala.meta.internal.metals.UserConfiguration
+
+import tests.BaseLspSuite
+
+class Scala3PcActionableDiagnosticLspSuite
+    extends BaseLspSuite("scala3-pc-actionable-diagnostic") {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(
+      fallbackScalaVersion = Some(BuildInfo.latestScala3Next),
+      presentationCompilerDiagnostics = true,
+      buildOnChange = false,
+      buildOnFocus = false,
+    )
+
+  override def initializeGitRepo: Boolean = true
+
+  test("remove-repeated-modifier") {
+    cleanWorkspace()
+    val file = "src/Repeated.scala"
+    for {
+      _ <- initialize(
+        s"""|/build.sbt
+            |scalaVersion := "${BuildInfo.scala213}"
+            |
+            |/$file
+            |private private val x = 1
+            |""".stripMargin,
+        expectError = true,
+      )
+      _ <- server.didOpen(file)
+      diagnosticsPublished = server.awaitNextDiagnostics(file, _.nonEmpty)
+      _ <- server.didFocus(file)
+      _ <- diagnosticsPublished
+      codeActions <- server.assertCodeAction(
+        file,
+        "<<private private val x = 1>>\n",
+        """|Remove repeated modifier: "private"
+           |""".stripMargin,
+        kind = Nil,
+        filterAction = _.getTitle.startsWith("Remove repeated modifier"),
+      )
+      edits = codeActions.head.getEdit.getChanges.asScala.values
+        .flatMap(_.asScala)
+        .toList
+      _ = assertNoDiff(
+        TextEdits.applyEdits("private private val x = 1", edits),
+        "private  val x = 1",
+      )
+    } yield ()
+  }
+
+  test("other-diagnostics-actions-should-not-leak") {
+    cleanWorkspace()
+    val file = "src/Repeated.scala"
+    for {
+      _ <- initialize(
+        s"""|/build.sbt
+            |scalaVersion := "${BuildInfo.scala213}"
+            |
+            |/$file
+            |private private val x = 1
+            |private private val y = 2
+            |""".stripMargin,
+        expectError = true,
+      )
+      _ <- server.didOpen(file)
+      diagnosticsPublished = server.awaitNextDiagnostics(file, _.size >= 2)
+      _ <- server.didFocus(file)
+      _ <- diagnosticsPublished
+      _ <- server.assertCodeAction(
+        file,
+        """|<<private private val x = 1>>
+           |private private val y = 2
+           |""".stripMargin,
+        """|Remove repeated modifier: "private"
+           |""".stripMargin,
+        kind = Nil,
+        filterAction = _.getTitle.startsWith("Remove repeated modifier"),
+      )
+    } yield ()
+  }
+}


### PR DESCRIPTION
The Scala 3 presentation compiler (dotty.tools.pc.DiagnosticProvider) attaches code actions to a diagnostic via `Diagnostic.setData(actions.asJava)`. Once the diagnostic is published to the client and echoed back in a `textDocument/codeAction` request, lsp4j deserializes the untyped `data` field into a `com.google.gson.JsonArray`. Metals didn't handle that shape, so the Scala 3 quick-fixes silently disappeared and
`WARN Unexpected data type: com.google.gson.JsonArray, data: []` was logged.

- `MetalsEnrichments.asScalaDiagnostic`: return `None` for a `JsonArray`. The BSP `ScalaDiagnostic` / legacy `TextEdit` formats are always JSON objects, so the PC code-actions array is declined here without warning.
- `ScalacDiagnostic.Scala3Diagnostic`: deserialize each `JsonArray` element into an `l.CodeAction`, so the quick-fixes work after the round-trip.


## Steps to reproduce (main-v2 branch)

1. Open a Scala 3 file served by the presentation compiler.
2. Write code that makes the PC emit a diagnostic carrying a code action, e.g.
   a repeated modifier: `private private val x = 1`.
3. Trigger code actions on the diagnostic (Quick Fix / lightbulb, Ctrl/Cmd+.).

**Before:** `WARN Unexpected data type: com.google.gson.JsonArray` is logged and
the "Remove repeated modifier" quick-fix is missing.

**After:** no warning, and the quick-fix appears and rewrites the line to
`private  val x = 1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Scala diagnostic code actions, including better support for Scala 3 quick fixes and repeated-modifier fixes.
  * Diagnostic updates are now handled more consistently before being sent to the editor.

* **Bug Fixes**
  * Fixed issues where some diagnostic payloads could be ignored or misread, restoring more reliable code actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->