### PR TITLE
Allow to run tests locally without the DAP wrapper for suites in MBT-based builds

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -388,6 +388,21 @@ class BuildServerConnection private (
     completableFuture.asScala
   }
 
+  def buildTargetTest(
+      params: TestParams,
+      cancelPromise: Promise[Unit],
+  ): Future[RunResult] = {
+    val completableFuture = register(server =>
+      server
+        .buildTargetTest(params)
+        .thenApply(result => new RunResult(result.getStatusCode()))
+    )
+    cancelPromise.future.foreach { _ =>
+      completableFuture.cancel(true)
+    }
+    completableFuture.asScala
+  }
+
   def buildTargetJvmClasspath(
       params: JvmCompileClasspathParams,
       cancelPromise: Promise[Unit],

--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -291,12 +291,16 @@ final class ForwardingMetalsBuildClient(
   }
 
   @JsonNotification("run/printStdout")
-  def runPrintStdout(params: b.PrintParams): Unit =
+  def runPrintStdout(params: b.PrintParams): Unit = {
+    forwarders.get().foreach(_.info(params.getMessage()))
     runPrintOutput(params)
+  }
 
   @JsonNotification("run/printStderr")
-  def runPrintStderr(params: b.PrintParams): Unit =
+  def runPrintStderr(params: b.PrintParams): Unit = {
+    forwarders.get().foreach(_.error(params.getMessage()))
     runPrintOutput(params)
+  }
 
   def runPrintOutput(params: b.PrintParams): Unit = {
     def createTerminal(name: String): String = {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -2087,16 +2087,18 @@ abstract class MetalsLspService(
 
   def debugDiscovery(params: DebugDiscoveryParams): Future[DebugSession] =
     afterCompilationFinished(params)(debugDiscovery.debugDiscovery)
-      .flatMap(debugProvider.asSession)
+      .flatMap(debugProvider.asSession(_, noDebug = false))
 
   def runClosest(params: DebugDiscoveryParams): Future[DebugSession] =
     afterCompilationFinished(params)(debugDiscovery.debugDiscovery)
-      .flatMap(debugProvider.asSession)
+      .flatMap(debugProvider.asSession(_, noDebug = false))
 
   def createDebugSession(
       target: b.BuildTargetIdentifier
   ): Future[DebugSession] =
-    debugProvider.createDebugSession(target).flatMap(debugProvider.asSession)
+    debugProvider
+      .createDebugSession(target)
+      .flatMap(debugProvider.asSession(_, noDebug = false))
 
   def testClassSearch(
       params: DebugUnresolvedTestClassParams
@@ -2113,9 +2115,12 @@ abstract class MetalsLspService(
       params: ScalaTestSuitesDebugRequest,
   ): Future[DebugSession] = debugProvider
     .startTestSuite(target, params)
-    .flatMap(debugProvider.asSession)
+    .flatMap(debugProvider.asSession(_, noDebug = params.noDebug))
 
-  def startDebugProvider(params: b.DebugSessionParams): Future[DebugSession] = {
+  def startDebugProvider(
+      params: b.DebugSessionParams,
+      noDebug: Boolean,
+  ): Future[DebugSession] = {
     val targets = params.getTargets.asScala.toSeq
     val mbtConnections = targets.flatMap { target =>
       val connOpt = buildTargets.buildServerOf(target)
@@ -2146,7 +2151,7 @@ abstract class MetalsLspService(
     compileFuture.flatMap { _ =>
       debugProvider
         .ensureNoWorkspaceErrors(targets)
-        .flatMap(_ => debugProvider.asSession(params))
+        .flatMap(_ => debugProvider.asSession(params, noDebug))
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -5,6 +5,7 @@ import javax.annotation.Nullable
 import scala.meta.internal.metals.newScalaFile.NewFileTypes
 
 import ch.epfl.scala.{bsp4j => b}
+import com.google.gson.JsonElement
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
@@ -349,7 +350,7 @@ object ServerCommands {
        |""".stripMargin,
   )
 
-  val StartDebugAdapter = new ParametrizedCommand[b.DebugSessionParams](
+  val StartDebugAdapter = new ParametrizedCommand[DebugAdapterStartParams](
     "debug-adapter-start",
     "Start debug adapter",
     "Start a new debugger session with fully specified DebugSessionParams",
@@ -907,6 +908,13 @@ case class DebugUnresolvedMainClassParams(
     @Nullable jvmOptions: java.util.List[String] = null,
     @Nullable env: java.util.Map[String, String] = null,
     @Nullable envFile: String = null,
+)
+
+final case class DebugAdapterStartParams(
+    @Nullable targets: java.util.List[b.BuildTargetIdentifier],
+    @Nullable dataKind: String,
+    @Nullable data: JsonElement,
+    noDebug: Boolean = false,
 )
 
 final case class ScalaTestSuitesDebugRequest(

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -912,6 +912,7 @@ case class DebugUnresolvedMainClassParams(
 final case class ScalaTestSuitesDebugRequest(
     @Nullable target: b.BuildTargetIdentifier,
     requestData: ScalaTestSuites,
+    noDebug: Boolean = false,
 )
 
 final case class ScalaTestSuites(

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1349,7 +1349,11 @@ class WorkspaceLspService(
           ServerCommands.GotoLog.title,
         ).asJavaObject
 
-      case ServerCommands.StartDebugAdapter(params) if params.getData != null =>
+      case ServerCommands.StartDebugAdapter(debugAdapterParams)
+          if debugAdapterParams.data != null =>
+        val params = new b.DebugSessionParams(debugAdapterParams.targets)
+        params.setDataKind(debugAdapterParams.dataKind)
+        params.setData(debugAdapterParams.data)
         val targets = params.getTargets().asScala
         folderServices
           .find(s => targets.forall(s.supportsBuildTarget(_).isDefined))
@@ -1364,7 +1368,10 @@ class WorkspaceLspService(
             val language = languageFromTargets(supportedTargets)
             val testName = testNameFromDebugSession(params)
             recordRunDebugEvent(language, testName)
-            service.startDebugProvider(params).liftToLspError.asJavaObject
+            service
+              .startDebugProvider(params, debugAdapterParams.noDebug)
+              .liftToLspError
+              .asJavaObject
           case None =>
             failedRequest(
               s"Could not find folder for build targets: ${targets.mkString(",")}"

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -22,7 +22,6 @@ import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.debug.DebugDiscovery
 import scala.meta.internal.metals.debug.ExtendedScalaMainClass
-import scala.meta.internal.metals.mbt.MbtBuildServer
 import scala.meta.internal.parsing.TokenEditDistance
 import scala.meta.internal.semanticdb.MethodSignature
 import scala.meta.internal.semanticdb.Scope
@@ -333,25 +332,20 @@ final class RunTestCodeLens(
       className: String,
       isJVM: Boolean,
   ): List[l.Command] = {
-    val isMbt = buildTargets.buildServerOf(target).exists(_.isMbt)
-    val data = singletonList(className).toJson
-    val runParams = sessionParams(
-      target,
-      if (isMbt) MbtBuildServer.RunTestDataKind
-      else b.TestParamsDataKind.SCALA_TEST_SUITES,
-      data,
-    )
-    val debugParams =
-      sessionParams(target, b.TestParamsDataKind.SCALA_TEST_SUITES, data)
+    val params = {
+      val dataKind = b.TestParamsDataKind.SCALA_TEST_SUITES
+      val data = singletonList(className).toJson
+      sessionParams(target, dataKind, data)
+    }
 
     if (isJVM)
       List(
-        command("test", StartRunSession, runParams),
-        command("debug test", StartDebugSession, debugParams),
+        command("test", StartRunSession, params),
+        command("debug test", StartDebugSession, params),
       )
     else
       List(
-        command("test", StartRunSession, runParams)
+        command("test", StartRunSession, params)
       )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -22,6 +22,7 @@ import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.debug.DebugDiscovery
 import scala.meta.internal.metals.debug.ExtendedScalaMainClass
+import scala.meta.internal.metals.mbt.MbtBuildServer
 import scala.meta.internal.parsing.TokenEditDistance
 import scala.meta.internal.semanticdb.MethodSignature
 import scala.meta.internal.semanticdb.Scope
@@ -332,20 +333,25 @@ final class RunTestCodeLens(
       className: String,
       isJVM: Boolean,
   ): List[l.Command] = {
-    val params = {
-      val dataKind = b.TestParamsDataKind.SCALA_TEST_SUITES
-      val data = singletonList(className).toJson
-      sessionParams(target, dataKind, data)
-    }
+    val isMbt = buildTargets.buildServerOf(target).exists(_.isMbt)
+    val data = singletonList(className).toJson
+    val runParams = sessionParams(
+      target,
+      if (isMbt) MbtBuildServer.RunTestDataKind
+      else b.TestParamsDataKind.SCALA_TEST_SUITES,
+      data,
+    )
+    val debugParams =
+      sessionParams(target, b.TestParamsDataKind.SCALA_TEST_SUITES, data)
 
     if (isJVM)
       List(
-        command("test", StartRunSession, params),
-        command("debug test", StartDebugSession, params),
+        command("test", StartRunSession, runParams),
+        command("debug test", StartDebugSession, debugParams),
       )
     else
       List(
-        command("test", StartRunSession, params)
+        command("test", StartRunSession, runParams)
       )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -123,7 +123,8 @@ class DebugProvider(
   }
 
   def start(
-      parameters: b.DebugSessionParams
+      parameters: b.DebugSessionParams,
+      noDebug: Boolean,
   )(implicit ec: ExecutionContext): Future[DebugServer] = {
     val cancelPromise = Promise[Unit]()
     for {
@@ -140,7 +141,7 @@ class DebugProvider(
         .forall(
           _.scalaInfo.getPlatform == b.ScalaPlatform.JVM
         )
-      isMbtTestRun = parameters.getDataKind == MbtBuildServer.RunTestDataKind
+      isMbtTestRun = noDebug && MbtBuildServer.isMbtServer(buildServer.name)
       debugServer <-
         if (isMbtTestRun)
           runMbtTestLocally(
@@ -182,6 +183,7 @@ class DebugProvider(
       val port = proxyServer.getLocalPort
       proxyServer.setSoTimeout(10 * 1000)
       val uri = URI.create(s"tcp://$host:$port")
+
       val awaitClient = () => Future(proxyServer.accept())
 
       DebugRunner
@@ -576,10 +578,12 @@ class DebugProvider(
   }
 
   def asSession(
-      debugParams: DebugSessionParams
+      debugParams: DebugSessionParams,
+      noDebug: Boolean,
   )(implicit ec: ExecutionContext): Future[DebugSession] = {
+    if (noDebug) scribe.info("Starting debug session without debugging")
     for {
-      server <- start(debugParams)
+      server <- start(debugParams, noDebug)
     } yield {
       statusBar.addMessage("Started debug server!")
       DebugSession(server.sessionName, server.uri.toString)
@@ -705,22 +709,10 @@ class DebugProvider(
       buildTarget: b.BuildTarget,
       request: ScalaTestSuitesDebugRequest,
   )(implicit ec: ExecutionContext): Future[DebugSessionParams] = {
-    val isMbt = buildTargets
-      .buildServerOf(buildTarget.getId)
-      .exists(_.isMbt)
-
     def makeDebugSession() = {
       val jvmOpts = JvmOpts.fromWorkspaceOrEnvForTest(workspace).getOrElse(Nil)
-      request.requestData.suites.asScala.forall(_.tests.isEmpty)
       val debugSession =
-        if (isMbt && request.noDebug) {
-          val testSuites = request.requestData.copy(jvmOptions = jvmOpts.asJava)
-          val params =
-            new b.DebugSessionParams(singletonList(buildTarget.getId))
-          params.setDataKind(MbtBuildServer.RunTestDataKind)
-          params.setData(testSuites.toJson)
-          params
-        } else if (supportsTestSelection(request.target)) {
+        if (supportsTestSelection(request.target)) {
           val testSuites =
             request.requestData.copy(
               suites = request.requestData.suites.map { suite =>
@@ -793,23 +785,6 @@ class DebugProvider(
                   s"${suite.className}(${suite.tests.asScala.mkString(", ")})"
                 )
                 .mkString(";")
-            }
-          case MbtBuildServer.RunTestDataKind =>
-            MbtBuildServer.decodeTestSuites(json) match {
-              case Some(suites) =>
-                Success(
-                  suites.getSuites.asScala
-                    .map(s =>
-                      s"${s.getClassName}(${s.getTests.asScala.mkString(", ")})"
-                    )
-                    .mkString(";")
-                )
-              case None =>
-                Failure(
-                  new IllegalStateException(
-                    "Cannot decode RunTestDataKind data"
-                  )
-                )
             }
         }
       case data =>
@@ -1028,7 +1003,9 @@ object DebugProvider {
     protected def search(): Future[Try[A]]
     protected def dapSessionParams(res: A): Future[DebugSessionParams]
     def createDapSession(args: A): Future[DebugSession] =
-      dapSessionParams(args).flatMap(debugProvider.asSession(_))
+      dapSessionParams(args).flatMap(
+        debugProvider.asSession(_, noDebug = false)
+      )
     def searchResult: Future[(Try[A], ClassSearch[A])] = {
       search().onComplete {
         case Success(resolved) => searchPromise.trySuccess(resolved)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -704,6 +704,7 @@ class DebugProvider(
 
     def makeDebugSession() = {
       val jvmOpts = JvmOpts.fromWorkspaceOrEnvForTest(workspace).getOrElse(Nil)
+      val suiteOnly = request.requestData.suites.asScala.forall(_.tests.isEmpty)
       val debugSession =
         if (isMbt && request.noDebug) {
           val testSuites = request.requestData.copy(jvmOptions = jvmOpts.asJava)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -47,7 +47,6 @@ import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.metals.config.RunType
 import scala.meta.internal.metals.debug.DiscoveryFailures._
-import scala.meta.internal.metals.mbt.MbtBuildServer
 import scala.meta.internal.metals.debug.server.AttachRemoteDebugAdapter
 import scala.meta.internal.metals.debug.server.DebugLogger
 import scala.meta.internal.metals.debug.server.DebugeeParamsCreator
@@ -57,6 +56,7 @@ import scala.meta.internal.metals.debug.server.MainClassDebugAdapter
 import scala.meta.internal.metals.debug.server.MetalsDebugToolsResolver
 import scala.meta.internal.metals.debug.server.MetalsDebuggee
 import scala.meta.internal.metals.debug.server.TestSuiteDebugAdapter
+import scala.meta.internal.metals.mbt.MbtBuildServer
 import scala.meta.internal.metals.testProvider.TestSuitesProvider
 import scala.meta.io.AbsolutePath
 
@@ -185,7 +185,13 @@ class DebugProvider(
       val awaitClient = () => Future(proxyServer.accept())
 
       DebugRunner
-        .open(sessionName, awaitClient, stacktraceAnalyzer, runFuture, cancelPromise)
+        .open(
+          sessionName,
+          awaitClient,
+          stacktraceAnalyzer,
+          runFuture,
+          cancelPromise,
+        )
         .flatMap { runner =>
           currentRunner.set(runner)
           runner.listen.map { code =>
@@ -263,7 +269,8 @@ class DebugProvider(
           testSuites.foreach { suite =>
             val entry: dap.testing.SingleTestSummary =
               if (passed)
-                dap.testing.SingleTestResult.Passed(suite.getClassName, duration)
+                dap.testing.SingleTestResult
+                  .Passed(suite.getClassName, duration)
               else
                 dap.testing.SingleTestResult.Failed(
                   suite.getClassName,
@@ -704,11 +711,12 @@ class DebugProvider(
 
     def makeDebugSession() = {
       val jvmOpts = JvmOpts.fromWorkspaceOrEnvForTest(workspace).getOrElse(Nil)
-      val suiteOnly = request.requestData.suites.asScala.forall(_.tests.isEmpty)
+      request.requestData.suites.asScala.forall(_.tests.isEmpty)
       val debugSession =
         if (isMbt && request.noDebug) {
           val testSuites = request.requestData.copy(jvmOptions = jvmOpts.asJava)
-          val params = new b.DebugSessionParams(singletonList(buildTarget.getId))
+          val params =
+            new b.DebugSessionParams(singletonList(buildTarget.getId))
           params.setDataKind(MbtBuildServer.RunTestDataKind)
           params.setData(testSuites.toJson)
           params

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -47,6 +47,7 @@ import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.metals.config.RunType
 import scala.meta.internal.metals.debug.DiscoveryFailures._
+import scala.meta.internal.metals.mbt.MbtBuildServer
 import scala.meta.internal.metals.debug.server.AttachRemoteDebugAdapter
 import scala.meta.internal.metals.debug.server.DebugLogger
 import scala.meta.internal.metals.debug.server.DebugeeParamsCreator
@@ -139,8 +140,16 @@ class DebugProvider(
         .forall(
           _.scalaInfo.getPlatform == b.ScalaPlatform.JVM
         )
+      isMbtTestRun = parameters.getDataKind == MbtBuildServer.RunTestDataKind
       debugServer <-
-        if (isJvm)
+        if (isMbtTestRun)
+          runMbtTestLocally(
+            sessionName,
+            jvmOptionsTranslatedParams,
+            buildServer,
+            cancelPromise,
+          )
+        else if (isJvm)
           workDoneProgress.trackFuture(
             "Starting debug server",
             start(
@@ -161,11 +170,11 @@ class DebugProvider(
     } yield debugServer
   }
 
-  private def runLocally(
+  private def openLocalDebugServer(
       sessionName: String,
-      parameters: b.DebugSessionParams,
-      buildServer: BuildServerConnection,
       cancelPromise: Promise[Unit],
+  )(
+      runFuture: () => Future[b.RunResult]
   )(implicit ec: ExecutionContext): Future[DebugServer] = {
     if (runningLocal.compareAndSet(false, true)) {
       val proxyServer = new ServerSocket(0, 50, localAddress)
@@ -173,36 +182,10 @@ class DebugProvider(
       val port = proxyServer.getLocalPort
       proxyServer.setSoTimeout(10 * 1000)
       val uri = URI.create(s"tcp://$host:$port")
-
       val awaitClient = () => Future(proxyServer.accept())
 
       DebugRunner
-        .open(
-          sessionName,
-          awaitClient,
-          stacktraceAnalyzer,
-          () => {
-            val runParams =
-              new b.RunParams(parameters.getTargets().asScala.head)
-            runParams.setOriginId(ju.UUID.randomUUID().toString())
-
-            /**
-             * We set data and dataKind with the information about the main class to run,
-             * otherwise if multiple main classes are found we would not know which one to run.
-             */
-            if (
-              parameters
-                .getDataKind() == b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS
-            ) {
-              runParams.setDataKind(parameters.getDataKind())
-              runParams.setData(parameters.getData())
-            }
-            val run = buildServer.buildTargetRun(runParams, cancelPromise)
-            run.onComplete(_ => runningLocal.set(false))
-            run
-          },
-          cancelPromise,
-        )
+        .open(sessionName, awaitClient, stacktraceAnalyzer, runFuture, cancelPromise)
         .flatMap { runner =>
           currentRunner.set(runner)
           runner.listen.map { code =>
@@ -221,6 +204,85 @@ class DebugProvider(
       Future.failed(
         new IllegalStateException("Cannot run multiple debug processes.")
       )
+    }
+  }
+
+  private def runLocally(
+      sessionName: String,
+      parameters: b.DebugSessionParams,
+      buildServer: BuildServerConnection,
+      cancelPromise: Promise[Unit],
+  )(implicit ec: ExecutionContext): Future[DebugServer] =
+    openLocalDebugServer(sessionName, cancelPromise) { () =>
+      val runParams =
+        new b.RunParams(parameters.getTargets().asScala.head)
+      runParams.setOriginId(ju.UUID.randomUUID().toString())
+
+      /**
+       * We set data and dataKind with the information about the main class to run,
+       * otherwise if multiple main classes are found we would not know which one to run.
+       */
+      if (
+        parameters
+          .getDataKind() == b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS
+      ) {
+        runParams.setDataKind(parameters.getDataKind())
+        runParams.setData(parameters.getData())
+      }
+      val run = buildServer.buildTargetRun(runParams, cancelPromise)
+      run.onComplete(_ => runningLocal.set(false))
+      run
+    }
+
+  private def runMbtTestLocally(
+      sessionName: String,
+      parameters: b.DebugSessionParams,
+      buildServer: BuildServerConnection,
+      cancelPromise: Promise[Unit],
+  )(implicit ec: ExecutionContext): Future[DebugServer] = {
+    val testSuites: Seq[b.ScalaTestSuiteSelection] =
+      MbtBuildServer
+        .decodeTestSuites(parameters.getData)
+        .map(_.getSuites.asScala.toSeq)
+        .getOrElse(Seq.empty)
+
+    openLocalDebugServer(sessionName, cancelPromise) { () =>
+      val testParams = new b.TestParams(parameters.getTargets())
+      testParams.setOriginId(ju.UUID.randomUUID().toString())
+      testParams.setDataKind(parameters.getDataKind)
+      testParams.setData(parameters.getData)
+      val test = buildServer.buildTargetTest(testParams, cancelPromise)
+      test.onComplete(_ => runningLocal.set(false))
+      test.map { result =>
+        val runner = currentRunner.get()
+        if (runner != null && testSuites.nonEmpty) {
+          val passed = result.getStatusCode == b.StatusCode.OK
+          // 0 is an obviously untrue value - a real duration will show up in the logs.
+          // Parsing the bazel xml output is an option, but might be hard to maintain.
+          val duration = 0L
+          testSuites.foreach { suite =>
+            val entry: dap.testing.SingleTestSummary =
+              if (passed)
+                dap.testing.SingleTestResult.Passed(suite.getClassName, duration)
+              else
+                dap.testing.SingleTestResult.Failed(
+                  suite.getClassName,
+                  duration,
+                  "Test suite failed",
+                  null,
+                  null,
+                )
+            runner.testResult(
+              dap.testing.TestSuiteSummary(
+                suite.getClassName,
+                duration,
+                ju.Collections.singletonList(entry),
+              )
+            )
+          }
+        }
+        result
+      }
     }
   }
 
@@ -636,10 +698,20 @@ class DebugProvider(
       buildTarget: b.BuildTarget,
       request: ScalaTestSuitesDebugRequest,
   )(implicit ec: ExecutionContext): Future[DebugSessionParams] = {
+    val isMbt = buildTargets
+      .buildServerOf(buildTarget.getId)
+      .exists(_.isMbt)
+
     def makeDebugSession() = {
       val jvmOpts = JvmOpts.fromWorkspaceOrEnvForTest(workspace).getOrElse(Nil)
       val debugSession =
-        if (supportsTestSelection(request.target)) {
+        if (isMbt && request.noDebug) {
+          val testSuites = request.requestData.copy(jvmOptions = jvmOpts.asJava)
+          val params = new b.DebugSessionParams(singletonList(buildTarget.getId))
+          params.setDataKind(MbtBuildServer.RunTestDataKind)
+          params.setData(testSuites.toJson)
+          params
+        } else if (supportsTestSelection(request.target)) {
           val testSuites =
             request.requestData.copy(
               suites = request.requestData.suites.map { suite =>
@@ -712,6 +784,23 @@ class DebugProvider(
                   s"${suite.className}(${suite.tests.asScala.mkString(", ")})"
                 )
                 .mkString(";")
+            }
+          case MbtBuildServer.RunTestDataKind =>
+            MbtBuildServer.decodeTestSuites(json) match {
+              case Some(suites) =>
+                Success(
+                  suites.getSuites.asScala
+                    .map(s =>
+                      s"${s.getClassName}(${s.getTests.asScala.mkString(", ")})"
+                    )
+                    .mkString(";")
+                )
+              case None =>
+                Failure(
+                  new IllegalStateException(
+                    "Cannot decode RunTestDataKind data"
+                  )
+                )
             }
         }
       case data =>

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugRunner.scala
@@ -11,10 +11,13 @@ import scala.util.Try
 import scala.util.control.NonFatal
 
 import scala.meta.internal.metals.Cancelable
+import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.StacktraceAnalyzer
 
 import ch.epfl.scala.bsp4j.RunResult
 import ch.epfl.scala.bsp4j.StatusCode
+import ch.epfl.scala.debugadapter.TestResultEvent
+import ch.epfl.scala.debugadapter.testing.TestSuiteSummary
 import org.eclipse.lsp4j.debug.Capabilities
 import org.eclipse.lsp4j.debug.ExitedEventArguments
 import org.eclipse.lsp4j.debug.OutputEventArguments
@@ -132,6 +135,14 @@ class DebugRunner(
         .map(DebugProtocol.stacktraceOutputResponse(notification, _))
 
     }
+  }
+
+  def testResult(summary: TestSuiteSummary): Unit = {
+    val notification = new DebugNotificationMessage()
+    notification.setMethod("testResult")
+    notification.setParams(TestResultEvent(summary).toJson)
+    notification.setId(lastId.incrementAndGet())
+    client.consume(notification)
   }
 
   private def output(message: String, category: String)(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
@@ -437,6 +437,10 @@ final class MbtBuildServer(
           case _ =>
             Left("buildTarget/test: expected test class names list")
         }
+      case MbtBuildServer.RunTestDataKind =>
+        MbtBuildServer
+          .decodeTestSuites(params.getData)
+          .toRight("buildTarget/test: cannot decode RunTestDataKind data")
       case _ =>
         Left(
           s"buildTarget/test: unsupported data kind: ${params.getDataKind}"
@@ -693,6 +697,9 @@ final class MbtBuildServer(
 object MbtBuildServer {
   val name = "MBT"
 
+  /** Custom data kind used in [[DebugSessionParams]] to signal a non-debug test run. */
+  val RunTestDataKind = "mbt-scala-test-suites-run"
+
   def details: BspConnectionDetails =
     new BspConnectionDetails(
       name,
@@ -704,6 +711,22 @@ object MbtBuildServer {
 
   def isMbtServer(name: String): Boolean =
     name == MbtBuildServer.name
+
+  def decodeTestSuites(data: Any): Option[ScalaTestSuites] =
+    data match {
+      case json: com.google.gson.JsonElement =>
+        // TestSuitesProvider (test explorer) sends ScalaTestSuites
+        json.as[ScalaTestSuites].toOption.orElse(
+          // RunTestCodeLens (code lenses) sends a plain list of class names
+          json.as[java.util.List[String]].toOption.map { tests =>
+            val suites = tests.asScala
+              .map(new ScalaTestSuiteSelection(_, List.empty.asJava))
+              .asJava
+            new ScalaTestSuites(suites, List.empty.asJava, List.empty.asJava)
+          }
+        )
+      case _ => None
+    }
 
   def newServer(
       workspace: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
@@ -437,10 +437,6 @@ final class MbtBuildServer(
           case _ =>
             Left("buildTarget/test: expected test class names list")
         }
-      case MbtBuildServer.RunTestDataKind =>
-        MbtBuildServer
-          .decodeTestSuites(params.getData)
-          .toRight("buildTarget/test: cannot decode RunTestDataKind data")
       case _ =>
         Left(
           s"buildTarget/test: unsupported data kind: ${params.getDataKind}"
@@ -696,9 +692,6 @@ final class MbtBuildServer(
 
 object MbtBuildServer {
   val name = "MBT"
-
-  /** Custom data kind used in [[DebugSessionParams]] to signal a non-debug test run. */
-  val RunTestDataKind = "mbt-scala-test-suites-run"
 
   def details: BspConnectionDetails =
     new BspConnectionDetails(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
@@ -716,15 +716,18 @@ object MbtBuildServer {
     data match {
       case json: com.google.gson.JsonElement =>
         // TestSuitesProvider (test explorer) sends ScalaTestSuites
-        json.as[ScalaTestSuites].toOption.orElse(
-          // RunTestCodeLens (code lenses) sends a plain list of class names
-          json.as[java.util.List[String]].toOption.map { tests =>
-            val suites = tests.asScala
-              .map(new ScalaTestSuiteSelection(_, List.empty.asJava))
-              .asJava
-            new ScalaTestSuites(suites, List.empty.asJava, List.empty.asJava)
-          }
-        )
+        json
+          .as[ScalaTestSuites]
+          .toOption
+          .orElse(
+            // RunTestCodeLens (code lenses) sends a plain list of class names
+            json.as[java.util.List[String]].toOption.map { tests =>
+              val suites = tests.asScala
+                .map(new ScalaTestSuiteSelection(_, List.empty.asJava))
+                .asJava
+              new ScalaTestSuites(suites, List.empty.asJava, List.empty.asJava)
+            }
+          )
       case _ => None
     }
 


### PR DESCRIPTION
The idea is that for some more complex builds (e.g. ones that use remote build execution/test runs), our standard approach with debug wrappers and java agents will not work (instead timing out trying to connect). Certain users might also not expect the additional setup when just running "run test" and not "debug test". Both Test Explorer and Code lens based runs were manually tested.

There are some quirks:
1. It's a little difficult to figure out whether a "run test" and "debug test" option was selected in the client. For Code Lenses, it's mostly straightforward, since we set those up in the server (here by setting up an new DataKind, MbtBuildServer.RunTestDataKind), they pass through the client and we can see which mode was chosen. For TestExplorer though, we still similarly set up code lenses (in TestSuitesProvider), but somewhere along the way in the client, before returning a call with ScalaRunTestSuitesSelection, the data kind there gets overwritten. We handle that by passing the noDebug field from vscode back to the server, and then setting up the RunTestDataKind based on that (so a bit later then in Code Lenses). Linked PR setting noDebug in VSCode plugin: https://github.com/scalameta/metals-vscode/pull/2017
2. We do not get as much information from the test run as when using the previous method. Theoretically, it would be possible to read the descriptive test results from an xml file (like bazel-testlogs/<target>/test.xml), but 1. that would be a maintainnance cost, 2.  unsure if maven has this by default, or would require plugin (would need to investigate more). Because of that, for now, we limit this new behavior to individual test suites (rather than test case, where we would have to choose multiple and handle that correctly). Again, I think this should be possible to handle correctly in the future (and not that hard to make).