### PR TITLE
Add BSP generated source manual suite

### DIFF
--- a/project/SemanticDbSupport.scala
+++ b/project/SemanticDbSupport.scala
@@ -19,50 +19,54 @@ object SemanticDbSupport {
   // to have semanticdb-scalac published for those versions. This is especially important
   // when SBT updates its meta-build Scala version (e.g., 2.12.21 in SBT 1.12.0).
   val last: Map[String, String] = {
-    val result = AllScalaVersions.flatMap { scalaVersion =>
-      val available = coursierapi.Complete
-        .create()
-        .withScalaVersion(scalaVersion)
-        .withScalaBinaryVersion(scalaVersion.split('.').take(2).mkString("."))
-        .withInput(s"org.scalameta:semanticdb-scalac_$scalaVersion:")
-        .complete()
-        .getCompletions()
-        .asScala
-        .toList
+    if (manualSuiteEnabled) {
+      AllScalaVersions.map(_ -> V.scalameta).toMap
+    } else {
+      val result = AllScalaVersions.flatMap { scalaVersion =>
+        val available = coursierapi.Complete
+          .create()
+          .withScalaVersion(scalaVersion)
+          .withScalaBinaryVersion(scalaVersion.split('.').take(2).mkString("."))
+          .withInput(s"org.scalameta:semanticdb-scalac_$scalaVersion:")
+          .complete()
+          .getCompletions()
+          .asScala
+          .toList
 
-      available.reverse
-        .collectFirst {
-          case version if Version.parse(version).exists(latestVersion >= _) =>
-            version
-        }
-        .orElse {
-          // Fallback: if no version <= latestVersion exists, use the earliest available
-          if (available.nonEmpty) {
-            System.err.println(
-              s"WARNING: No semanticdb-scalac version <= ${V.scalameta} found for Scala $scalaVersion. " +
-                s"Using earliest available: ${available.head}. Consider updating V.scalameta."
-            )
-            Some(available.head)
-          } else {
-            System.err.println(
-              s"ERROR: No semanticdb-scalac versions found for Scala $scalaVersion!"
-            )
-            None
+        available.reverse
+          .collectFirst {
+            case version if Version.parse(version).exists(latestVersion >= _) =>
+              version
           }
-        }
-        .map(scalaVersion -> _)
-    }.toMap
+          .orElse {
+            // Fallback: if no version <= latestVersion exists, use the earliest available
+            if (available.nonEmpty) {
+              System.err.println(
+                s"WARNING: No semanticdb-scalac version <= ${V.scalameta} found for Scala $scalaVersion. " +
+                  s"Using earliest available: ${available.head}. Consider updating V.scalameta."
+              )
+              Some(available.head)
+            } else {
+              System.err.println(
+                s"ERROR: No semanticdb-scalac versions found for Scala $scalaVersion!"
+              )
+              None
+            }
+          }
+          .map(scalaVersion -> _)
+      }.toMap
 
-    // Validate that all Scala versions have a mapping
-    val missing = AllScalaVersions.filterNot(result.contains)
-    if (missing.nonEmpty) {
-      sys.error(
-        s"Failed to find semanticdb-scalac versions for: ${missing.mkString(", ")}. " +
-          s"This may happen if V.scalameta (${V.scalameta}) is too old."
-      )
+      // Validate that all Scala versions have a mapping
+      val missing = AllScalaVersions.filterNot(result.contains)
+      if (missing.nonEmpty) {
+        sys.error(
+          s"Failed to find semanticdb-scalac versions for: ${missing.mkString(", ")}. " +
+            s"This may happen if V.scalameta (${V.scalameta}) is too old."
+        )
+      }
+
+      result
     }
-
-    result
   }
 
   // returns versions from newest to oldest
@@ -70,4 +74,8 @@ object SemanticDbSupport {
     val desc = if (range.step > 0) range.reverse else range
     desc.map { x => s"$major.$minor.$x" }
   }
+
+  private def manualSuiteEnabled: Boolean =
+    sys.props.get("metals.manual.enabled").contains("true") ||
+      sys.env.get("METALS_MANUAL_ENABLED").contains("true")
 }

--- a/tests/unit/src/main/scala/tests/BaseManualSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseManualSuite.scala
@@ -14,6 +14,7 @@ import scala.util.control.NonFatal
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.MetalsEnrichments.XtensionAbsolutePathBuffers
 import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.MtagsResolver
 import scala.meta.internal.metals.StatisticsConfig
 import scala.meta.internal.metals.Testing
 import scala.meta.internal.metals.Time
@@ -43,6 +44,7 @@ abstract class BaseManualSuite extends munit.FunSuite {
   def clientName: String = "Visual Studio Code"
   def awaitInitialized: Boolean = true
   def buildServerConnectionTimeout: Duration = Duration("2min")
+  def mtagsResolver: MtagsResolver = new TestMtagsResolver(checkCoursier = true)
 
   def defaultUserConfig: UserConfiguration = UserConfiguration.default.copy(
     preferredBuildServer = preferredBuildServer,
@@ -130,7 +132,7 @@ abstract class BaseManualSuite extends munit.FunSuite {
           time = Time.system,
           initializationOptions = TestingServer.TestDefault
             .copy(isVirtualDocumentSupported = Some(true)),
-          mtagsResolver = new TestMtagsResolver(checkCoursier = true),
+          mtagsResolver = mtagsResolver,
           clientName = clientName,
           onStartCompilation = () => (),
         )(ex)

--- a/tests/unit/src/main/scala/tests/BaseManualSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseManualSuite.scala
@@ -1,6 +1,7 @@
 package tests
 
 import java.nio.file.Paths
+import java.time.Instant
 import java.util.concurrent.Executors
 
 import scala.concurrent.ExecutionContext
@@ -8,6 +9,7 @@ import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.util.Try
+import scala.util.control.NonFatal
 
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.MetalsEnrichments.XtensionAbsolutePathBuffers
@@ -39,6 +41,8 @@ abstract class BaseManualSuite extends munit.FunSuite {
     )
   )
   def clientName: String = "Visual Studio Code"
+  def awaitInitialized: Boolean = true
+  def buildServerConnectionTimeout: Duration = Duration("2min")
 
   def defaultUserConfig: UserConfiguration = UserConfiguration.default.copy(
     preferredBuildServer = preferredBuildServer,
@@ -52,6 +56,44 @@ abstract class BaseManualSuite extends munit.FunSuite {
       statistics = StatisticsConfig.all
     )
 
+  protected def manualLog(message: String): Unit =
+    System.err.println(s"[ManualSuite ${Instant.now()}] $message")
+
+  protected def logged[A](message: String)(future: => Future[A]): Future[A] = {
+    manualLog(s"start: $message")
+    future.transform { result =>
+      result.fold(
+        error => manualLog(s"failed: $message: ${error.getMessage}"),
+        _ => manualLog(s"done: $message"),
+      )
+      result
+    }(ex)
+  }
+
+  private def waitForBuildServerConnection(
+      server: TestingServer
+  ): Future[Unit] = Future {
+    val deadline = System.nanoTime() + buildServerConnectionTimeout.toNanos
+    var last: Option[Throwable] = None
+    var connected = false
+    while (!connected && System.nanoTime() < deadline) {
+      try {
+        server.assertBuildServerConnection()
+        connected = true
+      } catch {
+        case NonFatal(error) =>
+          last = Some(error)
+          if (System.nanoTime() < deadline) {
+            Thread.sleep(1000)
+          }
+      }
+    }
+    if (!connected) {
+      last.foreach(throw _)
+      server.assertBuildServerConnection()
+    }
+  }(ex)
+
   def inDirectory(
       path: String,
       config: MetalsServerConfig = defaultMetalsServerConfig,
@@ -64,13 +106,17 @@ abstract class BaseManualSuite extends munit.FunSuite {
       setup = { test =>
         val buffers = Buffers()
         val workspace = AbsolutePath(path)
+        manualLog(s"setup ${test.name} in $workspace")
         onSetup(workspace)
+        manualLog("setupBsp completed")
         if (removeCache) {
           workspace.resolve(".metals").deleteRecursively()
+          manualLog("removed .metals")
         }
         if (removeIndexMbt) {
           val indexMbt = workspace.resolve(".metals").resolve("index.mbt")
           if (indexMbt.exists) indexMbt.delete()
+          manualLog("removed .metals/index.mbt")
         }
         val client = new TestingClient(workspace, buffers)
         val server = new TestingServer(
@@ -89,11 +135,23 @@ abstract class BaseManualSuite extends munit.FunSuite {
           onStartCompilation = () => (),
         )(ex)
         for {
-          _ <- server.initialize()
-          _ <- server.initialized()
-          _ <- server.didChangeConfiguration(userConfig.toString)
+          _ <- logged("server.initialize")(server.initialize())
+          _ <-
+            if (awaitInitialized) {
+              logged("server.initialized")(server.initialized())
+            } else {
+              manualLog("send: server.initialized")
+              server.initialized()
+              manualLog("sent: server.initialized")
+              Future.unit
+            }
+          _ <- logged("server.didChangeConfiguration")(
+            server.didChangeConfiguration(userConfig.toString)
+          )
+          _ <- logged("build server connection")(
+            waitForBuildServerConnection(server)
+          )
         } yield {
-          server.assertBuildServerConnection()
           (server, client)
         }
       },

--- a/tests/unit/src/test/scala/tests/ManualSuite.scala
+++ b/tests/unit/src/test/scala/tests/ManualSuite.scala
@@ -109,6 +109,26 @@ class ManualSuite extends BaseManualSuite {
       case Some("true")  => true
       case _             => configuredBspLauncher.isEmpty && writeBspConnection
     }
+  private val awaitEditorNotifications =
+    !prop("metals.manual.awaitEditorNotifications").contains("false")
+  private val afterOpenDelay =
+    prop("metals.manual.afterOpenDelay").map(Duration(_)).getOrElse(Duration.Zero)
+  private val afterDefinitionOpenDelay =
+    prop("metals.manual.afterDefinitionOpenDelay")
+      .map(Duration(_))
+      .getOrElse(Duration.Zero)
+  private val cleanDiagnosticsTimeout =
+    prop("metals.manual.cleanDiagnosticsTimeout")
+      .map(Duration(_))
+      .getOrElse(Duration.Zero)
+  private val javaSymbolLoader =
+    prop("metals.manual.javaSymbolLoader") match {
+      case Some("javac-sourcepath")         => JavaSymbolLoaderConfig.javacSourcepath
+      case Some("turbine-classpath") | None =>
+        JavaSymbolLoaderConfig.turbineClasspath
+      case Some(other) =>
+        sys.error(s"Invalid metals.manual.javaSymbolLoader: $other")
+    }
 
   override def preferredBuildServer: Option[String] = Some(bspName)
 
@@ -118,12 +138,20 @@ class ManualSuite extends BaseManualSuite {
   override def munitTimeout: Duration =
     prop("metals.manual.timeout").map(Duration(_)).getOrElse(super.munitTimeout)
 
+  override def awaitInitialized: Boolean =
+    !prop("metals.manual.awaitInitialized").contains("false")
+
+  override def buildServerConnectionTimeout: Duration =
+    prop("metals.manual.buildServerConnectionTimeout")
+      .map(Duration(_))
+      .getOrElse(super.buildServerConnectionTimeout)
+
   override def defaultUserConfig: UserConfiguration =
     super.defaultUserConfig.copy(
       preferredBuildServer = preferredBuildServer,
       fallbackClasspath = FallbackClasspathConfig.mbt,
       workspaceSymbolProvider = WorkspaceSymbolProviderConfig.mbt,
-      javaSymbolLoader = JavaSymbolLoaderConfig.turbineClasspath,
+      javaSymbolLoader = javaSymbolLoader,
       presentationCompilerDiagnostics = true,
       definitionIndexStrategy = DefinitionIndexStrategy.classpath,
       fallbackSourcepath = FallbackSourcepathConfig.allSources,
@@ -149,6 +177,9 @@ class ManualSuite extends BaseManualSuite {
         s"Missing BSP launcher at $bspLauncher. $installCommand",
       )
     }
+    manualLog(
+      s"workspace=${workspace.toNIO} bspName=$bspName writeBspConnection=$writeBspConnection runStripeBspSetup=$runStripeBspSetup"
+    )
 
     val bspDir = workspace.resolve(".bsp").toNIO
     val workspacePath = workspace.toNIO.toString
@@ -172,6 +203,7 @@ class ManualSuite extends BaseManualSuite {
         new Gson().toJson(details),
         StandardCharsets.UTF_8,
       )
+      manualLog(s"wrote .bsp/stripe-bsp.json for $syncTarget")
     }
 
     if (runStripeBspSetup) {
@@ -182,6 +214,7 @@ class ManualSuite extends BaseManualSuite {
 
   private def runStripeBsp(workspace: AbsolutePath, action: String): Unit = {
     val workspacePath = workspace.toNIO.toString
+    manualLog(s"stripe-bsp $action start for $syncTarget")
     val exitCode =
       Process(
         List(
@@ -195,6 +228,7 @@ class ManualSuite extends BaseManualSuite {
         workspace.toFile,
       ).!
     assertEquals(exitCode, 0)
+    manualLog(s"stripe-bsp $action done")
   }
 
   private def openDefinition(
@@ -204,7 +238,9 @@ class ManualSuite extends BaseManualSuite {
       generatedOnly: Boolean,
   ): Future[Unit] =
     for {
-      locations <- server.definitionSubstringQuery(filename, query)
+      locations <- logged(s"definition $filename $query")(
+        server.definitionSubstringQuery(filename, query)
+      )
       uri = locations
         .map(_.getUri)
         .find(uri =>
@@ -219,7 +255,9 @@ class ManualSuite extends BaseManualSuite {
               locations.map(_.getUri).mkString(", ")
           )
         )
-      _ <- server.didOpenAndFocus(uri)
+      _ = manualLog(s"definition selected $uri")
+      _ <- openAndFocus(server, uri, "definition")
+      _ <- sleep(afterDefinitionOpenDelay)
     } yield ()
 
   inDirectory(
@@ -229,37 +267,46 @@ class ManualSuite extends BaseManualSuite {
   ).test("bsp-generated-source-diagnostics") { case (server, client) =>
     val path = sourcePath
     for {
-      _ <- server.didOpenAndFocus(path)
-      _ <- Future.traverse(extraOpenFiles)(server.didOpenAndFocus)
-      _ <- server.didFocus(path)
-      _ = assertNoDiff(client.workspaceDiagnostics, "")
+      _ <- openAndFocus(server, path, "source")
+      _ <- Future.traverse(extraOpenFiles) { file =>
+        openAndFocus(server, file, "extra file")
+      }
+      _ <- sleep(afterOpenDelay)
+      _ <- logged(s"focus source $path")(server.didFocus(path))
+      _ <- assertCleanDiagnostics(client, "before navigation")
       _ <- Future.traverse(definitionSpecs) { spec =>
         for {
           _ <- openDefinition(server, spec.file, spec.query, spec.generatedOnly)
-          _ <- server.didFocus(path)
-          _ = assertNoDiff(client.workspaceDiagnostics, "")
+          _ <- logged(s"return focus $path")(server.didFocus(path))
+          _ <- assertCleanDiagnostics(client, s"after definition ${spec.query}")
         } yield ()
       }
       _ <- Future.traverse(referenceQueries) { spec =>
         for {
-          locations <- server.referencesSubquery(spec.file, spec.query)
+          locations <- logged(s"references ${spec.file} ${spec.query}")(
+            server.referencesSubquery(spec.file, spec.query)
+          )
           _ = assert(
             locations.size >= spec.minLocations,
             s"Expected at least ${spec.minLocations} references for " +
               s"`${spec.query}` in `${spec.file}`, got ${locations.size}",
           )
-          _ = assertNoDiff(client.workspaceDiagnostics, "")
+          _ = manualLog(s"references found ${locations.size}")
+          _ <- assertCleanDiagnostics(client, s"after references ${spec.query}")
         } yield ()
       }
       _ <- Future.traverse(implementationQueries) { spec =>
         for {
-          locations <- server.implementationsSubquery(spec.file, spec.query)
+          locations <- logged(s"implementations ${spec.file} ${spec.query}")(
+            server.implementationsSubquery(spec.file, spec.query)
+          )
           _ = assert(
             locations.size >= spec.minLocations,
             s"Expected at least ${spec.minLocations} implementations for " +
               s"`${spec.query}` in `${spec.file}`, got ${locations.size}",
           )
-          _ = assertNoDiff(client.workspaceDiagnostics, "")
+          _ = manualLog(s"implementations found ${locations.size}")
+          _ <- assertCleanDiagnostics(client, s"after implementations ${spec.query}")
         } yield ()
       }
     } yield ()
@@ -267,6 +314,47 @@ class ManualSuite extends BaseManualSuite {
 
   private def indexedProperties(prefix: String): List[String] =
     (1 to 10).flatMap(index => prop(s"$prefix.$index")).toList
+
+  private def openAndFocus(
+      server: TestingServer,
+      path: String,
+      label: String,
+  ): Future[Unit] =
+    if (awaitEditorNotifications) {
+      logged(s"open $label $path")(server.didOpenAndFocus(path))
+    } else {
+      manualLog(s"send: open $label $path")
+      server.didOpen(path)
+      server.didFocus(path)
+      manualLog(s"sent: open $label $path")
+      Future.unit
+    }
+
+  private def sleep(duration: Duration): Future[Unit] =
+    if (duration.length <= 0) Future.unit
+    else logged(s"sleep $duration")(Future(Thread.sleep(duration.toMillis)))
+
+  private def assertCleanDiagnostics(
+      client: TestingClient,
+      label: String,
+  ): Future[Unit] = Future {
+    manualLog(s"assert diagnostics $label")
+    if (cleanDiagnosticsTimeout.length <= 0) {
+      assertNoDiff(client.workspaceDiagnostics, "")
+    } else {
+      val deadline = System.nanoTime() + cleanDiagnosticsTimeout.toNanos
+      var diagnostics = client.workspaceDiagnostics
+      while (diagnostics.nonEmpty && System.nanoTime() < deadline) {
+        Thread.sleep(1000)
+        diagnostics = client.workspaceDiagnostics
+      }
+      if (diagnostics.isEmpty) {
+        manualLog(s"diagnostics clean $label")
+      } else {
+        assertNoDiff(diagnostics, "")
+      }
+    }
+  }
 
   private def querySpecs(prefix: String, defaultFile: String): List[QuerySpec] =
     (1 to 10).flatMap { index =>

--- a/tests/unit/src/test/scala/tests/ManualSuite.scala
+++ b/tests/unit/src/test/scala/tests/ManualSuite.scala
@@ -5,6 +5,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
 import scala.sys.process.Process
 import scala.util.Try
@@ -21,6 +22,11 @@ class ManualSuite extends BaseManualSuite {
       file: String,
       query: String,
       minLocations: Int,
+  )
+  private case class DefinitionSpec(
+      file: String,
+      query: String,
+      generatedOnly: Boolean,
   )
 
   private val DefaultBspName = "Stripe Bazel"
@@ -49,56 +55,68 @@ class ManualSuite extends BaseManualSuite {
       "stripe-bsp-server",
     )
   private val workspacePath: String =
-    sys.props
-      .get("metals.manual.workspace")
-      .orElse(sys.props.get("metals.manual.zoolander"))
+    prop("metals.manual.workspace")
+      .orElse(prop("metals.manual.zoolander"))
       .getOrElse(Paths.get("/pay", "src", "zoolander").toString())
   private val bspName =
-    sys.props.getOrElse("metals.manual.bsp.name", DefaultBspName)
+    prop("metals.manual.bsp.name").getOrElse(DefaultBspName)
   private val configuredBspLauncher =
-    sys.props.get("metals.manual.bsp.launcher")
+    prop("metals.manual.bsp.launcher")
   private val bspLauncher =
     configuredBspLauncher
       .map(path => Paths.get(path))
       .getOrElse(defaultBspLauncher)
   private val syncTarget =
-    sys.props.getOrElse("metals.manual.bsp.syncTarget", DefaultSyncTarget)
+    prop("metals.manual.bsp.syncTarget").getOrElse(DefaultSyncTarget)
   private val sourcePath =
-    sys.props.getOrElse("metals.manual.source", DefaultSourcePath)
+    prop("metals.manual.source").getOrElse(DefaultSourcePath)
   private val extraOpenFiles =
     indexedProperties("metals.manual.openFile")
   private val definitionQueries =
     (1 to 5)
-      .flatMap(index => sys.props.get(s"metals.manual.definitionQuery.$index"))
+      .flatMap(index => prop(s"metals.manual.definitionQuery.$index"))
       .toList match {
       case Nil if sourcePath == DefaultSourcePath => DefaultDefinitionQueries
-      case Nil => Nil
-      case queries => queries
+      case Nil                                    => Nil
+      case queries                                => queries
+    }
+  private val definitionSpecs =
+    definitionQueries.zipWithIndex.map { case (query, offset) =>
+      val index = offset + 1
+      DefinitionSpec(
+        prop(s"metals.manual.definitionQuery.$index.file").getOrElse(sourcePath),
+        query,
+        !prop(s"metals.manual.definitionQuery.$index.generatedOnly")
+          .contains("false"),
+      )
     }
   private val referenceQueries =
     querySpecs("metals.manual.referenceQuery", sourcePath)
   private val implementationQueries =
     querySpecs("metals.manual.implementationQuery", sourcePath)
   private val bspLanguages =
-    sys.props
-      .getOrElse("metals.manual.bsp.languages", "java,scala")
+    prop("metals.manual.bsp.languages")
+      .getOrElse("java,scala")
       .split(",")
       .map(_.trim)
       .filter(_.nonEmpty)
       .toList
   private val writeBspConnection =
-    !sys.props.get("metals.manual.bsp.writeConnection").contains("false")
+    !prop("metals.manual.bsp.writeConnection").contains("false")
   private val runStripeBspSetup =
-    sys.props.get("metals.manual.stripe-bsp.codegen") match {
+    prop("metals.manual.stripe-bsp.codegen") match {
       case Some("false") => false
-      case Some("true") => true
-      case _ => configuredBspLauncher.isEmpty && writeBspConnection
+      case Some("true")  => true
+      case _             => configuredBspLauncher.isEmpty && writeBspConnection
     }
 
   override def preferredBuildServer: Option[String] = Some(bspName)
 
   override def munitIgnore: Boolean =
-    !sys.props.get("metals.manual.enabled").contains("true")
+    !prop("metals.manual.enabled").contains("true")
+
+  override def munitTimeout: Duration =
+    prop("metals.manual.timeout").map(Duration(_)).getOrElse(super.munitTimeout)
 
   override def defaultUserConfig: UserConfiguration =
     super.defaultUserConfig.copy(
@@ -179,23 +197,25 @@ class ManualSuite extends BaseManualSuite {
     assertEquals(exitCode, 0)
   }
 
-  private def openGeneratedDefinition(
+  private def openDefinition(
       server: TestingServer,
       filename: String,
       query: String,
+      generatedOnly: Boolean,
   ): Future[Unit] =
     for {
       locations <- server.definitionSubstringQuery(filename, query)
       uri = locations
         .map(_.getUri)
         .find(uri =>
-          uri.contains("bazel-out") ||
+          !generatedOnly ||
+            uri.contains("bazel-out") ||
             uri.contains("generated") ||
             !uri.startsWith(server.workspace.toURI.toString)
         )
         .getOrElse(
           fail(
-            s"Expected a generated definition for `$query`, got " +
+            s"Expected a definition for `$query`, got " +
               locations.map(_.getUri).mkString(", ")
           )
         )
@@ -213,9 +233,9 @@ class ManualSuite extends BaseManualSuite {
       _ <- Future.traverse(extraOpenFiles)(server.didOpenAndFocus)
       _ <- server.didFocus(path)
       _ = assertNoDiff(client.workspaceDiagnostics, "")
-      _ <- Future.traverse(definitionQueries) { query =>
+      _ <- Future.traverse(definitionSpecs) { spec =>
         for {
-          _ <- openGeneratedDefinition(server, path, query)
+          _ <- openDefinition(server, spec.file, spec.query, spec.generatedOnly)
           _ <- server.didFocus(path)
           _ = assertNoDiff(client.workspaceDiagnostics, "")
         } yield ()
@@ -246,17 +266,21 @@ class ManualSuite extends BaseManualSuite {
   }
 
   private def indexedProperties(prefix: String): List[String] =
-    (1 to 10).flatMap(index => sys.props.get(s"$prefix.$index")).toList
+    (1 to 10).flatMap(index => prop(s"$prefix.$index")).toList
 
   private def querySpecs(prefix: String, defaultFile: String): List[QuerySpec] =
     (1 to 10).flatMap { index =>
-      sys.props.get(s"$prefix.$index").map { query =>
-        val file = sys.props.getOrElse(s"$prefix.$index.file", defaultFile)
-        val minLocations = sys.props
-          .get(s"$prefix.$index.min")
+      prop(s"$prefix.$index").map { query =>
+        val file = prop(s"$prefix.$index.file").getOrElse(defaultFile)
+        val minLocations = prop(s"$prefix.$index.min")
           .flatMap(value => Try(value.toInt).toOption)
           .getOrElse(1)
         QuerySpec(file, query, minLocations)
       }
     }.toList
+
+  private def prop(name: String): Option[String] =
+    sys.props
+      .get(name)
+      .orElse(sys.env.get(name.replaceAll("[^A-Za-z0-9]", "_").toUpperCase))
 }

--- a/tests/unit/src/test/scala/tests/ManualSuite.scala
+++ b/tests/unit/src/test/scala/tests/ManualSuite.scala
@@ -1,19 +1,93 @@
 package tests
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.nio.file.Paths
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.sys.process.Process
 
 import scala.meta.internal.metals.Configs._
 import scala.meta.internal.metals.UserConfiguration
+import scala.meta.io.AbsolutePath
+
+import ch.epfl.scala.bsp4j.BspConnectionDetails
+import com.google.gson.Gson
 
 // Uncomment to run this test manually locally
 @munit.IgnoreSuite
 class ManualSuite extends BaseManualSuite {
-  val trino: String =
-    Paths.get(System.getProperty("user.home"), "trino").toString()
+  private val DefaultBspName = "Stripe Bazel"
+  private val DefaultSyncTarget =
+    "//src/test/java/com/stripe/log/loggingvalidation/server/rpcserver/ops/" +
+      "loggingvalidationapi:tests_auto_gen_LoggingValidationOpTest"
+  private val DefaultSourcePath =
+    "src/test/java/com/stripe/log/loggingvalidation/server/rpcserver/ops/" +
+      "RpcServerTestBase.java"
+  private val DefaultDefinitionQueries = List(
+    "DaggerRpcServerTestBase_RpcServerTestCompo@@nent.builder()",
+    "LoggingValidationApiCli@@ent loggingValidationApiClient()",
+  )
+
+  private val home = System.getProperty("user.home")
+  private val defaultBspLauncher =
+    Paths.get(
+      home,
+      "stripe",
+      "jetbrains-plugins",
+      "bsp-server",
+      "build",
+      "install",
+      "bsp-server",
+      "bin",
+      "stripe-bsp-server",
+    )
+  private val workspacePath: String =
+    sys.props
+      .get("metals.manual.workspace")
+      .orElse(sys.props.get("metals.manual.zoolander"))
+      .getOrElse(Paths.get("/pay", "src", "zoolander").toString())
+  private val bspName =
+    sys.props.getOrElse("metals.manual.bsp.name", DefaultBspName)
+  private val configuredBspLauncher =
+    sys.props.get("metals.manual.bsp.launcher")
+  private val bspLauncher =
+    configuredBspLauncher
+      .map(path => Paths.get(path))
+      .getOrElse(defaultBspLauncher)
+  private val syncTarget =
+    sys.props.getOrElse("metals.manual.bsp.syncTarget", DefaultSyncTarget)
+  private val sourcePath =
+    sys.props.getOrElse("metals.manual.source", DefaultSourcePath)
+  private val definitionQueries =
+    (1 to 5)
+      .flatMap(index => sys.props.get(s"metals.manual.definitionQuery.$index"))
+      .toList match {
+      case Nil => DefaultDefinitionQueries
+      case queries => queries
+    }
+  private val bspLanguages =
+    sys.props
+      .getOrElse("metals.manual.bsp.languages", "java,scala")
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .toList
+  private val writeBspConnection =
+    !sys.props.get("metals.manual.bsp.writeConnection").contains("false")
+  private val runStripeBspSetup =
+    sys.props.get("metals.manual.stripe-bsp.codegen") match {
+      case Some("false") => false
+      case Some("true") => true
+      case _ => configuredBspLauncher.isEmpty && writeBspConnection
+    }
+
+  override def preferredBuildServer: Option[String] = Some(bspName)
 
   override def defaultUserConfig: UserConfiguration =
     super.defaultUserConfig.copy(
-      preferredBuildServer = Some("bloop"),
+      preferredBuildServer = preferredBuildServer,
       fallbackClasspath = FallbackClasspathConfig.mbt,
       workspaceSymbolProvider = WorkspaceSymbolProviderConfig.mbt,
       javaSymbolLoader = JavaSymbolLoaderConfig.turbineClasspath,
@@ -22,31 +96,113 @@ class ManualSuite extends BaseManualSuite {
       fallbackSourcepath = FallbackSourcepathConfig.allSources,
       compilerProgress = CompilerProgressConfig.enabled,
       referenceProvider = ReferenceProviderConfig.mbt,
-      definitionProviders = DefinitionProviderConfig.protobuf,
+      definitionProviders = DefinitionProviderConfig.default,
       scalaImportsPlacement = ScalaImportsPlacementConfig.smart,
       rangeFormattingProviders = RangeFormattingProviders.scalafmt,
       javacServicesOverrides = JavacServicesOverrides.default,
       buildOnChange = false,
       buildOnFocus = false,
-      // definitionProviders = DefinitionProviderConfig(List("protobuf"))
     )
 
+  private def setupBsp(workspace: AbsolutePath): Unit = {
+    val installCommand = configuredBspLauncher
+      .map(_ => s"Install the BSP launcher at $bspLauncher.")
+      .getOrElse(
+        "Run `cd ~/stripe/jetbrains-plugins && ./gradlew :bsp-server:installDist`."
+      )
+    if (writeBspConnection || runStripeBspSetup) {
+      assert(
+        Files.isExecutable(bspLauncher),
+        s"Missing BSP launcher at $bspLauncher. $installCommand",
+      )
+    }
+
+    val bspDir = workspace.resolve(".bsp").toNIO
+    val workspacePath = workspace.toNIO.toString
+    if (writeBspConnection) {
+      Files.createDirectories(bspDir)
+      val details = new BspConnectionDetails(
+        bspName,
+        List(
+          bspLauncher.toString,
+          "--workspace",
+          workspacePath,
+          "--sync-targets",
+          syncTarget,
+        ).asJava,
+        "0.1.0",
+        "2.2.0-M2",
+        bspLanguages.asJava,
+      )
+      Files.writeString(
+        bspDir.resolve("stripe-bsp.json"),
+        new Gson().toJson(details),
+        StandardCharsets.UTF_8,
+      )
+    }
+
+    if (runStripeBspSetup) {
+      runStripeBsp(workspace, "--run-sync")
+      runStripeBsp(workspace, "--run-codegen")
+    }
+  }
+
+  private def runStripeBsp(workspace: AbsolutePath, action: String): Unit = {
+    val workspacePath = workspace.toNIO.toString
+    val exitCode =
+      Process(
+        List(
+          bspLauncher.toString,
+          "--workspace",
+          workspacePath,
+          "--sync-targets",
+          syncTarget,
+          action,
+        ),
+        workspace.toFile,
+      ).!
+    assertEquals(exitCode, 0)
+  }
+
+  private def openGeneratedDefinition(
+      server: TestingServer,
+      filename: String,
+      query: String,
+  ): Future[Unit] =
+    for {
+      locations <- server.definitionSubstringQuery(filename, query)
+      uri = locations
+        .map(_.getUri)
+        .find(uri =>
+          uri.contains("bazel-out") ||
+            uri.contains("generated") ||
+            !uri.startsWith(server.workspace.toURI.toString)
+        )
+        .getOrElse(
+          fail(
+            s"Expected a generated definition for `$query`, got " +
+              locations.map(_.getUri).mkString(", ")
+          )
+        )
+      _ <- server.didOpenAndFocus(uri)
+    } yield ()
+
   inDirectory(
-    trino
-  ).test("oss-test") { case (server, client) =>
-    val path =
-      "core/trino-main/src/main/java/io/trino/operator/join/JoinHashSupplier.java"
+    workspacePath,
+    removeIndexMbt = false,
+    onSetup = setupBsp,
+  ).test("bsp-generated-source-diagnostics") { case (server, client) =>
+    val path = sourcePath
     for {
       _ <- server.didOpenAndFocus(path)
       _ = assertNoDiff(client.workspaceDiagnostics, "")
-      _ <- server.assertDefinition(
-        path,
-        "import com.google.common.collect.Immutab@@leList;",
-        """|guava-33.5.0-jre-sources.jar!/com/google/common/collect/ImmutableList.java:65:23: definition
-           |public abstract class ImmutableList<E> extends ImmutableCollection<E>
-           |                      ^^^^^^^^^^^^^
-           |""".stripMargin,
-      )
+      _ <- Future.traverse(definitionQueries) { query =>
+        for {
+          _ <- openGeneratedDefinition(server, path, query)
+          _ <- server.didFocus(path)
+          _ = assertNoDiff(client.workspaceDiagnostics, "")
+        } yield ()
+      }
     } yield ()
   }
 }

--- a/tests/unit/src/test/scala/tests/ManualSuite.scala
+++ b/tests/unit/src/test/scala/tests/ManualSuite.scala
@@ -11,6 +11,7 @@ import scala.sys.process.Process
 import scala.util.Try
 
 import scala.meta.internal.metals.Configs._
+import scala.meta.internal.metals.MtagsResolver
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
 
@@ -145,6 +146,9 @@ class ManualSuite extends BaseManualSuite {
     prop("metals.manual.buildServerConnectionTimeout")
       .map(Duration(_))
       .getOrElse(super.buildServerConnectionTimeout)
+
+  override def mtagsResolver: MtagsResolver =
+    new TestMtagsResolver(checkCoursier = false)
 
   override def defaultUserConfig: UserConfiguration =
     super.defaultUserConfig.copy(

--- a/tests/unit/src/test/scala/tests/ManualSuite.scala
+++ b/tests/unit/src/test/scala/tests/ManualSuite.scala
@@ -7,6 +7,7 @@ import java.nio.file.Paths
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.sys.process.Process
+import scala.util.Try
 
 import scala.meta.internal.metals.Configs._
 import scala.meta.internal.metals.UserConfiguration
@@ -15,9 +16,13 @@ import scala.meta.io.AbsolutePath
 import ch.epfl.scala.bsp4j.BspConnectionDetails
 import com.google.gson.Gson
 
-// Uncomment to run this test manually locally
-@munit.IgnoreSuite
 class ManualSuite extends BaseManualSuite {
+  private case class QuerySpec(
+      file: String,
+      query: String,
+      minLocations: Int,
+  )
+
   private val DefaultBspName = "Stripe Bazel"
   private val DefaultSyncTarget =
     "//src/test/java/com/stripe/log/loggingvalidation/server/rpcserver/ops/" +
@@ -60,13 +65,20 @@ class ManualSuite extends BaseManualSuite {
     sys.props.getOrElse("metals.manual.bsp.syncTarget", DefaultSyncTarget)
   private val sourcePath =
     sys.props.getOrElse("metals.manual.source", DefaultSourcePath)
+  private val extraOpenFiles =
+    indexedProperties("metals.manual.openFile")
   private val definitionQueries =
     (1 to 5)
       .flatMap(index => sys.props.get(s"metals.manual.definitionQuery.$index"))
       .toList match {
-      case Nil => DefaultDefinitionQueries
+      case Nil if sourcePath == DefaultSourcePath => DefaultDefinitionQueries
+      case Nil => Nil
       case queries => queries
     }
+  private val referenceQueries =
+    querySpecs("metals.manual.referenceQuery", sourcePath)
+  private val implementationQueries =
+    querySpecs("metals.manual.implementationQuery", sourcePath)
   private val bspLanguages =
     sys.props
       .getOrElse("metals.manual.bsp.languages", "java,scala")
@@ -84,6 +96,9 @@ class ManualSuite extends BaseManualSuite {
     }
 
   override def preferredBuildServer: Option[String] = Some(bspName)
+
+  override def munitIgnore: Boolean =
+    !sys.props.get("metals.manual.enabled").contains("true")
 
   override def defaultUserConfig: UserConfiguration =
     super.defaultUserConfig.copy(
@@ -195,6 +210,8 @@ class ManualSuite extends BaseManualSuite {
     val path = sourcePath
     for {
       _ <- server.didOpenAndFocus(path)
+      _ <- Future.traverse(extraOpenFiles)(server.didOpenAndFocus)
+      _ <- server.didFocus(path)
       _ = assertNoDiff(client.workspaceDiagnostics, "")
       _ <- Future.traverse(definitionQueries) { query =>
         for {
@@ -203,6 +220,43 @@ class ManualSuite extends BaseManualSuite {
           _ = assertNoDiff(client.workspaceDiagnostics, "")
         } yield ()
       }
+      _ <- Future.traverse(referenceQueries) { spec =>
+        for {
+          locations <- server.referencesSubquery(spec.file, spec.query)
+          _ = assert(
+            locations.size >= spec.minLocations,
+            s"Expected at least ${spec.minLocations} references for " +
+              s"`${spec.query}` in `${spec.file}`, got ${locations.size}",
+          )
+          _ = assertNoDiff(client.workspaceDiagnostics, "")
+        } yield ()
+      }
+      _ <- Future.traverse(implementationQueries) { spec =>
+        for {
+          locations <- server.implementationsSubquery(spec.file, spec.query)
+          _ = assert(
+            locations.size >= spec.minLocations,
+            s"Expected at least ${spec.minLocations} implementations for " +
+              s"`${spec.query}` in `${spec.file}`, got ${locations.size}",
+          )
+          _ = assertNoDiff(client.workspaceDiagnostics, "")
+        } yield ()
+      }
     } yield ()
   }
+
+  private def indexedProperties(prefix: String): List[String] =
+    (1 to 10).flatMap(index => sys.props.get(s"$prefix.$index")).toList
+
+  private def querySpecs(prefix: String, defaultFile: String): List[QuerySpec] =
+    (1 to 10).flatMap { index =>
+      sys.props.get(s"$prefix.$index").map { query =>
+        val file = sys.props.getOrElse(s"$prefix.$index.file", defaultFile)
+        val minLocations = sys.props
+          .get(s"$prefix.$index.min")
+          .flatMap(value => Try(value.toInt).toOption)
+          .getOrElse(1)
+        QuerySpec(file, query, minLocations)
+      }
+    }.toList
 }


### PR DESCRIPTION
This PR replaces the old ManualSuite sample with a manual repro for BSP generated-source
  navigation and diagnostics.

  By default, it is configured for our Stripe/Zoolander setup:

  - workspace: /pay/src/zoolander
  - BSP: Stripe BSP from ~/stripe/jetbrains-plugins
  - target: LoggingValidationOpTest
  - source: RpcServerTestBase.java
  - actions: open source, jump to generated Dagger/client definitions, refocus the original
    file, assert diagnostics remain empty

  It is also property-driven so it can live in OSS Metals without being only Stripe-specific.
  Other users can override the workspace, BSP launcher/name/languages, sync target, source
  file, and definition queries with -Dmetals.manual.*, or use an existing .bsp connection.

  How We Tested

  We did not successfully run the full ManualSuite end-to-end via Metals’ sbt test runner,
  because this devbox could not resolve sbt/scalafmt dependencies from Maven Central.

  We did verify the important Stripe BSP/Zoolander pieces manually:

  - Built the local Stripe BSP distribution from ~/stripe/jetbrains-plugins.
  - Ran Stripe BSP sync and codegen against /pay/src/zoolander.
  - Confirmed the original macro target did not expose a useful graph, then switched to the
    generated test target.

  - Verified debug-graph-stats reports the generated target is exposed with a populated
    graph.

  - Verified debug-sources includes RpcServerTestBase’s target sources and generated source
    roots/files, including the Dagger generated component and generated logging validation
    client.

  - Ran git diff --check.
  - Ran a best-effort format pass using Zoolander’s prebuilt native scalafmt, but note it is
    3.10.2; Metals pins 3.10.7.