### PR TITLE
Fix test runs in mbt-bazel for BUILD files with multiple test targets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -1,6 +1,8 @@
 package scala.meta.internal.builds
 
+import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationInt
 
 import scala.meta.internal.metals.Embedded
 import scala.meta.internal.metals.JavaBinary
@@ -11,6 +13,7 @@ import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.mbt.MbtDebugLauncher
 import scala.meta.internal.metals.mbt.MbtTarget
 import scala.meta.internal.metals.mbt.importer.BazelMbtImporter
+import scala.meta.internal.metals.mbt.importer.BazelQuery
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.ScalaMainClass
@@ -130,16 +133,24 @@ case class BazelBuildTool(
       workspace: AbsolutePath,
       target: MbtTarget,
       testSuites: ScalaTestSuites,
+      sourceFiles: Seq[AbsolutePath],
   ): List[String] =
-    mbtTestExecCommand(target, testSuites, debugAgentFlag = None)
+    mbtTestExecCommand(
+      resolveTestRunTargets(workspace, target, sourceFiles),
+      target,
+      testSuites,
+      debugAgentFlag = None,
+    )
 
   override def mbtTestDebugCommand(
       workspace: AbsolutePath,
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
+      sourceFiles: Seq[AbsolutePath],
   ): List[String] =
     mbtTestExecCommand(
+      resolveTestRunTargets(workspace, target, sourceFiles),
       target,
       testSuites,
       debugAgentFlag = Some(debugAgentFlag),
@@ -151,20 +162,63 @@ case class BazelBuildTool(
       workspace: AbsolutePath,
       target: MbtTarget,
       testSuites: ScalaTestSuites,
-  ): Int => List[String] = { port =>
-    mbtTestExecCommand(
-      target,
-      testSuites,
-      debugAgentFlag = None,
-    ) ::: List(
-      "--nocache_test_results",
-      "--test_output=streamed",
-      "--test_strategy=exclusive",
-      s"--test_arg=--wrapper_script_flag=--debug=$port",
-    )
+      sourceFiles: Seq[AbsolutePath],
+  ): Int => List[String] = {
+    val resolvedRunTargets =
+      resolveTestRunTargets(workspace, target, sourceFiles)
+    (port: Int) =>
+      mbtTestExecCommand(
+        resolvedRunTargets,
+        target,
+        testSuites,
+        debugAgentFlag = None,
+      ) ::: List(
+        "--nocache_test_results",
+        "--test_output=streamed",
+        "--test_strategy=exclusive",
+        s"--test_arg=--wrapper_script_flag=--debug=$port",
+      )
   }
 
+  private def resolveTestRunTargets(
+      workspace: AbsolutePath,
+      target: MbtTarget,
+      sourceFiles: Seq[AbsolutePath],
+  ): List[String] =
+    target.configurations.toList match {
+      case Nil => List(target.name)
+      case single :: Nil => List(single)
+      case multiple =>
+        val filenames = sourceFiles.map(_.filename).distinct
+        if (filenames.isEmpty) List(multiple.head)
+        else {
+          val setExpr =
+            s"set(${multiple.flatMap(BazelQuery.quoteTarget).mkString(" ")})"
+          val queryStr = filenames
+            .map(filename => s"attr(srcs, $filename, $setExpr)")
+            .mkString(" union ")
+          val env =
+            BazelQuery.Env(projectRoot, shellRunner, userConfig().javaHome)
+          val result =
+            try
+              Await.result(
+                BazelQuery(queryStr, BazelQuery.OutputMode.Label).run(env)(ec),
+                10.seconds,
+              )
+            catch {
+              case _: java.util.concurrent.TimeoutException =>
+                scribe.warn(
+                  s"bazel-mbt: timed out resolving test targets for ${target.name}, falling back to ${multiple.head}"
+                )
+                ""
+            }
+          val resolved = result.linesIterator.filter(_.nonEmpty).toList
+          if (resolved.nonEmpty) resolved else List(multiple.head)
+        }
+    }
+
   private def mbtTestExecCommand(
+      runTargets: List[String],
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       debugAgentFlag: Option[String],
@@ -185,13 +239,9 @@ case class BazelBuildTool(
     val jvmFlagsArgs =
       jvmFlags.map(flag => s"--test_arg=--wrapper_script_flag=--jvm_flag=$flag")
     List(
-      "bazel",
-      "test",
-      "--ui_event_filters=-info,-stderr,-warning",
-      "--noshow_progress",
-      "--test_output=all",
-      bazelRunTarget(target),
-    ) ::: testFilterArgs ::: jvmFlagsArgs
+      "bazel", "test", "--ui_event_filters=-info,-stderr,-warning",
+      "--noshow_progress", "--test_output=all",
+    ) ::: runTargets ::: testFilterArgs ::: jvmFlagsArgs
   }
 
   private def bazelBuildTargets(target: MbtTarget): List[String] =

--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -1,8 +1,7 @@
 package scala.meta.internal.builds
 
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.Future
 
 import scala.meta.internal.metals.Embedded
 import scala.meta.internal.metals.JavaBinary
@@ -38,6 +37,8 @@ case class BazelBuildTool(
     with BuildServerProvider
     with VersionRecommendation
     with MbtDebugLauncher {
+
+  private implicit val executionContext: ExecutionContext = ec
 
   override def digest(workspace: AbsolutePath): Option[String] = {
     BazelDigest.current(projectRoot)
@@ -134,13 +135,10 @@ case class BazelBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-  ): List[String] =
-    mbtTestExecCommand(
-      resolveTestRunTargets(workspace, target, sourceFiles),
-      target,
-      testSuites,
-      debugAgentFlag = None,
-    )
+  ): Future[List[String]] =
+    resolveTestRunTargets(workspace, target, sourceFiles).map { runTargets =>
+      mbtTestExecCommand(runTargets, target, testSuites, debugAgentFlag = None)
+    }
 
   override def mbtTestDebugCommand(
       workspace: AbsolutePath,
@@ -148,13 +146,15 @@ case class BazelBuildTool(
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
-  ): List[String] =
-    mbtTestExecCommand(
-      resolveTestRunTargets(workspace, target, sourceFiles),
-      target,
-      testSuites,
-      debugAgentFlag = Some(debugAgentFlag),
-    )
+  ): Future[List[String]] =
+    resolveTestRunTargets(workspace, target, sourceFiles).map { runTargets =>
+      mbtTestExecCommand(
+        runTargets,
+        target,
+        testSuites,
+        debugAgentFlag = Some(debugAgentFlag),
+      )
+    }
 
   override def supportsForkedTestDebug: Boolean = true
 
@@ -163,34 +163,36 @@ case class BazelBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-  ): Int => List[String] = {
+  ): Int => Future[List[String]] = {
     val resolvedRunTargets =
       resolveTestRunTargets(workspace, target, sourceFiles)
     (port: Int) =>
-      mbtTestExecCommand(
-        resolvedRunTargets,
-        target,
-        testSuites,
-        debugAgentFlag = None,
-      ) ::: List(
-        "--nocache_test_results",
-        "--test_output=streamed",
-        "--test_strategy=exclusive",
-        s"--test_arg=--wrapper_script_flag=--debug=$port",
-      )
+      resolvedRunTargets.map { runTargets =>
+        mbtTestExecCommand(
+          runTargets,
+          target,
+          testSuites,
+          debugAgentFlag = None,
+        ) ::: List(
+          "--nocache_test_results",
+          "--test_output=streamed",
+          "--test_strategy=exclusive",
+          s"--test_arg=--wrapper_script_flag=--debug=$port",
+        )
+      }
   }
 
   private def resolveTestRunTargets(
       workspace: AbsolutePath,
       target: MbtTarget,
       sourceFiles: Seq[AbsolutePath],
-  ): List[String] =
+  ): Future[List[String]] =
     target.configurations.toList match {
-      case Nil => List(target.name)
-      case single :: Nil => List(single)
+      case Nil => Future.successful(List(target.name))
+      case single :: Nil => Future.successful(List(single))
       case multiple =>
         val filenames = sourceFiles.map(_.filename).distinct
-        if (filenames.isEmpty) List(multiple.head)
+        if (filenames.isEmpty) Future.successful(List(multiple.head))
         else {
           val setExpr =
             s"set(${multiple.flatMap(BazelQuery.quoteTarget).mkString(" ")})"
@@ -199,21 +201,18 @@ case class BazelBuildTool(
             .mkString(" union ")
           val env =
             BazelQuery.Env(projectRoot, shellRunner, userConfig().javaHome)
-          val result =
-            try
-              Await.result(
-                BazelQuery(queryStr, BazelQuery.OutputMode.Label).run(env)(ec),
-                10.seconds,
+          BazelQuery(queryStr, BazelQuery.OutputMode.Label)
+            .run(env)(ec)
+            .recover { case e =>
+              scribe.warn(
+                s"bazel-mbt: failed to resolve test targets for ${target.name}, falling back to ${multiple.head}: ${e.getMessage}"
               )
-            catch {
-              case _: java.util.concurrent.TimeoutException =>
-                scribe.warn(
-                  s"bazel-mbt: timed out resolving test targets for ${target.name}, falling back to ${multiple.head}"
-                )
-                ""
+              ""
             }
-          val resolved = result.linesIterator.filter(_.nonEmpty).toList
-          if (resolved.nonEmpty) resolved else List(multiple.head)
+            .map { result =>
+              val resolved = result.linesIterator.filter(_.nonEmpty).toList
+              if (resolved.nonEmpty) resolved else List(multiple.head)
+            }
         }
     }
 

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -254,6 +254,7 @@ case class GradleBuildTool(
       workspace: AbsolutePath,
       target: MbtTarget,
       testSuites: ScalaTestSuites,
+      sourceFiles: Seq[AbsolutePath],
   ): List[String] =
     gradleTestCommand(target, testSuites, debugAgentFlag = None)
 
@@ -262,6 +263,7 @@ case class GradleBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
+      sourceFiles: Seq[AbsolutePath],
   ): List[String] =
     gradleTestCommand(target, testSuites, Some(debugAgentFlag))
 
@@ -271,6 +273,7 @@ case class GradleBuildTool(
       workspace: AbsolutePath,
       target: MbtTarget,
       testSuites: ScalaTestSuites,
+      sourceFiles: Seq[AbsolutePath],
   ): Int => List[String] = { port =>
     val debugAgentFlag =
       s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$port"

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -5,6 +5,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.util.Properties
 
 import scala.meta.internal.metals.BuildInfo
@@ -255,8 +256,10 @@ case class GradleBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-  ): List[String] =
-    gradleTestCommand(target, testSuites, debugAgentFlag = None)
+  ): Future[List[String]] =
+    Future.successful(
+      gradleTestCommand(target, testSuites, debugAgentFlag = None)
+    )
 
   override def mbtTestDebugCommand(
       workspace: AbsolutePath,
@@ -264,8 +267,10 @@ case class GradleBuildTool(
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
-  ): List[String] =
-    gradleTestCommand(target, testSuites, Some(debugAgentFlag))
+  ): Future[List[String]] =
+    Future.successful(
+      gradleTestCommand(target, testSuites, Some(debugAgentFlag))
+    )
 
   override def supportsForkedTestDebug: Boolean = true
 
@@ -274,10 +279,12 @@ case class GradleBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-  ): Int => List[String] = { port =>
+  ): Int => Future[List[String]] = { port =>
     val debugAgentFlag =
       s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$port"
-    gradleTestCommand(target, testSuites, Some(debugAgentFlag))
+    Future.successful(
+      gradleTestCommand(target, testSuites, Some(debugAgentFlag))
+    )
   }
 
   private def gradleTestCommand(

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -4,6 +4,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.util.Properties
 
 import scala.meta.internal.metals.BuildInfo
@@ -177,11 +178,13 @@ case class MavenBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-  ): List[String] =
-    mbtTestExecCommand(
-      mbtMavenBaseCommand(workspace),
-      target,
-      testSuites,
+  ): Future[List[String]] =
+    Future.successful(
+      mbtTestExecCommand(
+        mbtMavenBaseCommand(workspace),
+        target,
+        testSuites,
+      )
     )
 
   override def mbtTestDebugCommand(
@@ -190,11 +193,10 @@ case class MavenBuildTool(
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
-  ): List[String] = {
+  ): Future[List[String]] =
     mbtTestDebugCommandWithPort(workspace, target, testSuites, sourceFiles)(
       5005
     )
-  }
 
   override def supportsForkedTestDebug: Boolean = true
 
@@ -203,16 +205,18 @@ case class MavenBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-  ): Int => List[String] = { port =>
+  ): Int => Future[List[String]] = { port =>
     // Use Surefire's forked JVM with a pre-assigned debug port.
     // This allows proper source mapping since tests run in a separate JVM.
     val debugAgentFlag =
       s"\"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$port\""
-    mbtTestExecCommand(
-      mbtMavenBaseCommand(workspace),
-      target,
-      testSuites,
-      forkedDebugAgentFlag = Some(debugAgentFlag),
+    Future.successful(
+      mbtTestExecCommand(
+        mbtMavenBaseCommand(workspace),
+        target,
+        testSuites,
+        forkedDebugAgentFlag = Some(debugAgentFlag),
+      )
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -176,6 +176,7 @@ case class MavenBuildTool(
       workspace: AbsolutePath,
       target: MbtTarget,
       testSuites: ScalaTestSuites,
+      sourceFiles: Seq[AbsolutePath],
   ): List[String] =
     mbtTestExecCommand(
       mbtMavenBaseCommand(workspace),
@@ -188,8 +189,11 @@ case class MavenBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
+      sourceFiles: Seq[AbsolutePath],
   ): List[String] = {
-    mbtTestDebugCommandWithPort(workspace, target, testSuites)(5005)
+    mbtTestDebugCommandWithPort(workspace, target, testSuites, sourceFiles)(
+      5005
+    )
   }
 
   override def supportsForkedTestDebug: Boolean = true
@@ -198,6 +202,7 @@ case class MavenBuildTool(
       workspace: AbsolutePath,
       target: MbtTarget,
       testSuites: ScalaTestSuites,
+      sourceFiles: Seq[AbsolutePath],
   ): Int => List[String] = { port =>
     // Use Surefire's forked JVM with a pre-assigned debug port.
     // This allows proper source mapping since tests run in a separate JVM.

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -209,6 +209,7 @@ class ProjectMetalsLspService(
         buildTool = buildTool,
         userJavaHome = () => userConfig.javaHome,
         workDoneProgress = workDoneProgress,
+        classToSourceFile = buildTargetClasses.sourceFileForMbtTestClass,
       )(ec)
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -125,6 +125,12 @@ final class BuildTargetClasses(
         .map(_.fullyQualifiedName)
     )
 
+  def sourceFileForMbtTestClass(
+      className: String,
+      targetId: b.BuildTargetIdentifier,
+  ): Option[AbsolutePath] =
+    index.get(targetId).flatMap(_.confirmedMbtTestClassFile.get(className))
+
   def resolveCandidateTestClass(
       name: String,
       target: Option[String],
@@ -884,6 +890,10 @@ final class BuildTargetClasses(
         // Extract and store confirmed test classes
         for ((symbol, testInfo) <- testClasses) {
           classes.testClasses.put(symbol, testInfo)
+          classes.confirmedMbtTestClassFile.put(
+            testInfo.fullyQualifiedName,
+            docPath,
+          )
         }
       }
     }
@@ -1112,6 +1122,14 @@ object BuildTargetClasses {
   final class Classes {
     val mainClasses = new TrieMap[Symbol, b.ScalaMainClass]()
     val testClasses = new TrieMap[Symbol, TestSymbolInfo]()
+
+    /**
+     * Maps fully-qualified test class name to its source file, populated when
+     * candidates are confirmed via semanticdb. Persists after confirmation so
+     * that source-file lookups remain valid.
+     */
+    val confirmedMbtTestClassFile =
+      new TrieMap[FullyQualifiedClassName, AbsolutePath]()
 
     /**
      * Candidate main classes discovered from the MBT index without semanticdb.

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/server/BuildToolDebugAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/server/BuildToolDebugAdapter.scala
@@ -1,6 +1,10 @@
 package scala.meta.internal.metals.debug.server
 
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
@@ -9,7 +13,7 @@ import ch.epfl.scala.debugadapter.CancelableFuture
 import ch.epfl.scala.debugadapter.DebuggeeListener
 
 class BuildToolDebugAdapter(
-    command: List[String],
+    command: Future[List[String]],
     workspace: AbsolutePath,
     env: Map[String, String],
     project: DebugeeProject,
@@ -18,30 +22,41 @@ class BuildToolDebugAdapter(
     extends MetalsDebuggee(project, userJavaHome) {
 
   def name: String =
-    s"${getClass.getSimpleName}(${project.name}, ${command.headOption.getOrElse("")})"
+    s"${getClass.getSimpleName}(${project.name})"
 
   def run(listener: DebuggeeListener): CancelableFuture[Unit] = {
     val logger = new Logger(listener)
-    scribe.debug(
-      s"Starting build tool debug session: ${command.mkString(" ")} (cwd=$workspace)"
-    )
-    val process = SystemProcess.run(
-      cmd = command,
-      cwd = workspace,
-      redirectErrorOutput = false,
-      env = env,
-      processOut = Some(logger.logOutput),
-      processErr = Some(logger.logError),
-    )
+    val cancelled = new AtomicBoolean(false)
+    val processRef = new AtomicReference[Option[SystemProcess]](None)
 
-    new CancelableFuture[Unit] {
-      def future = process.complete.map { code =>
+    val completeFuture: Future[Unit] = command.flatMap { cmd =>
+      scribe.debug(
+        s"Starting build tool debug session: ${cmd.mkString(" ")} (cwd=$workspace)"
+      )
+      val process = SystemProcess.run(
+        cmd = cmd,
+        cwd = workspace,
+        redirectErrorOutput = false,
+        env = env,
+        processOut = Some(logger.logOutput),
+        processErr = Some(logger.logError),
+      )
+      processRef.set(Some(process))
+      if (cancelled.get()) process.cancel
+      process.complete.map { code =>
         if (code != 0)
           throw new Exception(
-            s"build tool process exited with code $code: ${command.mkString(" ")}"
+            s"build tool process exited with code $code: ${cmd.mkString(" ")}"
           )
       }
-      def cancel(): Unit = process.cancel
+    }
+
+    new CancelableFuture[Unit] {
+      def future = completeFuture
+      def cancel(): Unit = {
+        cancelled.set(true)
+        processRef.get().foreach(_.cancel)
+      }
     }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/server/ForkedTestDebugAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/server/ForkedTestDebugAdapter.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals.debug.server
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -24,7 +25,7 @@ import ch.epfl.scala.debugadapter.DebuggeeListener
  * be captured immediately by Maven.
  */
 class ForkedTestDebugAdapter(
-    commandWithPort: Int => List[String],
+    commandWithPort: Int => Future[List[String]],
     workspace: AbsolutePath,
     env: Map[String, String],
     project: DebugeeProject,
@@ -37,50 +38,62 @@ class ForkedTestDebugAdapter(
 
   def run(listener: DebuggeeListener): CancelableFuture[Unit] = {
     val port = ForkedTestDebugAdapter.findFreePort()
-    val command = commandWithPort(port)
+    val commandFuture = commandWithPort(port)
     val logger = new Logger(listener)
     val cancelled = new AtomicBoolean(false)
+    val processRef = new AtomicReference[Option[SystemProcess]](None)
 
-    scribe.debug(
-      s"Starting forked test debug session on port $port: ${command.mkString(" ")} (cwd=$workspace)"
-    )
+    val completeFuture: Future[Unit] = commandFuture.flatMap { command =>
+      scribe.debug(
+        s"Starting forked test debug session on port $port: ${command.mkString(" ")} (cwd=$workspace)"
+      )
 
-    val process = SystemProcess.run(
-      cmd = command,
-      cwd = workspace,
-      redirectErrorOutput = false,
-      env = env,
-      processOut = Some(logger.logOutput),
-      processErr = Some(logger.logError),
-    )
+      val process = SystemProcess.run(
+        cmd = command,
+        cwd = workspace,
+        redirectErrorOutput = false,
+        env = env,
+        processOut = Some(logger.logOutput),
+        processErr = Some(logger.logError),
+      )
+      processRef.set(Some(process))
+      // If cancel() was called before the process started, cancel it now
+      if (cancelled.get()) process.cancel
 
-    // Poll for the port to become available
-    Future {
-      val address = new InetSocketAddress("127.0.0.1", port)
-      if (
-        ForkedTestDebugAdapter.waitForJdwp(port, cancelled, maxWaitMs = 120000)
-      ) {
-        // Add a small delay to ensure the debug agent is fully initialized
-        Thread.sleep(500)
-        if (!cancelled.get()) {
-          scribe.debug(s"Forked test JVM is now listening on port $port")
-          listener.onListening(address)
+      // Poll for the port to become available
+      Future {
+        val address = new InetSocketAddress("127.0.0.1", port)
+        if (
+          ForkedTestDebugAdapter.waitForJdwp(
+            port,
+            cancelled,
+            maxWaitMs = 120000,
+          )
+        ) {
+          // Add a small delay to ensure the debug agent is fully initialized
+          Thread.sleep(500)
+          if (!cancelled.get()) {
+            scribe.debug(s"Forked test JVM is now listening on port $port")
+            listener.onListening(address)
+          }
+        } else if (!cancelled.get()) {
+          scribe.error(s"Timeout waiting for forked test JVM on port $port")
         }
-      } else if (!cancelled.get()) {
-        scribe.error(s"Timeout waiting for forked test JVM on port $port")
       }
-    }
 
-    new CancelableFuture[Unit] {
-      def future = process.complete.map { code =>
+      process.complete.map { code =>
         if (code != 0)
           throw new Exception(
             s"forked test process exited with code $code: ${command.mkString(" ")}"
           )
       }
+    }
+
+    new CancelableFuture[Unit] {
+      def future = completeFuture
       def cancel(): Unit = {
         cancelled.set(true)
-        process.cancel
+        processRef.get().foreach(_.cancel)
       }
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugLauncher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugLauncher.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals.mbt
 
+import scala.concurrent.Future
 import scala.jdk.CollectionConverters.ListHasAsScala
 
 import scala.meta.internal.builds.BuildTool
@@ -35,7 +36,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-  ): List[String]
+  ): Future[List[String]]
 
   def mbtTestDebugCommand(
       workspace: AbsolutePath,
@@ -43,7 +44,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
-  ): List[String]
+  ): Future[List[String]]
 
   /**
    * Returns true if this launcher supports forked test debugging with a pre-assigned port.
@@ -60,7 +61,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-  ): Int => List[String] = { _ =>
+  ): Int => Future[List[String]] = { _ =>
     mbtTestDebugCommand(
       workspace,
       target,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugLauncher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugLauncher.scala
@@ -34,6 +34,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       workspace: AbsolutePath,
       target: MbtTarget,
       testSuites: ScalaTestSuites,
+      sourceFiles: Seq[AbsolutePath],
   ): List[String]
 
   def mbtTestDebugCommand(
@@ -41,6 +42,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
+      sourceFiles: Seq[AbsolutePath],
   ): List[String]
 
   /**
@@ -57,12 +59,14 @@ trait MbtDebugLauncher { self: BuildTool =>
       workspace: AbsolutePath,
       target: MbtTarget,
       testSuites: ScalaTestSuites,
+      sourceFiles: Seq[AbsolutePath],
   ): Int => List[String] = { _ =>
     mbtTestDebugCommand(
       workspace,
       target,
       testSuites,
       MbtDebugLauncher.DebugAgentFlag,
+      sourceFiles,
     )
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
@@ -123,26 +123,28 @@ class MbtDebugSessionStarter(
     val command =
       buildTool.mbtTestCommand(workspace, target, testSuites, sourceFiles)
     val toolName = buildTool.executableName
-    scribe.info(
-      s"MBT test session via $toolName: ${redactedCommand(command)}"
-    )
     val artifactId = {
       val parts = target.name.split(':')
       if (parts.length >= 2) parts(1) else target.name
     }
-    workDoneProgress.trackFuture(
-      s"Testing $artifactId",
-      SystemProcess
-        .run(
-          command,
-          workspace,
-          redirectErrorOutput = false,
-          env = javaHomeEnv(target),
-          processOut = Some(out),
-          processErr = Some(err),
-        )
-        .complete,
-    )
+    command.flatMap { command =>
+      scribe.info(
+        s"MBT test session via $toolName: ${redactedCommand(command)}"
+      )
+      workDoneProgress.trackFuture(
+        s"Testing $artifactId",
+        SystemProcess
+          .run(
+            command,
+            workspace,
+            redirectErrorOutput = false,
+            env = javaHomeEnv(target),
+            processOut = Some(out),
+            processErr = Some(err),
+          )
+          .complete,
+      )
+    }
   }
 
   private def launchVia(
@@ -168,7 +170,7 @@ class MbtDebugSessionStarter(
             s"MBT debug session via $toolName: ${redactedCommand(command)}"
           )
           val debuggee = new BuildToolDebugAdapter(
-            command,
+            Future.successful(command),
             workspace,
             env = javaHomeEnv(target),
             patched,
@@ -220,9 +222,11 @@ class MbtDebugSessionStarter(
                     testSuites,
                     sourceFiles,
                   )
-                scribe.info(
-                  s"MBT test debug session via $toolName (forked): ${redactedCommand(commandWithPort(0))}"
-                )
+                commandWithPort(0).foreach { command =>
+                  scribe.info(
+                    s"MBT test debug session via $toolName (forked): ${redactedCommand(command)}"
+                  )
+                }
                 new ForkedTestDebugAdapter(
                   commandWithPort,
                   workspace,
@@ -232,18 +236,20 @@ class MbtDebugSessionStarter(
                 )
               } else {
                 val debugAgentFlag = MbtDebugLauncher.DebugAgentFlag
-                val command = launcher.mbtTestDebugCommand(
+                val commandFuture = launcher.mbtTestDebugCommand(
                   workspace,
                   target,
                   testSuites,
                   debugAgentFlag,
                   sourceFiles,
                 )
-                scribe.info(
-                  s"MBT test debug session via $toolName: ${redactedCommand(command)}"
-                )
+                commandFuture.foreach { command =>
+                  scribe.info(
+                    s"MBT test debug session via $toolName: ${redactedCommand(command)}"
+                  )
+                }
                 new BuildToolDebugAdapter(
-                  command,
+                  commandFuture,
                   workspace,
                   env = javaHomeEnv(target),
                   patched,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
@@ -28,6 +28,10 @@ class MbtDebugSessionStarter(
     buildTool: MbtDebugLauncher,
     userJavaHome: () => Option[String],
     workDoneProgress: BaseWorkDoneProgress,
+    classToSourceFile: (
+        String,
+        ch.epfl.scala.bsp4j.BuildTargetIdentifier,
+    ) => Option[AbsolutePath] = (_, _) => None,
     debuggeeGracePeriodSeconds: Long = 60L,
 )(implicit ec: ExecutionContext) {
 
@@ -100,6 +104,14 @@ class MbtDebugSessionStarter(
 
   }
 
+  private def resolveSourceFiles(
+      target: MbtTarget,
+      testSuites: ScalaTestSuites,
+  ): Seq[AbsolutePath] =
+    MbtDebugLauncher
+      .listOrNil(testSuites.getSuites)
+      .flatMap(s => classToSourceFile(s.getClassName, target.id))
+
   def test(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
@@ -107,7 +119,9 @@ class MbtDebugSessionStarter(
       out: String => Unit,
       err: String => Unit,
   ): Future[Int] = {
-    val command = buildTool.mbtTestCommand(workspace, target, testSuites)
+    val sourceFiles = resolveSourceFiles(target, testSuites)
+    val command =
+      buildTool.mbtTestCommand(workspace, target, testSuites, sourceFiles)
     val toolName = buildTool.executableName
     scribe.info(
       s"MBT test session via $toolName: ${redactedCommand(command)}"
@@ -179,6 +193,7 @@ class MbtDebugSessionStarter(
   ): Future[URI] = {
     val toolName = launcher.executableName
     val cancelPromise = Promise[Unit]()
+    val sourceFiles = resolveSourceFiles(target, testSuites)
     compile(target, workspace, scribe.info(_), scribe.warn(_)).flatMap { _ =>
       debugConfigCreator.create(
         target.id,
@@ -203,6 +218,7 @@ class MbtDebugSessionStarter(
                     workspace,
                     target,
                     testSuites,
+                    sourceFiles,
                   )
                 scribe.info(
                   s"MBT test debug session via $toolName (forked): ${redactedCommand(commandWithPort(0))}"
@@ -221,6 +237,7 @@ class MbtDebugSessionStarter(
                   target,
                   testSuites,
                   debugAgentFlag,
+                  sourceFiles,
                 )
                 scribe.info(
                   s"MBT test debug session via $toolName: ${redactedCommand(command)}"

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
@@ -67,7 +67,7 @@ object BazelQuery {
         }
     }
 
-  private def quoteTarget(target: String): Option[String] =
+  def quoteTarget(target: String): Option[String] =
     if (needsQuoting(target)) {
       val hasDouble = target.contains('"')
       val hasSingle = target.contains('\'')

--- a/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
@@ -222,6 +222,94 @@ class BazelDapMbtLspSuite
     } yield assertContains(output, "FooBar")
   }
 
+  test("bazel-mbt-test-multiple-test-targets-same-build-file", maxRetry = 3) {
+    client.selectedServer = Messages.ChooseBuildServer.mbt
+    cleanWorkspace()
+
+    for {
+      _ <- initialize(
+        BazelBuildLayout(
+          multipleJavaTargetsLayout,
+          V.scala213,
+          bazelVersion,
+          List("junit:junit:4.13.2"),
+        ),
+        runAdditionalCommands = pinMaven,
+      )
+      _ <- server.headServer.connectionProvider.buildServerPromise.future
+      _ <- server.didOpen("test/FooTest.java")
+      _ <- awaitMbtTestClassDiscovery("test/FooTest.java")
+      fooDebugger <- server.startDebuggingUnresolved(
+        new DebugUnresolvedTestClassParams("test.FooTest").toJson
+      )
+      _ <- fooDebugger.initialize
+      _ <- fooDebugger.launch
+      _ <- fooDebugger.configurationDone
+      _ <- fooDebugger.shutdown
+      fooOutput <- fooDebugger.allOutput
+      _ <- server.didOpen("test/BarTest.java")
+      _ <- awaitMbtTestClassDiscovery("test/BarTest.java")
+      barDebugger <- server.startDebuggingUnresolved(
+        new DebugUnresolvedTestClassParams("test.BarTest").toJson
+      )
+      _ <- barDebugger.initialize
+      _ <- barDebugger.launch
+      _ <- barDebugger.configurationDone
+      _ <- barDebugger.shutdown
+      barOutput <- barDebugger.allOutput
+    } yield {
+      assertContains(fooOutput, "OK (1 test)")
+      assertContains(barOutput, "OK (1 test)")
+    }
+  }
+
+  private def multipleJavaTargetsLayout: String =
+    """|/.bazelproject
+       |targets:
+       |    //...
+       |
+       |/test/BUILD
+       |java_test(
+       |    name = "BarTest",
+       |    srcs = ["BarTest.java"],
+       |    test_class = "test.BarTest",
+       |    deps = ["@maven//:junit_junit"],
+       |)
+       |
+       |java_test(
+       |    name = "FooTest",
+       |    srcs = ["FooTest.java"],
+       |    test_class = "test.FooTest",
+       |    deps = ["@maven//:junit_junit"],
+       |)
+       |
+       |/test/BarTest.java
+       |package test;
+       |
+       |import org.junit.Test;
+       |import static org.junit.Assert.*;
+       |
+       |public class BarTest {
+       |  @Test
+       |  public void testAddition() {
+       |    assertEquals(4, 2 + 2);
+       |  }
+       |}
+       |
+       |/test/FooTest.java
+       |package test;
+       |
+       |import org.junit.Test;
+       |import static org.junit.Assert.*;
+       |
+       |public class FooTest {
+       |  @Test
+       |  public void testAddition() {
+       |    assertEquals(4, 2 + 2);
+       |  }
+       |}
+       |""".stripMargin
+
   private def bazelTestWorkspaceLayout: String =
     """|/.bazelproject
        |targets:

--- a/tests/unit/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/unit/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -157,6 +157,7 @@ class GradleBuildToolSuite extends BaseSuite {
           workspace,
           mbtTarget("app", gradleProjectPath = ":app"),
           testSuites,
+          Nil,
         )
 
     assertEquals(
@@ -188,6 +189,7 @@ class GradleBuildToolSuite extends BaseSuite {
           mbtTarget("app"),
           testSuites,
           "debug-agent",
+          Nil,
         )
 
     assertEquals(command.take(2), List("gradle", "--console=plain"))

--- a/tests/unit/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/unit/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -3,7 +3,9 @@ package tests
 import java.nio.file.Files
 import java.nio.file.Paths
 
+import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
 
 import scala.meta.internal.builds.GradleBuildTool
@@ -152,13 +154,16 @@ class GradleBuildToolSuite extends BaseSuite {
     )
 
     val command =
-      gradleBuildTool(workspace)
-        .mbtTestCommand(
-          workspace,
-          mbtTarget("app", gradleProjectPath = ":app"),
-          testSuites,
-          Nil,
-        )
+      Await.result(
+        gradleBuildTool(workspace)
+          .mbtTestCommand(
+            workspace,
+            mbtTarget("app", gradleProjectPath = ":app"),
+            testSuites,
+            Nil,
+          ),
+        Duration.Inf,
+      )
 
     assertEquals(
       command,
@@ -183,14 +188,17 @@ class GradleBuildToolSuite extends BaseSuite {
     )
 
     val command =
-      gradleBuildTool(workspace)
-        .mbtTestDebugCommand(
-          workspace,
-          mbtTarget("app"),
-          testSuites,
-          "debug-agent",
-          Nil,
-        )
+      Await.result(
+        gradleBuildTool(workspace)
+          .mbtTestDebugCommand(
+            workspace,
+            mbtTarget("app"),
+            testSuites,
+            "debug-agent",
+            Nil,
+          ),
+        Duration.Inf,
+      )
 
     assertEquals(command.take(2), List("gradle", "--console=plain"))
     assert(command.contains("--init-script"))


### PR DESCRIPTION
Previously, we could get a `ClassNotFound` exception when trying to invoke a test - this is because we would pick the first element from mbt.json's `configurations`, which wouldn’t necessarily correspond to the test target.
To get the actual target, we now call `bazel query attr(srcs, sourceFile1, set(configurations) union attr(srcs, sourceFile2…` to get the right `configurations` to run for each suite - if multiple configurations match one file/suite, they are all run. Actually getting the sourceFile corresponding to the suite is trickier, and source of the most of the complexity of this PR - we have to get it way back from the testDiscovery phase (we now save which file corresponds to which suite and BuildTarget to help with that).

One quirk is the fact that for multiple test suites in multiple targets, we will still call one `bazel test ... //test:FooTest //test:BarTest --test_filter=test.FooTest,test.BarTest` - it probably has to stay this way, since I believe we can only connect to one debug wrapper regardless. Hopefully the actual test library is able to filter for the right suite (although, I don't really know how to run multiple suites at once, so hopefully this is a rare case regardless)