### PR TITLE
Bsp connection factory

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -14,6 +14,7 @@ import scala.util.Try
 import scala.meta.internal.bsp.BspServers.readInBspConfig
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.metals.BuildServerConnection
+import scala.meta.internal.metals.BuildServerConnectionFactory
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ClosableOutputStream
 import scala.meta.internal.metals.Directories
@@ -191,12 +192,11 @@ final class BspServers(
         debugStarter = mbtDebugStarter(),
       )
     } else {
-      BuildServerConnection.fromSockets(
+      val connectionFactory = new BuildServerConnectionFactory(
         projectDirectory,
         bspTraceRoot,
         buildClient,
         client,
-        newConnection,
         tables.dismissedNotifications.RequestTimeout,
         tables.dismissedNotifications.ReconnectBsp,
         config,
@@ -204,7 +204,10 @@ final class BspServers(
         details.getName(),
         bspStatusOpt,
         workDoneProgress = workDoneProgress,
-      )
+      ) {
+        override def connect(): Future[SocketConnection] = newConnection()
+      }
+      connectionFactory.fromSockets()
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -94,25 +94,26 @@ final class BloopServers(
       progress: TaskProgress,
   ): Future[BuildServerConnection] = {
     progress.message = "connecting to bloop"
-    BuildServerConnection
-      .fromSockets(
-        projectRoot,
-        bspTraceRoot,
-        client,
-        languageClient,
-        () =>
-          connect(
-            projectRoot,
-            userConfiguration(),
-          ),
-        tables.dismissedNotifications.RequestTimeout,
-        tables.dismissedNotifications.ReconnectBsp,
-        serverConfig,
-        userConfiguration(),
-        name,
-        bspStatusOpt,
-        workDoneProgress = workDoneProgress,
-      )
+    val outer = this
+    val connectionFactory = new BuildServerConnectionFactory(
+      projectRoot,
+      bspTraceRoot,
+      client,
+      languageClient,
+      tables.dismissedNotifications.RequestTimeout,
+      tables.dismissedNotifications.ReconnectBsp,
+      serverConfig,
+      userConfiguration(),
+      name,
+      bspStatusOpt,
+      workDoneProgress = workDoneProgress,
+    ) {
+      override def connect(): Future[SocketConnection] =
+        outer.connect(projectRoot, userConfiguration())
+
+    }
+    connectionFactory
+      .fromSockets()
       .recover { case NonFatal(e) =>
         Try(
           // Bloop output

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -22,9 +22,6 @@ import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 import scala.util.Success
 
-import scala.meta.internal.bsp.ConnectionBspStatus
-import scala.meta.internal.bsp.ProtocolExtension
-import scala.meta.internal.bsp.sync.SyncExtension
 import scala.meta.internal.bsp.sync.SyncMode
 import scala.meta.internal.bsp.sync.WorkspaceSyncParams
 import scala.meta.internal.bsp.sync.WorkspaceSyncResult
@@ -44,23 +41,20 @@ import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j._
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import org.eclipse.lsp4j.jsonrpc.JsonRpcException
-import org.eclipse.lsp4j.jsonrpc.MessageConsumer
 import org.eclipse.lsp4j.jsonrpc.MessageIssueException
 
 /**
  * An actively running and initialized BSP connection
  */
-class BuildServerConnection private (
+class BuildServerConnection private[metals] (
     setupConnection: () => Future[
       BuildServerConnection.LauncherConnection
     ],
     initialConnection: BuildServerConnection.LauncherConnection,
     languageClient: ConfiguredLanguageClient,
-    reconnectNotification: DismissedNotifications#Notification,
     requestTimeOutNotification: DismissedNotifications#Notification,
+    reconnectNotification: DismissedNotifications#Notification,
     config: MetalsServerConfig,
     workspace: AbsolutePath,
     supportsWrappedSources: Boolean,
@@ -646,144 +640,6 @@ class BuildServerConnection private (
 
 object BuildServerConnection {
 
-  /**
-   * Establishes a new build server connection with the given input/output streams.
-   *
-   * This method is blocking, doesn't return Future[], because if the `initialize` handshake
-   * doesn't complete within a few seconds then something is wrong. We want to fail fast
-   * when initialization is not successful.
-   *
-   * @param bspTraceRoot we look for  `bspTraceRoot/.metals/.bsp.trace.json` to write down bsp trace
-   */
-  def fromSockets(
-      projectRoot: AbsolutePath,
-      bspTraceRoot: AbsolutePath,
-      localClient: MetalsBuildClient,
-      languageClient: ConfiguredLanguageClient,
-      connect: () => Future[SocketConnection],
-      requestTimeOutNotification: DismissedNotifications#Notification,
-      reconnectNotification: DismissedNotifications#Notification,
-      config: MetalsServerConfig,
-      userConfiguration: UserConfiguration,
-      serverName: String,
-      bspStatusOpt: Option[ConnectionBspStatus] = None,
-      retry: Int = 5,
-      supportsWrappedSources: Option[Boolean] = None,
-      workDoneProgress: WorkDoneProgress,
-  )(implicit
-      ec: ExecutionContextExecutorService
-  ): Future[BuildServerConnection] = {
-
-    def setupServer(): Future[LauncherConnection] = {
-      connect().map { case conn @ SocketConnection(_, output, input, _, _) =>
-        val tracePrinter = Trace.setupTracePrinter("BSP", bspTraceRoot)
-        val requestMonitorOpt =
-          bspStatusOpt.map(new RequestMonitorImpl(_, serverName))
-        val wrapper: MessageConsumer => MessageConsumer =
-          requestMonitorOpt.map(_.wrapper).getOrElse(identity)
-        val launcher =
-          new LargeLauncher.Builder[MetalsBuildServer]()
-            .traceMessages(tracePrinter.orNull)
-            .setOutput(output)
-            .setInput(input)
-            .setLocalService(localClient)
-            .setRemoteInterface(classOf[MetalsBuildServer])
-            .setExecutorService(ec)
-            .wrapMessages(wrapper(_))
-            .create()
-        val listening = launcher.startListening()
-        val server = launcher.getRemoteProxy
-        val stopListening =
-          Cancelable(() => listening.cancel(false))
-        val result =
-          try {
-            BuildServerConnection.initialize(
-              projectRoot,
-              server,
-              serverName,
-              config,
-              userConfiguration,
-            )
-          } catch {
-            case e: TimeoutException =>
-              conn.cancelables.foreach(_.cancel())
-              stopListening.cancel()
-              scribe.error("Timeout waiting for 'build/initialize' response")
-              throw e
-          }
-
-        // For Bloop we use the `workspace/buildTargets`,
-        // since the `buildTarget/compile` request with empty targets results in an error
-        val ping: () => Unit =
-          if (serverName == BloopServers.name || ScalaCli.names(serverName))
-            () => server.workspaceBuildTargets()
-          else
-            () => server.buildTargetCompile(new CompileParams(Nil.asJava))
-
-        val optServerLivenessMonitor =
-          for {
-            bspStatus <- bspStatusOpt
-            requestMonitor <- requestMonitorOpt
-          } yield new ServerLivenessMonitor(
-            requestMonitor,
-            ping,
-            config.metalsToIdleTime,
-            config.pingInterval,
-            bspStatus,
-          )
-
-        LauncherConnection(
-          conn,
-          server,
-          result.getDisplayName(),
-          stopListening,
-          result.getVersion(),
-          result.getCapabilities(),
-          optServerLivenessMonitor,
-          extractSyncModes(result),
-        )
-      }
-    }
-
-    setupServer()
-      .map { connection =>
-        new BuildServerConnection(
-          setupServer,
-          connection,
-          languageClient,
-          requestTimeOutNotification,
-          reconnectNotification,
-          config,
-          projectRoot,
-          supportsWrappedSources.getOrElse(connection.supportsWrappedSources),
-          workDoneProgress,
-        )
-      }
-      .recoverWith { case e: TimeoutException =>
-        if (retry > 0) {
-          scribe.warn(s"Retrying connection to the build server $serverName")
-          fromSockets(
-            projectRoot,
-            bspTraceRoot,
-            localClient,
-            languageClient,
-            connect,
-            requestTimeOutNotification,
-            reconnectNotification,
-            config,
-            userConfiguration,
-            serverName,
-            bspStatusOpt,
-            retry - 1,
-            supportsWrappedSources,
-            workDoneProgress,
-          )
-        } else {
-          Future.failed(e)
-        }
-      }
-  }
-
   final case class BspExtraBuildParams(
       javaSemanticdbVersion: String,
       semanticdbVersion: String,
@@ -795,100 +651,7 @@ object BuildServerConnection {
       enabledRules: Array[String]
   )
 
-  private def extractSyncModes(
-      result: InitializeBuildResult
-  ): Option[List[SyncMode]] = {
-    val gson = new Gson
-    try {
-      (Option(result.getDataKind), Option(result.getData)) match {
-        case (Some("extensions"), Some(data)) =>
-          val listType =
-            new TypeToken[java.util.List[ProtocolExtension]]() {}.getType
-          val tree = gson.toJsonTree(data)
-          val extensions: Option[java.util.List[ProtocolExtension]] = Option(
-            gson.fromJson(tree, listType)
-          )
-          extensions
-            .flatMap(_.asScala.find(_.getKind.toLowerCase == "sync"))
-            .map(ext => gson.toJsonTree(ext.getData))
-            .flatMap(ext => Option(gson.fromJson(ext, classOf[SyncExtension])))
-            .map(_.getModes.asScala.toList)
-        case _ =>
-          None
-      }
-    } catch {
-      case _: Exception =>
-        scribe.warn(
-          "Failed to parse protocol extensions from build/initialize result"
-        )
-        None
-    }
-  }
-
-  /**
-   * Run build/initialize handshake
-   */
-  private def initialize(
-      workspace: AbsolutePath,
-      server: MetalsBuildServer,
-      serverName: String,
-      config: MetalsServerConfig,
-      userConfiguration: UserConfiguration,
-  ): InitializeBuildResult = {
-    val isBazel = serverName == BazelBuildTool.bspName
-    val gson = new Gson
-    val (data, dataKind) =
-      if (isBazel)
-        (
-          gson.toJsonTree(
-            InitializeBuildData(BazelBuildTool.enabledRules(workspace).toArray)
-          ),
-          "bazel-data-kind",
-        )
-      else
-        (
-          gson.toJsonTree(
-            BspExtraBuildParams(
-              BuildInfo.javaSemanticdbVersion,
-              BuildInfo.scalametaVersion,
-              BuildInfo.supportedScalaVersions.asJava,
-              config.enableBestEffort || userConfiguration.enableBestEffort,
-            )
-          ),
-          "bloop-data-kind",
-        )
-
-    val capabilities = new BuildClientCapabilities(
-      List("scala", "java").asJava
-    )
-    capabilities.setJvmCompileClasspathReceiver(true)
-    val initializeResult = server.buildInitialize {
-      val params = new InitializeBuildParams(
-        "Metals",
-        BuildInfo.metalsVersion,
-        BuildInfo.bspVersion,
-        workspace.toURI.toString,
-        capabilities,
-      )
-
-      params.setData(data)
-      params.setDataKind(dataKind)
-      params
-    }
-    // Block on the `build/initialize` request because it should respond instantly by Bloop
-    // and we want to fail fast if the connection is not made
-    val result =
-      if (serverName == BloopServers.name) {
-        initializeResult.get(20, TimeUnit.SECONDS)
-      } else {
-        initializeResult.get(60, TimeUnit.SECONDS)
-      }
-
-    server.onBuildInitialized()
-    result
-  }
-
-  private case class LauncherConnection(
+  private[metals] case class LauncherConnection(
       socketConnection: SocketConnection,
       server: MetalsBuildServer,
       displayName: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnectionFactory.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnectionFactory.scala
@@ -1,0 +1,240 @@
+package scala.meta.internal.metals
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+import scala.concurrent.ExecutionContextExecutorService
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+import scala.meta.internal.bsp.ConnectionBspStatus
+import scala.meta.internal.bsp.ProtocolExtension
+import scala.meta.internal.bsp.sync.SyncExtension
+import scala.meta.internal.bsp.sync.SyncMode
+import scala.meta.internal.builds.BazelBuildTool
+import scala.meta.internal.metals.BuildServerConnection.BspExtraBuildParams
+import scala.meta.internal.metals.BuildServerConnection.InitializeBuildData
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
+import scala.meta.internal.metals.scalacli.ScalaCli
+import scala.meta.io.AbsolutePath
+
+import ch.epfl.scala.bsp4j.InitializeBuildResult
+import ch.epfl.scala.bsp4j._
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer
+
+abstract class BuildServerConnectionFactory(
+    projectRoot: AbsolutePath,
+    bspTraceRoot: AbsolutePath,
+    localClient: MetalsBuildClient,
+    languageClient: ConfiguredLanguageClient,
+    requestTimeOutNotification: DismissedNotifications#Notification,
+    reconnectNotification: DismissedNotifications#Notification,
+    config: MetalsServerConfig,
+    userConfiguration: UserConfiguration,
+    serverName: String,
+    bspStatusOpt: Option[ConnectionBspStatus] = None,
+    supportsWrappedSources: Option[Boolean] = None,
+    workDoneProgress: WorkDoneProgress,
+) {
+  protected def connect(): Future[SocketConnection]
+
+  def fromSockets(retry: Int = 5)(implicit
+      ec: ExecutionContextExecutorService
+  ): Future[BuildServerConnection] = {
+    setupServer()
+      .map { connection =>
+        new BuildServerConnection(
+          setupServer,
+          connection,
+          languageClient,
+          requestTimeOutNotification = requestTimeOutNotification,
+          reconnectNotification = reconnectNotification,
+          config,
+          projectRoot,
+          supportsWrappedSources.getOrElse(connection.supportsWrappedSources),
+          workDoneProgress,
+        )
+      }
+      .recoverWith { case e: TimeoutException =>
+        if (retry > 0) {
+          scribe.warn(s"Retrying connection to the build server $serverName")
+          fromSockets(retry - 1)
+        } else {
+          Future.failed(e)
+        }
+      }
+
+  }
+
+  private def setupServer()(implicit
+      ec: ExecutionContextExecutorService
+  ): Future[BuildServerConnection.LauncherConnection] = {
+    connect().map { case conn @ SocketConnection(_, output, input, _, _) =>
+      val tracePrinter = Trace.setupTracePrinter("BSP", bspTraceRoot)
+      val requestMonitorOpt =
+        bspStatusOpt.map(new RequestMonitorImpl(_, serverName))
+      val wrapper: MessageConsumer => MessageConsumer =
+        requestMonitorOpt.map(_.wrapper).getOrElse(identity)
+      val launcher =
+        new LargeLauncher.Builder[MetalsBuildServer]()
+          .traceMessages(tracePrinter.orNull)
+          .setOutput(output)
+          .setInput(input)
+          .setLocalService(localClient)
+          .setRemoteInterface(classOf[MetalsBuildServer])
+          .setExecutorService(ec)
+          .wrapMessages(wrapper(_))
+          .create()
+      val listening = launcher.startListening()
+      val server = launcher.getRemoteProxy
+      val stopListening =
+        Cancelable(() => listening.cancel(false))
+      val result =
+        try {
+          initialize(
+            projectRoot,
+            server,
+            serverName,
+            config,
+            userConfiguration,
+          )
+        } catch {
+          case NonFatal(e) =>
+            conn.cancelables.foreach(_.cancel())
+            stopListening.cancel()
+            scribe.error(
+              s"Cancelled waiting for 'build/initialize' response, cause: $e"
+            )
+            throw e
+        }
+
+      // For Bloop we use the `workspace/buildTargets`,
+      // since the `buildTarget/compile` request with empty targets results in an error
+      val ping: () => Unit =
+        if (serverName == BloopServers.name || ScalaCli.names(serverName))
+          () => server.workspaceBuildTargets()
+        else
+          () => server.buildTargetCompile(new CompileParams(Nil.asJava))
+
+      val optServerLivenessMonitor =
+        for {
+          bspStatus <- bspStatusOpt
+          requestMonitor <- requestMonitorOpt
+        } yield new ServerLivenessMonitor(
+          requestMonitor,
+          ping,
+          config.metalsToIdleTime,
+          config.pingInterval,
+          bspStatus,
+        )
+
+      BuildServerConnection.LauncherConnection(
+        conn,
+        server,
+        result.getDisplayName(),
+        stopListening,
+        result.getVersion(),
+        result.getCapabilities(),
+        optServerLivenessMonitor,
+        extractSyncModes(result),
+      )
+    }
+  }
+
+  private def extractSyncModes(
+      result: InitializeBuildResult
+  ): Option[List[SyncMode]] = {
+    val gson = new Gson
+    try {
+      (Option(result.getDataKind), Option(result.getData)) match {
+        case (Some("extensions"), Some(data)) =>
+          val listType =
+            new TypeToken[java.util.List[ProtocolExtension]]() {}.getType
+          val tree = gson.toJsonTree(data)
+          val extensions: Option[java.util.List[ProtocolExtension]] = Option(
+            gson.fromJson(tree, listType)
+          )
+          extensions
+            .flatMap(_.asScala.find(_.getKind.toLowerCase == "sync"))
+            .map(ext => gson.toJsonTree(ext.getData))
+            .flatMap(ext => Option(gson.fromJson(ext, classOf[SyncExtension])))
+            .map(_.getModes.asScala.toList)
+        case _ =>
+          None
+      }
+    } catch {
+      case _: Exception =>
+        scribe.warn(
+          "Failed to parse protocol extensions from build/initialize result"
+        )
+        None
+    }
+  }
+
+  /**
+   * Run build/initialize handshake
+   */
+  private def initialize(
+      workspace: AbsolutePath,
+      server: MetalsBuildServer,
+      serverName: String,
+      config: MetalsServerConfig,
+      userConfiguration: UserConfiguration,
+  ): InitializeBuildResult = {
+    val isBazel = serverName == BazelBuildTool.bspName
+    val gson = new Gson
+    val (data, dataKind) =
+      if (isBazel)
+        (
+          gson.toJsonTree(
+            InitializeBuildData(BazelBuildTool.enabledRules(workspace).toArray)
+          ),
+          "bazel-data-kind",
+        )
+      else
+        (
+          gson.toJsonTree(
+            BspExtraBuildParams(
+              BuildInfo.javaSemanticdbVersion,
+              BuildInfo.scalametaVersion,
+              BuildInfo.supportedScalaVersions.asJava,
+              config.enableBestEffort || userConfiguration.enableBestEffort,
+            )
+          ),
+          "bloop-data-kind",
+        )
+
+    val capabilities = new BuildClientCapabilities(
+      List("scala", "java").asJava
+    )
+    capabilities.setJvmCompileClasspathReceiver(true)
+    val initializeResult = server.buildInitialize {
+      val params = new InitializeBuildParams(
+        "Metals",
+        BuildInfo.metalsVersion,
+        BuildInfo.bspVersion,
+        workspace.toURI.toString,
+        capabilities,
+      )
+
+      params.setData(data)
+      params.setDataKind(dataKind)
+      params
+    }
+    // Block on the `build/initialize` request because it should respond instantly by Bloop
+    // and we want to fail fast if the connection is not made
+    val result =
+      if (serverName == BloopServers.name) {
+        initializeResult.get(20, TimeUnit.SECONDS)
+      } else {
+        initializeResult.get(60, TimeUnit.SECONDS)
+      }
+
+    server.onBuildInitialized()
+    result
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
@@ -25,6 +25,7 @@ import scala.util.Success
 import scala.meta.internal.bsp.ConnectionBspStatus
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.BuildServerConnection
+import scala.meta.internal.metals.BuildServerConnectionFactory
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ClosableOutputStream
 import scala.meta.internal.metals.DismissedNotifications
@@ -755,60 +756,12 @@ object MbtBuildServer {
   )(implicit
       ec: ExecutionContextExecutorService
   ): Future[BuildServerConnection] = {
-    def connect(): Future[SocketConnection] = Future.successful {
-      val clientInput = new PipedInputStream()
-      val serverOutput = new PipedOutputStream(clientInput)
-      val serverInput = new PipedInputStream()
-      val clientOutput = new PipedOutputStream(serverInput)
-      val finished = Promise[Unit]()
-      def eagerBuild() = {
-        val updatedBuild = mbtBuild()
-        if (updatedBuild.isEmpty) MbtBuild.fromWorkspace(workspace)
-        else updatedBuild
-      }
-      val server =
-        new MbtBuildServer(
-          workspace,
-          eagerBuild,
-          scalaVersionSelector,
-          debugStarter,
-        )
-      val serverLauncher = new Launcher.Builder[BuildClient]()
-        .setInput(serverInput)
-        .setOutput(serverOutput)
-        .setLocalService(server)
-        .setRemoteInterface(classOf[BuildClient])
-        .setExecutorService(ec)
-        .create()
-      server.onConnectWithClient(serverLauncher.getRemoteProxy)
-      val listening = serverLauncher.startListening()
-      Future {
-        listening.get()
-        ()
-      }.onComplete(finished.tryComplete)
-      val cancel = Cancelable { () =>
-        listening.cancel(false)
-        clientOutput.close()
-        clientInput.close()
-        serverInput.close()
-        serverOutput.close()
-        finished.trySuccess(())
-      }
-      SocketConnection(
-        name,
-        new ClosableOutputStream(clientOutput, s"$name output stream"),
-        new QuietInputStream(clientInput, s"$name input stream"),
-        List(cancel),
-        finished,
-      )
-    }
 
-    BuildServerConnection.fromSockets(
+    val connectionFactory = new BuildServerConnectionFactory(
       workspace,
       workspace,
       buildClient,
       languageClient,
-      connect,
       requestTimeOutNotification,
       reconnectNotification,
       config,
@@ -816,6 +769,58 @@ object MbtBuildServer {
       name,
       bspStatusOpt,
       workDoneProgress = workDoneProgress,
-    )
+    ) {
+
+      override def connect(): Future[SocketConnection] = Future.successful {
+        val clientInput = new PipedInputStream()
+        val serverOutput = new PipedOutputStream(clientInput)
+        val serverInput = new PipedInputStream()
+        val clientOutput = new PipedOutputStream(serverInput)
+        val finished = Promise[Unit]()
+        def eagerBuild() = {
+          val updatedBuild = mbtBuild()
+          if (updatedBuild.isEmpty) MbtBuild.fromWorkspace(workspace)
+          else updatedBuild
+        }
+        val server =
+          new MbtBuildServer(
+            workspace,
+            eagerBuild,
+            scalaVersionSelector,
+            debugStarter,
+          )
+        val serverLauncher = new Launcher.Builder[BuildClient]()
+          .setInput(serverInput)
+          .setOutput(serverOutput)
+          .setLocalService(server)
+          .setRemoteInterface(classOf[BuildClient])
+          .setExecutorService(ec)
+          .create()
+        server.onConnectWithClient(serverLauncher.getRemoteProxy)
+        val listening = serverLauncher.startListening()
+        Future {
+          listening.get()
+          ()
+        }.onComplete(finished.tryComplete)
+        val cancel = Cancelable { () =>
+          listening.cancel(false)
+          clientOutput.close()
+          clientInput.close()
+          serverInput.close()
+          serverOutput.close()
+          finished.trySuccess(())
+        }
+        SocketConnection(
+          name,
+          new ClosableOutputStream(clientOutput, s"$name output stream"),
+          new QuietInputStream(clientInput, s"$name input stream"),
+          List(cancel),
+          finished,
+        )
+      }
+
+    }
+
+    connectionFactory.fromSockets()
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -22,6 +22,7 @@ import scala.util.control.NonFatal
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.BuildServerConnection
+import scala.meta.internal.metals.BuildServerConnectionFactory
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ClosableOutputStream
 import scala.meta.internal.metals.Compilations
@@ -188,12 +189,11 @@ class ScalaCli(
 
     val nextSt = ConnectionState.Connecting(path)
     if (state.compareAndSet(ConnectionState.Empty, nextSt)) {
-      val futureConn = BuildServerConnection.fromSockets(
+      val connectionFactory = new BuildServerConnectionFactory(
         connDir,
         connDir,
         buildClient(),
         languageClient,
-        () => ScalaCli.socketConn(command, connDir),
         tables.dismissedNotifications.RequestTimeout,
         tables.dismissedNotifications.ReconnectScalaCli,
         config(),
@@ -201,9 +201,12 @@ class ScalaCli(
         "Scala CLI",
         supportsWrappedSources = Some(true),
         workDoneProgress = workDoneProgress,
-      )
+      ) {
+        override def connect(): Future[SocketConnection] =
+          ScalaCli.socketConn(command, connDir)
+      }
 
-      val f = futureConn.flatMap { conn =>
+      val f = connectionFactory.fromSockets().flatMap { conn =>
         state.set(ConnectionState.Connected(path, conn, ImportedBuild.empty))
         scribe.info(s"Connected to Scala CLI server v${conn.version}")
         importBuild()


### PR DESCRIPTION
This pull request just extracts some code from the `BuildServerConnection` companion object into a separate class. The logic is not changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-server connection setup for BSP, Bloop, MBT, and Scala CLI, which should make startup and reconnect behavior more reliable.
  * Reduced connection-related timeout issues during server initialization.
* **Refactor**
  * Consolidated build-server connection handling behind a shared path, keeping behavior consistent across supported build servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->