### PR TITLE
bugfix: Rename public symbols in MBT mode (#8495)

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -20,8 +20,10 @@ import scala.meta.io.AbsolutePath
 /**
  * Produces SemanticDBs on-demand by using the presentation compiler.
  *
- * Only used to provide navigation inside external library sources, not used to compile
- * workspace sources.
+ * Normally only used to provide navigation inside external library sources, not
+ * to compile workspace sources. The exception is MBT mode, where the build
+ * server does not emit on-disk SemanticDB for workspace sources, so we compute
+ * it interactively here as well.
  *
  * Uses persistent storage to keep track of what external source file is associated
  * with what build target (to determine classpath and compiler options).
@@ -36,6 +38,7 @@ final class InteractiveSemanticdbs(
     buffers: Buffers,
     scalaCliServers: => ScalaCliServers,
     featureFlags: FeatureFlagProvider,
+    isMbt: () => Boolean = () => false,
 ) extends Cancelable
     with Semanticdbs {
 
@@ -87,6 +90,7 @@ final class InteractiveSemanticdbs(
           doesNotBelongToBuildTarget && buffers.contains(
             source
           ) || // standalone files that are opened
+          isMbt() || // MBT build server does not emit on-disk SemanticDB
           scalaCliServers.loadedExactly(source) || // scala-cli single files
           sourceText.exists(
             _.startsWith(Shebang.shebang)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -982,18 +982,20 @@ object MetalsEnrichments
     def inString(text: String): Option[String] = {
       var i = 0
       var max = 0
-      def isNewline = text.charAt(i) == '\n'
-      while (max < range.startLine) {
+      // Guard against `text` being empty or shorter than the range expects
+      // (e.g. a stale on-disk SemanticDB document that carries no text).
+      def isNewline = i < text.length && text.charAt(i) == '\n'
+      while (max < range.startLine && i < text.length) {
         if (isNewline) max += 1
         i += 1
       }
       val start = i + range.startCharacter
-      while (max < range.endLine) {
+      while (max < range.endLine && i < text.length) {
         if (isNewline) max += 1
         i += 1
       }
       val end = i + range.endCharacter
-      if (start < text.size && end <= text.size)
+      if (max == range.endLine && start < text.size && end <= text.size)
         Some(text.substring(start, end))
       else
         None

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -501,6 +501,8 @@ abstract class MetalsLspService(
         buffers,
         scalaCli,
         featureFlags,
+        isMbt =
+          () => bspSession.exists(s => MbtBuildServer.isMbtServer(s.main.name)),
       )
     )
   }
@@ -718,6 +720,7 @@ abstract class MetalsLspService(
 
   protected val renameProvider: RenameProvider = new RenameProvider(
     referencesProvider,
+    mbtReferenceProvider,
     implementationProvider,
     symbolHierarchyOps,
     definitionProvider,
@@ -727,6 +730,7 @@ abstract class MetalsLspService(
     compilations,
     compilers,
     clientConfig,
+    () => userConfig,
     trees,
   )
 

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -19,9 +19,13 @@ import scala.meta.internal.metals.DefinitionProvider
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.PositionSyntax.XtensionPositionsScalafix
 import scala.meta.internal.metals.ReferenceProvider
+import scala.meta.internal.metals.ReferencesResult
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.TextEdits
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.mbt.MbtReferenceProvider
+import scala.meta.internal.metals.noAdjustRange
 import scala.meta.internal.parsing.Trees
 import scala.meta.internal.pc.Identifier
 import scala.meta.internal.search.SymbolHierarchyOps
@@ -57,6 +61,7 @@ import org.eclipse.lsp4j.{Range => LSPRange}
 
 final class RenameProvider(
     referenceProvider: ReferenceProvider,
+    mbtReferenceProvider: MbtReferenceProvider,
     implementationProvider: ImplementationProvider,
     symbolHierarchyOps: SymbolHierarchyOps,
     definitionProvider: DefinitionProvider,
@@ -66,10 +71,27 @@ final class RenameProvider(
     compilations: Compilations,
     compilers: Compilers,
     clientConfig: ClientConfiguration,
+    userConfig: () => UserConfiguration,
     trees: Trees,
 )(implicit executionContext: ExecutionContext, reportContext: ReportContext) {
 
   private val awaitingSave = new ConcurrentLinkedQueue[() => Future[Unit]]
+
+  /**
+   * Find references for rename. In MBT mode the standard [[ReferenceProvider]]
+   * cannot discover cross-file references for workspace sources (the build
+   * server emits no on-disk SemanticDB and per-target presentation compilers
+   * don't see sibling sources), so we delegate to the MBT reference provider,
+   * mirroring how the `textDocument/references` request is dispatched.
+   */
+  private def findReferences(
+      params: ReferenceParams,
+      findRealRange: AdjustRange = noAdjustRange,
+      includeSynthetics: Synthetic => Boolean = _ => true,
+  ): Future[List[ReferencesResult]] =
+    if (userConfig().referenceProvider.isMbt)
+      mbtReferenceProvider.references(params)
+    else referenceProvider.references(params, findRealRange, includeSynthetics)
 
   def prepareRename(
       params: TextDocumentPositionParams,
@@ -174,13 +196,29 @@ final class RenameProvider(
                     textDocument: TextDocument,
                     occ: SymbolOccurrence,
                 ): Boolean = {
-                  def realName = occ.symbol.desc.name.value
+                  val desc = occ.symbol.desc
+                  // A Java constructor occurrence sits on the class name, so its
+                  // "real name" for the purpose of this check is the class name,
+                  // not `<init>`.
+                  def realName =
+                    if (desc.isMethod && desc.name.value == "<init>")
+                      occ.symbol.owner.desc.name.value
+                    else desc.name.value
+                  // The SemanticDB document may carry no text (e.g. a stale
+                  // on-disk document, or one produced in MBT mode); fall back to
+                  // the current source so the check still runs instead of
+                  // silently treating the symbol as already renamed.
+                  val text =
+                    if (textDocument.text.nonEmpty) textDocument.text
+                    else source.toInputFromBuffers(buffers).text
                   def foundName =
                     occ.range
-                      .flatMap(rng => rng.inString(textDocument.text))
+                      .flatMap(rng => rng.inString(text))
                       .map(_.stripBackticks.stripSuffix(","))
                   val notRenamed =
-                    occ.symbol.isLocal || foundName.contains(realName)
+                    occ.symbol.isLocal || text.isEmpty || foundName.contains(
+                      realName
+                    )
                   if (!notRenamed)
                     scribe.debug(s"Expected $realName, but found $foundName")
                   notRenamed
@@ -219,19 +257,18 @@ final class RenameProvider(
                     }
                     isJava = definitionPath.isJava
                     currentReferences =
-                      referenceProvider
-                        .references(
-                          /**
-                           * isJava - in Java we can include declarations safely and we
-                           * also need to include contructors.
-                           */
-                          toReferenceParams(
-                            txtParams,
-                            includeDeclaration = isJava,
-                          ),
-                          findRealRange = AdjustRange(findRealRange(newName)),
-                          includeSynthetic,
-                        )
+                      findReferences(
+                        /**
+                         * isJava - in Java we can include declarations safely and we
+                         * also need to include contructors.
+                         */
+                        toReferenceParams(
+                          txtParams,
+                          includeDeclaration = isJava,
+                        ),
+                        findRealRange = AdjustRange(findRealRange(newName)),
+                        includeSynthetic,
+                      )
                         .map { refs =>
                           scribe.debug(s"Found ${refs.size} basic references")
                           refs.flatMap(_.locations)
@@ -457,11 +494,10 @@ final class RenameProvider(
       // no companion objects in Java files
       if loc.getUri().isScalaFilename
     } yield {
-      referenceProvider
-        .references(
-          toReferenceParams(loc, includeDeclaration = false),
-          findRealRange = AdjustRange(findRealRange(newName)),
-        )
+      findReferences(
+        toReferenceParams(loc, includeDeclaration = false),
+        findRealRange = AdjustRange(findRealRange(newName)),
+      )
         .map(_.flatMap(_.locations :+ loc))
     }
     Future.sequence(results).map(_.flatten.toSeq)
@@ -512,12 +548,11 @@ final class RenameProvider(
             implLoc <- implLocs
             locParams = toReferenceParams(implLoc, includeDeclaration = true)
           } yield {
-            referenceProvider
-              .references(
-                locParams,
-                findRealRange = AdjustRange(findRealRange(newName)),
-                includeSynthetic,
-              )
+            findReferences(
+              locParams,
+              findRealRange = AdjustRange(findRealRange(newName)),
+              includeSynthetic,
+            )
               .map(_.flatMap(_.locations))
           }
           Future.sequence(result)

--- a/tests/unit/src/test/scala/tests/MetalsEnrichmentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/MetalsEnrichmentsSuite.scala
@@ -6,10 +6,22 @@ import java.nio.file.NoSuchFileException
 import java.util.zip.ZipOutputStream
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
 
 class MetalsEnrichmentsSuite extends BaseSuite {
+
+  test("in-string-empty-text") {
+    // A stale on-disk SemanticDB may carry no text; `inString` must not throw.
+    val range = s.Range(2, 4, 2, 9)
+    assertEquals(range.inString(""), None)
+    assertEquals(range.inString("too\nshort"), None)
+    assertEquals(
+      s.Range(1, 4, 1, 9).inString("first\nhello world"),
+      Some("o wor"),
+    )
+  }
 
   test("create-directories") {
     val tmpDir = Files.createTempDirectory("metals-enrichment")

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -503,6 +503,44 @@ class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
     newName = "Renamed",
   )
 
+  // Renames started from the *declaration* of a public Java symbol (the scenario
+  // in https://github.com/scalameta/metals/issues/8495), cross-file.
+  renamed(
+    "java-public-field-from-definition",
+    """|/a/src/main/java/a/Upstream.java
+       |package a;
+       |public class Upstream {
+       |  public static String <<gree@@ting>> = "Hello";
+       |}
+       |/a/src/main/java/a/Downstream.java
+       |package a;
+       |public class Downstream {
+       |  public static void main(String[] args) {
+       |    System.out.println(Upstream.<<greeting>>);
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "salutation",
+  )
+
+  renamed(
+    "java-public-class-from-definition",
+    """|/a/src/main/java/a/Upstream.java
+       |package a;
+       |public class <<Upstr@@eam>> {
+       |  public static String greeting = "Hello";
+       |}
+       |/a/src/main/java/a/Downstream.java
+       |package a;
+       |public class Downstream {
+       |  public static void main(String[] args) {
+       |    System.out.println(<<Upstream>>.greeting);
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "Greeter",
+  )
+
   renamed(
     "compile-error",
     """|/a/src/main/scala/a/Main.scala

--- a/tests/unit/src/test/scala/tests/mbt/MbtRenameSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtRenameSuite.scala
@@ -1,0 +1,124 @@
+package tests.mbt
+
+import scala.meta.internal.metals.AutoImportBuildKind
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.mbt.MbtBuildServer
+
+import tests.BuildInfo
+import tests.MbtJsonBuilder
+
+/**
+ * Renaming a public (non-local) symbol requires SemanticDB for the workspace
+ * source file. In MBT mode the build server does not emit on-disk SemanticDB,
+ * so we rely on interactively computed SemanticDB. See issue #8495.
+ */
+class MbtRenameSuite extends BaseMbtReferenceSuite("mbt-rename") {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(
+      fallbackScalaVersion = Some(BuildInfo.scalaVersion),
+      preferredBuildServer = Some(MbtBuildServer.name),
+      automaticImportBuild = AutoImportBuildKind.All,
+    )
+
+  private val a = "src/a/Upstream.java"
+  private val b = "src/a/Downstream.java"
+
+  private val mbtJson = new MbtJsonBuilder(BuildInfo.scalaVersion)
+    .addScalaLibrary()
+    .addNamespace("a", List("src/**"))
+    .build()
+
+  private def initLayout(className: String, field: String): String =
+    s"""|/.metals/mbt.json
+        |$mbtJson
+        |/$a
+        |package a;
+        |public class $className {
+        |  public static String $field = "Hello, World!";
+        |}
+        |/$b
+        |package a;
+        |public class Downstream {
+        |  public static void main(String[] args) {
+        |    System.out.println($className.$field);
+        |  }
+        |}
+        |""".stripMargin
+
+  test("public-java-field") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(initLayout("Upstream", "greeting"))
+      _ = assertConnectedToBuildServer("MBT")
+      _ <- server.didOpen(a)
+      _ <- server.didOpen(b)
+      renamed <- server.rename(
+        a,
+        s"""|package a;
+            |public class Upstream {
+            |  public static String greeti@@ng = "Hello, World!";
+            |}
+            |""".stripMargin,
+        Set(a, b),
+        "salutation",
+      )
+      _ = assertNoDiff(
+        renamed(a),
+        """|package a;
+           |public class Upstream {
+           |  public static String salutation = "Hello, World!";
+           |}
+           |""".stripMargin,
+      )
+      _ = assertNoDiff(
+        renamed(b),
+        """|package a;
+           |public class Downstream {
+           |  public static void main(String[] args) {
+           |    System.out.println(Upstream.salutation);
+           |  }
+           |}
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("public-java-class") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(initLayout("Upstream", "greeting"))
+      _ = assertConnectedToBuildServer("MBT")
+      _ <- server.didOpen(a)
+      _ <- server.didOpen(b)
+      renamed <- server.rename(
+        a,
+        s"""|package a;
+            |public class Upstr@@eam {
+            |  public static String greeting = "Hello, World!";
+            |}
+            |""".stripMargin,
+        Set(a, b),
+        "Greeter",
+      )
+      _ = assertNoDiff(
+        renamed(a),
+        """|package a;
+           |public class Greeter {
+           |  public static String greeting = "Hello, World!";
+           |}
+           |""".stripMargin,
+      )
+      _ = assertNoDiff(
+        renamed(b),
+        """|package a;
+           |public class Downstream {
+           |  public static void main(String[] args) {
+           |    System.out.println(Greeter.greeting);
+           |  }
+           |}
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+}


### PR DESCRIPTION
In MBT mode the build server does not emit on-disk SemanticDB for workspace sources, so renaming a non-local (public) symbol failed with "The element can't be renamed": `prepareRename` could not resolve a symbol occurrence because `semanticdbs()` returned nothing for the workspace source.

- InteractiveSemanticdbs: compute SemanticDB on-demand for workspace sources when the active build server is MBT.
- RenameProvider: find references through the MBT reference provider when `referenceProvider == mbt`, mirroring the textDocument/references dispatch, so cross-file rename works (the standard ReferenceProvider can't discover cross-file references in MBT). Resolve a Java constructor occurrence's name to the owning class so renaming a class from its declaration is not rejected. Fall back to the current source text in `isNotRenamedSymbol` when the SemanticDB document carries no text.
- MetalsEnrichments.inString: guard against empty/short text so a stale on-disk SemanticDB no longer throws StringIndexOutOfBoundsException.

Tests: MbtRenameSuite (real MBT server), RenameLspSuite cases renaming a public Java field/class from their declarations cross-file, and an inString robustness unit test.