### PR TITLE
improvement: Switch to using MBT for renames

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -92,6 +92,32 @@ object MetalsEnrichments
     with AsScalaExtensions
     with MtagsEnrichments {
 
+  protected def inString(
+      text: String,
+      startLine: Int,
+      startCharacter: Int,
+      endLine: Int,
+      endCharacter: Int,
+  ): Option[String] = {
+    var i = 0
+    var max = 0
+    def isNewline = text.charAt(i) == '\n'
+    while (max < startLine) {
+      if (isNewline) max += 1
+      i += 1
+    }
+    val start = i + startCharacter
+    while (max < endLine) {
+      if (isNewline) max += 1
+      i += 1
+    }
+    val end = i + endCharacter
+    if (start < text.size && end <= text.size)
+      Some(text.substring(start, end))
+    else
+      None
+  }
+
   implicit class XtensionScanner(scanner: LegacyScanner) {
 
     import scala.meta.internal.tokenizers.LegacyToken._
@@ -980,23 +1006,13 @@ object MetalsEnrichments
 
   implicit class XtensionPositionRange(range: s.Range) {
     def inString(text: String): Option[String] = {
-      var i = 0
-      var max = 0
-      def isNewline = text.charAt(i) == '\n'
-      while (max < range.startLine) {
-        if (isNewline) max += 1
-        i += 1
-      }
-      val start = i + range.startCharacter
-      while (max < range.endLine) {
-        if (isNewline) max += 1
-        i += 1
-      }
-      val end = i + range.endCharacter
-      if (start < text.size && end <= text.size)
-        Some(text.substring(start, end))
-      else
-        None
+      MetalsEnrichments.inString(
+        text,
+        range.startLine,
+        range.startCharacter,
+        range.endLine,
+        range.endCharacter,
+      )
     }
 
     def toMeta(input: Input): Option[Position] =
@@ -1117,6 +1133,18 @@ object MetalsEnrichments
   implicit class XtensionLspRangeBsp(range: l.Range) {
     def toBsp: b.Range =
       new b.Range(range.getStart.toBsp, range.getEnd.toBsp)
+
+    def inString(text: String): Option[String] = {
+      val start = range.getStart()
+      val end = range.getEnd()
+      MetalsEnrichments.inString(
+        text,
+        start.getLine(),
+        start.getCharacter(),
+        end.getLine(),
+        end.getCharacter(),
+      )
+    }
   }
 
   implicit class XtensionScalaAction(scalaAction: b.ScalaAction) {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -92,7 +92,7 @@ object MetalsEnrichments
     with AsScalaExtensions
     with MtagsEnrichments {
 
-  protected def inString(
+  private def inString(
       text: String,
       startLine: Int,
       startCharacter: Int,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -719,9 +719,7 @@ abstract class MetalsLspService(
     )
 
   protected val renameProvider: RenameProvider = new RenameProvider(
-    referencesProvider,
-    implementationProvider,
-    symbolHierarchyOps,
+    mbtReferenceProvider,
     definitionProvider,
     folder,
     languageClient,

--- a/metals/src/main/scala/scala/meta/internal/metals/SymbolAlternatives.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SymbolAlternatives.scala
@@ -134,6 +134,19 @@ object SymbolAlternatives {
         )
       }
       symbol.value +: constructors
+    } else if (symbol.isConstructor) {
+      symbol match {
+        case GlobalSymbol(owner, Descriptor.Method("<init>", _)) =>
+          Seq(symbol.value, owner.value) ++ 0
+            .until(maxConstructors)
+            .map { i =>
+              Symbols.Global(
+                owner.value,
+                Descriptor.Method("<init>", if (i == 0) "()" else s"(+$i)"),
+              )
+            }
+            .distinct
+      }
     } else {
       // For members of Scala objects, Java sees them as members of a class.
       // Scala uses `.` for object (term) members, Java uses `#` for class (type) members.

--- a/metals/src/main/scala/scala/meta/internal/metals/SymbolAlternatives.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SymbolAlternatives.scala
@@ -119,6 +119,17 @@ class SymbolAlternatives(symbol: String, name: String) {
 
 object SymbolAlternatives {
 
+  def generateConstructors(
+      maxConstructors: Int,
+      symbol: Symbol,
+  ): IndexedSeq[String] =
+    0.until(maxConstructors).map { i =>
+      Symbols.Global(
+        symbol.value,
+        Descriptor.Method("<init>", if (i == 0) "()" else s"(+$i)"),
+      )
+    }
+
   /**
    * Expands a symbol to include alternatives for Java matching.
    * This includes:
@@ -126,26 +137,15 @@ object SymbolAlternatives {
    * - For object member symbols: class member equivalents (Java sees Scala objects as classes)
    */
   def expand(symbol: Symbol, maxConstructors: Int = 10): Seq[String] = {
-    if (symbol.isType) {
-      val constructors = 0.until(maxConstructors).map { i =>
-        Symbols.Global(
-          symbol.value,
-          Descriptor.Method("<init>", if (i == 0) "()" else s"(+$i)"),
-        )
-      }
+    val all = if (symbol.isType) {
+      val constructors = generateConstructors(maxConstructors, symbol)
       symbol.value +: constructors
     } else if (symbol.isConstructor) {
       symbol match {
         case GlobalSymbol(owner, Descriptor.Method("<init>", _)) =>
-          Seq(symbol.value, owner.value) ++ 0
-            .until(maxConstructors)
-            .map { i =>
-              Symbols.Global(
-                owner.value,
-                Descriptor.Method("<init>", if (i == 0) "()" else s"(+$i)"),
-              )
-            }
-            .distinct
+          Seq(symbol.value, owner.value) ++
+            generateConstructors(maxConstructors, symbol.owner)
+        case _ => Seq(symbol.value)
       }
     } else {
       // For members of Scala objects, Java sees them as members of a class.
@@ -153,6 +153,7 @@ object SymbolAlternatives {
       val javaAlternative = objectMemberToClassMember(symbol)
       javaAlternative.toList :+ symbol.value
     }
+    all.distinct
   }
 
   /**

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtProtobufReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtProtobufReferenceProvider.scala
@@ -248,14 +248,13 @@ final class MbtProtobufReferenceProvider(
       path: AbsolutePath,
       timer: Timer,
       requestDoc: s.TextDocument,
-      enclosingOccurrences: Seq[s.SymbolOccurrence],
+      protoSymbols: Seq[String],
       toQuerySymbols: Seq[String],
       taskProgress: TaskProgress,
       indexDocuments: Seq[AbsolutePath] => s.TextDocuments,
       token: Option[JEither[String, Integer]],
       includeDefinition: Boolean,
   ): List[ReferencesResult] = {
-    val protoSymbols = enclosingOccurrences.map(_.symbol)
     val protoJavaResult = {
       val result =
         ProtoJavaSymbolMapper.protoToJavaSymbols(path, protoSymbols, buffers)

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtReferenceProvider.scala
@@ -16,6 +16,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import scala.meta.infra.Event
 import scala.meta.infra.MonitoringClient
+import scala.meta.internal.metals.AdjustRange
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Compilers
@@ -23,6 +24,7 @@ import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ReferencesResult
 import scala.meta.internal.metals.SymbolAlternatives
+import scala.meta.internal.metals.Synthetics
 import scala.meta.internal.metals.TaskProgress
 import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.Timer
@@ -33,6 +35,7 @@ import scala.meta.internal.mtags.MD5
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.mtags.Symbol
 import scala.meta.internal.semanticdb.Scala._
+import scala.meta.internal.semanticdb.Synthetic
 import scala.meta.internal.semanticdb.TypeRef
 import scala.meta.internal.semanticdb.XtensionSemanticdbSymbolInformation
 import scala.meta.internal.{semanticdb => s}
@@ -312,6 +315,12 @@ class MbtReferenceProvider(
     this.enclosingOccurrences(requestDoc, queryRange)
   }
 
+  def textDocument(
+      path: AbsolutePath
+  ): s.TextDocument = {
+    cache.indexSingle(path)
+  }
+
   /**
    * Find all method reference occurrences within a given range.
    * Used for outgoing calls to find all methods called within a method body.
@@ -338,24 +347,31 @@ class MbtReferenceProvider(
       }
   }
 
-  def references(params: ReferenceParams): Future[List[ReferencesResult]] = {
+  def references(
+      params: ReferenceParams,
+      findRealRange: AdjustRange = noAdjustRange,
+      includeSynthetics: Synthetic => Boolean = _ => true,
+      withDefinitionfallback: Option[String] = None,
+  ): Future[List[ReferencesResult]] = {
     val timer = new Timer(time)
     val path = params.getTextDocument.getUri.toAbsolutePath
     val queryRange = params.getPosition()
     val requestDoc = cache.indexSingle(path)
-    val enclosingOccurrences = this.enclosingOccurrences(requestDoc, queryRange)
+    val semanticdbOccurrences =
+      this.enclosingOccurrences(requestDoc, queryRange).map(_.symbol)
+    val enclosingSymbols =
+      if (semanticdbOccurrences.isEmpty) withDefinitionfallback.toSeq
+      else semanticdbOccurrences
     scribe.info(
-      s"references: found ${enclosingOccurrences.length} occurrences"
+      s"references: found ${enclosingSymbols.length} occurrences"
     )
-
     // If all symbols are local, use compilers.references directly
-    val allLocal = enclosingOccurrences.forall(_.symbol.isLocal)
-
+    val allLocal = enclosingSymbols.forall(_.isLocal)
     val results =
       if (allLocal && requestDoc.language.isScala) {
         scribe.debug("references: all local, using compilers.references")
         compilers
-          .references(params, EmptyCancelToken, noAdjustRange)
+          .references(params, EmptyCancelToken, findRealRange)
       } else {
         workDoneProgress.trackProgressFuture(
           "Finding references",
@@ -365,9 +381,11 @@ class MbtReferenceProvider(
                 timer,
                 params,
                 requestDoc,
-                enclosingOccurrences,
+                enclosingSymbols,
                 taskProgress,
                 params.getContext().isIncludeDeclaration(),
+                findRealRange,
+                includeSynthetics,
               )
             },
         )
@@ -391,9 +409,11 @@ class MbtReferenceProvider(
       timer: Timer,
       params: ReferenceParams,
       requestDoc: s.TextDocument,
-      enclosingOccurrences: Seq[s.SymbolOccurrence],
+      enclosingSymbols: Seq[String],
       taskProgress: TaskProgress,
       includeDefinition: Boolean,
+      findRealRange: AdjustRange,
+      includeSynthetics: Synthetic => Boolean,
   ): List[ReferencesResult] = {
     val path = params.getTextDocument.getUri.toAbsolutePath
     val token = Option(params.getPartialResultToken())
@@ -402,9 +422,11 @@ class MbtReferenceProvider(
       path,
       token,
       requestDoc,
-      enclosingOccurrences,
+      enclosingSymbols,
       taskProgress,
       includeDefinition,
+      findRealRange,
+      includeSynthetics,
     )
   }
 
@@ -413,22 +435,25 @@ class MbtReferenceProvider(
       path: AbsolutePath,
       token: Option[JEither[String, Integer]],
       requestDoc: s.TextDocument,
-      enclosingOccurrences: Seq[s.SymbolOccurrence],
+      enclosingSymbols: Seq[String],
       taskProgress: TaskProgress,
       includeDefinition: Boolean,
+      findRealRange: AdjustRange,
+      includeSynthetics: Synthetic => Boolean,
   ): List[ReferencesResult] = {
-
-    val superMethods = for {
-      enclosing <- enclosingOccurrences
-      info <- requestDoc.symbols.find(_.symbol == enclosing.symbol).iterator
-      if info.kind.isMethod
-      canBeOverridden = info.displayName != "<init>" && !info.isFinal
-      selfSymbol =
-        if (canBeOverridden)
-          // Search for overrides of this method
-          Iterator.single(info.symbol)
-        else Iterator.empty
-      overridden <- selfSymbol ++ info.overriddenSymbols.iterator
+    val superMembers = for {
+      enclosing <- enclosingSymbols
+      info <- requestDoc.symbols.find(_.symbol == enclosing).iterator
+      isMethod = info.kind.isMethod
+      isTypeMember =
+        info.kind.isType && Symbol(info.symbol).owner.isType && !Symbol(
+          info.symbol
+        ).isToplevel
+      if isMethod || isTypeMember
+      canBeOverridden =
+        !isMethod || (info.displayName != "<init>" && !info.isFinal)
+      sym <- Option.when(canBeOverridden)(info.symbol).iterator
+      overridden <- sym +: info.overriddenSymbols
       if !ignoredSuperSymbols(overridden)
     } yield overridden
     val implementationMethods =
@@ -437,19 +462,19 @@ class MbtReferenceProvider(
         // Use maximum half of the timeout for finding implementations
         timeout.div(2),
         cache,
-        superMethods,
+        superMembers,
         path,
-      ) ++ superMethods).distinct
+      ) ++ superMembers).distinct
     val toQuerySymbols =
       if (implementationMethods.nonEmpty) implementationMethods
-      else enclosingOccurrences.map(_.symbol)
+      else enclosingSymbols
 
     if (path.isProtoFilename) {
       return protobufReferences.references(
         path,
         timer,
         requestDoc,
-        enclosingOccurrences,
+        enclosingSymbols,
         toQuerySymbols,
         taskProgress,
         cache.index,
@@ -458,8 +483,6 @@ class MbtReferenceProvider(
       )
     }
 
-    // Expand symbols to include alternatives like companion objects/classes,
-    // apply/copy params, constructor params, etc.
     val scalaMatchingOccurrence = (for {
       symbol <- toQuerySymbols.iterator
       docAlternatives = SymbolAlternatives.referenceAlternatives(
@@ -468,25 +491,40 @@ class MbtReferenceProvider(
       )
       alternative <- docAlternatives + symbol
     } yield alternative -> symbol).toMap
-
     val javaMatchingOccurrence = (for {
       symbol <- toQuerySymbols.iterator
       expanded = SymbolAlternatives.expand(Symbol(symbol))
       alternative <- expanded
     } yield alternative -> symbol).toMap
-
     val enclosingGlobalOccurrences =
       toQuerySymbols.filter(sym => sym.isGlobal)
     val candidatesList =
       if (enclosingGlobalOccurrences.nonEmpty) {
-        sortedCandidates(
+        val candidates = sortedCandidates(
           MbtPossibleReferencesParams(references = toQuerySymbols),
           path,
         )
+        // Fallback mode with no build targets
+        if (buildTargets.all.isEmpty) candidates
+        else {
+          val allowedBuildTargets =
+            buildTargets
+              .inverseSources(path)
+              .toList
+              .flatMap(
+                buildTargets.allInverseDependencies
+              )
+              .toSet
+
+          candidates.filter { candidate =>
+            buildTargets
+              .inverseSources(candidate)
+              .exists(allowedBuildTargets.contains)
+          }
+        }
       } else {
         Nil
       }
-
     val totalCandidates = candidatesList.size
     scribe.info(
       s"references: found $totalCandidates external document candidates in $timer"
@@ -495,6 +533,30 @@ class MbtReferenceProvider(
       .map(occ => occ -> Buffer.empty[l.Location])
       .toMap
     var processedCandidates = 0
+
+    def addLocation(
+        matchSymbol: String,
+        symbol: String,
+        range: s.Range,
+        doc: s.TextDocument,
+    ): Unit = {
+      val adjustedRange =
+        findRealRange(range, doc.text, symbol)
+      for {
+        realRange <- adjustedRange
+        x <- referenceResults.get(matchSymbol)
+      } {
+        val location = realRange.toLocation(doc.uri)
+        token match {
+          case Some(token) =>
+            languageClient.notifyProgress(
+              new l.ProgressParams(token, JEither.forRight(location))
+            )
+          case None =>
+            x += location
+        }
+      }
+    }
 
     def processDoc(doc: s.TextDocument): Unit = {
       for {
@@ -507,18 +569,26 @@ class MbtReferenceProvider(
         // Exclude definition occurrences for alternate symbols. For example, when
         // doing find-refs on a class symbol, we want usages of the class
         // constructor but not definitions of those constructors.
-        if occ.role.isReference || (occ.symbol == matchSymbol && includeDefinition)
-        x <- referenceResults.get(matchSymbol)
+        if !occ.role.isDefinition || includeDefinition
       } {
-        val location = range.toLocation(doc.uri)
-        token match {
-          case Some(token) =>
-            languageClient.notifyProgress(
-              new l.ProgressParams(token, JEither.forRight(location))
-            )
-          case None =>
-            x += location
-        }
+        addLocation(matchSymbol, occ.symbol, range, doc)
+      }
+
+      for {
+        synthetic <- doc.synthetics
+        if includeSynthetics(synthetic)
+        range <- synthetic.range.toList
+        matchSymbol <- {
+          val matchingOccurrence =
+            if (doc.language.isScala) scalaMatchingOccurrence
+            else javaMatchingOccurrence
+          matchingOccurrence.iterator.collectFirst {
+            case (sym, orig) if Synthetics.existsSymbol(synthetic)(_ == sym) =>
+              orig
+          }
+        }.toList
+      } {
+        addLocation(matchSymbol, matchSymbol, range, doc)
       }
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtReferenceProvider.scala
@@ -351,7 +351,7 @@ class MbtReferenceProvider(
       params: ReferenceParams,
       findRealRange: AdjustRange = noAdjustRange,
       includeSynthetics: Synthetic => Boolean = _ => true,
-      withDefinitionfallback: Option[String] = None,
+      withDefinitionFallback: Option[String] = None,
   ): Future[List[ReferencesResult]] = {
     val timer = new Timer(time)
     val path = params.getTextDocument.getUri.toAbsolutePath
@@ -360,7 +360,7 @@ class MbtReferenceProvider(
     val semanticdbOccurrences =
       this.enclosingOccurrences(requestDoc, queryRange).map(_.symbol)
     val enclosingSymbols =
-      if (semanticdbOccurrences.isEmpty) withDefinitionfallback.toSeq
+      if (semanticdbOccurrences.isEmpty) withDefinitionFallback.toSeq
       else semanticdbOccurrences
     scribe.info(
       s"references: found ${enclosingSymbols.length} occurrences"

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -9,28 +9,28 @@ import scala.meta.Importee
 import scala.meta.Tree
 import scala.meta.inputs.Input
 import scala.meta.internal.async.ConcurrentQueue
-import scala.meta.internal.implementation.ImplementationProvider
 import scala.meta.internal.metals.AdjustRange
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ClientConfiguration
 import scala.meta.internal.metals.Compilations
 import scala.meta.internal.metals.Compilers
 import scala.meta.internal.metals.DefinitionProvider
+import scala.meta.internal.metals.DefinitionResult
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.PositionSyntax.XtensionPositionsScalafix
-import scala.meta.internal.metals.ReferenceProvider
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.TextEdits
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.mbt.MbtReferenceProvider
+import scala.meta.internal.mtags.DefinitionAlternatives.GlobalSymbol
+import scala.meta.internal.mtags.Symbol
 import scala.meta.internal.parsing.Trees
 import scala.meta.internal.pc.Identifier
-import scala.meta.internal.search.SymbolHierarchyOps
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semanticdb.SelectTree
 import scala.meta.internal.semanticdb.SymbolOccurrence
 import scala.meta.internal.semanticdb.Synthetic
 import scala.meta.internal.semanticdb.TextDocument
-import scala.meta.internal.semanticdb.XtensionSemanticdbSymbolInformation
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
@@ -56,9 +56,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.{Either => LSPEither}
 import org.eclipse.lsp4j.{Range => LSPRange}
 
 final class RenameProvider(
-    referenceProvider: ReferenceProvider,
-    implementationProvider: ImplementationProvider,
-    symbolHierarchyOps: SymbolHierarchyOps,
+    mbtReferenceProvider: MbtReferenceProvider,
     definitionProvider: DefinitionProvider,
     workspace: AbsolutePath,
     client: MetalsLanguageClient,
@@ -86,17 +84,28 @@ final class RenameProvider(
           .flatMap { _ =>
             definitionProvider.definition(source, params, token).map {
               definition =>
-                val symbolOccurrence: Option[(SymbolOccurrence, TextDocument)] =
-                  definitionProvider
-                    .symbolOccurrence(source, params.getPosition)
-                    .orElse(
+                val symbolOccurrence: Option[LspOccurrence] =
+                  mbtReferenceProvider
+                    .enclosingOccurrences(params.getPosition(), source)
+                    .headOption
+                    .orElse {
                       findRenamedImportOccurrenceAtPosition(
                         source,
                         params.getPosition(),
                       )
-                    )
+                    }
+                    .map { occ =>
+                      LspOccurrence(occ.symbol, occ.range.map(_.toLsp))
+                    }
+                    .orElse {
+                      occurrenceAtDefinition(
+                        source,
+                        definition,
+                        params.getPosition(),
+                      )
+                    }
                 for {
-                  (occurence, _) <- symbolOccurrence
+                  occurence <- symbolOccurrence
                   soughtSymbols = Set(occurence.symbol) ++ companion(
                     occurence.symbol
                   )
@@ -110,7 +119,7 @@ final class RenameProvider(
                         occurence.symbol.desc.name.value,
                       ).isDefined)
                   range <- occurence.range
-                } yield range.toLsp
+                } yield range
             }
           }
       }
@@ -124,7 +133,6 @@ final class RenameProvider(
     val localRename = compilers
       .rename(params, token)
       .map(_.asScala.toList)
-
     localRename
       .filter(_.nonEmpty)
       .map(edits =>
@@ -136,205 +144,187 @@ final class RenameProvider(
         compilations
           .compilationFinished(source, compileInverseDependencies = true)
           .flatMap { _ =>
-            val definitionFuture = definitionProvider
-              .definition(source, params, token)
-            definitionFuture
-              .flatMap { definition =>
-                val textParams = new TextDocumentPositionParams(
-                  params.getTextDocument(),
-                  params.getPosition(),
-                )
-
-                lazy val definitionTextParams =
-                  definition.locations.asScala.map { l =>
-                    new TextDocumentPositionParams(
-                      new TextDocumentIdentifier(l.getUri()),
-                      l.getRange().getStart(),
-                    )
-                  }
-
-                val symbolOccurrence =
-                  definitionProvider
-                    .symbolOccurrence(source, textParams.getPosition)
-                    .orElse(
-                      findRenamedImportOccurrenceAtPosition(
-                        source,
-                        params.getPosition(),
-                      )
-                    )
-
-                val suggestedName = params.getNewName()
-                val withoutBackticks =
-                  if (suggestedName.isBackticked)
-                    suggestedName.stripBackticks
-                  else suggestedName
-                val newName = Identifier.backtickWrap(withoutBackticks)
-
-                def isNotRenamedSymbol(
-                    textDocument: TextDocument,
-                    occ: SymbolOccurrence,
-                ): Boolean = {
-                  def realName = occ.symbol.desc.name.value
-                  def foundName =
-                    occ.range
-                      .flatMap(rng => rng.inString(textDocument.text))
-                      .map(_.stripBackticks.stripSuffix(","))
-                  val notRenamed =
-                    occ.symbol.isLocal || foundName.contains(realName)
-                  if (!notRenamed)
-                    scribe.debug(s"Expected $realName, but found $foundName")
-                  notRenamed
-                }
-
-                def shouldCheckImplementation(
-                    symbol: String,
-                    path: AbsolutePath,
-                    textDocument: TextDocument,
-                ) = {
-                  lazy val isClassOrTrait = symbolHierarchyOps
-                    .defaultSymbolSearch(path, textDocument)(symbol)
-                    .exists(info => info.isTrait || info.isClass)
-                  (!symbol.desc.isType || symbol.owner.isType && !isClassOrTrait) && !(symbol.isLocal && isClassOrTrait)
-                }
-
-                val allReferences =
-                  for {
-                    (occurence, semanticDb) <- symbolOccurrence.toIterable
-                    definitionLoc <-
-                      definition.locations.asScala.headOption.toIterable
-                    definitionPath = definitionLoc.getUri().toAbsolutePath
-                    defSemanticdb <- definition.semanticdb.toIterable
-                    if canRenameSymbol(occurence.symbol, Option(newName)) &&
-                      isWorkspaceSymbol(occurence.symbol, definitionPath) &&
-                      isNotRenamedSymbol(semanticDb, occurence)
-                    parentSymbols =
-                      symbolHierarchyOps
-                        .topMethodParents(occurence.symbol, defSemanticdb)
-                    txtParams <- {
-                      if (parentSymbols.nonEmpty)
-                        parentSymbols.map(toTextParams)
-                      else if (definitionTextParams.nonEmpty)
-                        definitionTextParams
-                      else List(textParams)
-                    }
-                    isJava = definitionPath.isJava
-                    currentReferences =
-                      referenceProvider
-                        .references(
-                          /**
-                           * isJava - in Java we can include declarations safely and we
-                           * also need to include contructors.
-                           */
-                          toReferenceParams(
-                            txtParams,
-                            includeDeclaration = isJava,
-                          ),
-                          findRealRange = AdjustRange(findRealRange(newName)),
-                          includeSynthetic,
-                        )
-                        .map { refs =>
-                          scribe.debug(s"Found ${refs.size} basic references")
-                          refs.flatMap(_.locations)
-                        }
-                    definitionLocation = {
-                      if (parentSymbols.isEmpty)
-                        definition.locations.asScala
-                          .filter(_.getUri().isScalaOrJavaFilename)
-                          .map(findDefinitionRage)
-                      else parentSymbols
-                    }
-                    companionRefs = companionReferences(
-                      occurence.symbol,
-                      source,
-                      newName,
-                    )
-                    implReferences = implementations(
-                      txtParams,
-                      shouldCheckImplementation(
-                        occurence.symbol,
-                        source,
-                        semanticDb,
-                      ),
-                      newName,
-                    )
-                  } yield Future
-                    .sequence(
-                      List(implReferences, currentReferences, companionRefs)
-                    )
-                    .map(
-                      _.flatten ++ definitionLocation
-                    )
-                Future
-                  .sequence(allReferences)
-                  .map(locs =>
-                    (
-                      locs.flatten.filterNot(_.getRange().isOffset),
-                      symbolOccurrence,
-                      definition,
-                      newName,
-                    )
-                  )
-              }
-              .map {
-                case (allReferences, symbolOccurrence, definition, newName) =>
-                  def isOccurrence(fn: String => Boolean): Boolean = {
-                    symbolOccurrence.exists { case (occ, _) =>
-                      fn(occ.symbol)
-                    }
-                  }
-
-                  // If we didn't find any references then it might be a renamed symbol `import a.{ B => C }`
-                  val fallbackOccurences =
-                    if (allReferences.isEmpty)
-                      renamedImportOccurrences(source, symbolOccurrence)
-                    else allReferences
-
-                  if (fallbackOccurences.isEmpty) {
-                    scribe.debug(
-                      s"Symbol occurence was ${symbolOccurrence.map(_._1)}"
-                    )
-                    scribe.debug(s"""|The definition found was:
-                                     | - path ${definition.definition}
-                                     | - symbol ${definition.symbol}
-                                     |""".stripMargin)
-                  }
-
-                  val allChanges = for {
-                    (path, locs) <- fallbackOccurences.toList.distinct
-                      .groupBy(_.getUri().toAbsolutePath)
-                  } yield {
-                    val textEdits = for (loc <- locs) yield {
-                      textEdit(isOccurrence, loc, newName)
-                    }
-                    Seq(path -> textEdits.toList)
-                  }
-                  val fileChanges = allChanges.flatten.toMap
-                  val shouldRenameInBackground =
-                    !clientConfig
-                      .isOpenFilesOnRenameProvider() || fileChanges.keySet.size >= clientConfig
-                      .renameFileThreshold()
-                  val (openedEdits, closedEdits) =
-                    if (shouldRenameInBackground) {
-                      if (clientConfig.isOpenFilesOnRenameProvider()) {
-                        client.showMessage(
-                          fileThreshold(fileChanges.keySet.size)
-                        )
-                      }
-                      fileChanges.partition { case (path, _) =>
-                        buffers.contains(path)
-                      }
-                    } else {
-                      (fileChanges, Map.empty[AbsolutePath, List[TextEdit]])
-                    }
-
-                  awaitingSave.add(() => changeClosedFiles(closedEdits))
-
-                  val edits = documentEdits(openedEdits)
-                  val renames =
-                    fileRenames(isOccurrence, fileChanges.keySet, newName)
-                  new WorkspaceEdit((edits ++ renames).asJava)
-              }
+            workspaceRename(params, token, source)
           }
+      }
+  }
+
+  private def workspaceRename(
+      params: RenameParams,
+      token: CancelToken,
+      source: AbsolutePath,
+  ): Future[WorkspaceEdit] = {
+    val definitionFuture = definitionProvider
+      .definition(source, params, token)
+    definitionFuture
+      .flatMap { definition =>
+        val textParams = new TextDocumentPositionParams(
+          params.getTextDocument(),
+          params.getPosition(),
+        )
+
+        lazy val definitionTextParams =
+          definition.locations.asScala.map { l =>
+            new TextDocumentPositionParams(
+              new TextDocumentIdentifier(l.getUri()),
+              l.getRange().getStart(),
+            )
+          }
+        val symbolOccurrence =
+          mbtReferenceProvider
+            .enclosingOccurrences(params.getPosition(), source)
+            .headOption
+            .orElse(
+              findRenamedImportOccurrenceAtPosition(
+                source,
+                params.getPosition(),
+              )
+            )
+            .map { occ => LspOccurrence(occ.symbol, occ.range.map(_.toLsp)) }
+            .orElse(
+              occurrenceAtDefinition(source, definition, params.getPosition())
+            )
+            .toSeq
+        val suggestedName = params.getNewName()
+        val withoutBackticks =
+          if (suggestedName.isBackticked)
+            suggestedName.stripBackticks
+          else suggestedName
+        val newName = Identifier.backtickWrap(withoutBackticks)
+        def isNotRenamedSymbol(
+            text: String,
+            occ: LspOccurrence,
+        ): Boolean = {
+          def realName = occ.symbol.desc.name.value
+          def foundName =
+            occ.range
+              .flatMap { rng =>
+                rng.inString(text)
+              }
+              .map(_.stripBackticks.stripSuffix(","))
+          val notRenamed =
+            occ.symbol.isLocal || foundName.contains(realName)
+          if (!notRenamed)
+            scribe.debug(s"Expected $realName, but found $foundName")
+          notRenamed
+        }
+
+        val allReferences =
+          for {
+            occurence <- symbolOccurrence.iterator
+            text <- buffers.get(source).iterator
+            definitionLoc <-
+              definition.locations.asScala.headOption.toIterable
+            definitionPath = definitionLoc.getUri().toAbsolutePath
+            if canRenameSymbol(occurence.symbol, Option(newName)) &&
+              isWorkspaceSymbol(occurence.symbol, definitionPath) &&
+              isNotRenamedSymbol(text, occurence) || source.isJava
+            txtParams <-
+              if (definitionTextParams.nonEmpty)
+                definitionTextParams
+              else List(textParams)
+            currentReferences =
+              mbtReferenceProvider
+                .references(
+                  toReferenceParams(
+                    txtParams,
+                    includeDeclaration = true,
+                  ),
+                  findRealRange = AdjustRange(findRealRange(newName)),
+                  includeSynthetic,
+                )
+                .map { refs =>
+                  scribe.debug(s"Found ${refs.size} basic references")
+                  refs.flatMap(_.locations)
+                }
+            definitionLocation =
+              definition.locations.asScala
+                .filter(_.getUri().isScalaOrJavaFilename)
+                .map(findDefinitionRage)
+            companionRefs = companionReferences(
+              occurence.symbol,
+              source,
+              newName,
+            )
+          } yield Future
+            .sequence(
+              List(currentReferences, companionRefs)
+            )
+            .map(
+              _.flatten ++ definitionLocation
+            )
+        Future
+          .sequence(allReferences)
+          .map(locs =>
+            (
+              locs.flatten.filterNot(_.getRange().isOffset),
+              symbolOccurrence,
+              definition,
+              newName,
+            )
+          )
+      }
+      .map { case (allReferences, symbolOccurrence, definition, newName) =>
+        def isOccurrence(fn: String => Boolean): Boolean = {
+          symbolOccurrence.exists { occ =>
+            fn(occ.symbol)
+          }
+        }
+
+        // If we didn't find any references then it might be a renamed symbol `import a.{ B => C }`
+        val fallbackOccurences =
+          if (allReferences.isEmpty)
+            renamedImportOccurrences(
+              source,
+              symbolOccurrence.headOption,
+              mbtReferenceProvider.textDocument(source),
+            )
+          else allReferences
+
+        if (fallbackOccurences.isEmpty) {
+          scribe.debug(
+            s"Symbol occurence was $symbolOccurrence"
+          )
+          scribe.debug(s"""|The definition found was:
+                           | - path ${definition.definition}
+                           | - symbol ${definition.symbol}
+                           |""".stripMargin)
+        }
+
+        val allChanges = for {
+          (path, locs) <- fallbackOccurences.toList.distinct
+            .groupBy(_.getUri().toAbsolutePath)
+        } yield {
+          val textEdits = for (loc <- locs) yield {
+            textEdit(isOccurrence, loc, newName)
+          }
+          Seq(path -> textEdits.toList)
+        }
+        val fileChanges = allChanges.flatten.toMap
+        val shouldRenameInBackground =
+          !clientConfig
+            .isOpenFilesOnRenameProvider() || fileChanges.keySet.size >= clientConfig
+            .renameFileThreshold()
+        val (openedEdits, closedEdits) =
+          if (shouldRenameInBackground) {
+            if (clientConfig.isOpenFilesOnRenameProvider()) {
+              client.showMessage(
+                fileThreshold(fileChanges.keySet.size)
+              )
+            }
+            fileChanges.partition { case (path, _) =>
+              buffers.contains(path)
+            }
+          } else {
+            (fileChanges, Map.empty[AbsolutePath, List[TextEdit]])
+          }
+
+        awaitingSave.add(() => changeClosedFiles(closedEdits))
+
+        val edits = documentEdits(openedEdits)
+        val renames =
+          fileRenames(isOccurrence, fileChanges.keySet, newName)
+        new WorkspaceEdit((edits ++ renames).asJava)
       }
   }
 
@@ -370,14 +360,15 @@ final class RenameProvider(
    */
   private def renamedImportOccurrences(
       source: AbsolutePath,
-      symbolOccurrence: Option[(SymbolOccurrence, TextDocument)],
+      symbolOccurrence: Option[LspOccurrence],
+      semanticDb: TextDocument,
   ): Seq[Location] = {
     lazy val uri = source.toURI.toString()
 
     def withoutBacktick(str: String) = str.stripPrefix("`").stripSuffix("`")
     def occurrences(
         semanticDb: TextDocument,
-        occurence: SymbolOccurrence,
+        occurence: LspOccurrence,
         renameName: String,
         isSymbol: String => Boolean,
     ) = {
@@ -390,7 +381,7 @@ final class RenameProvider(
       } yield new Location(uri, rng.toLsp)
     }
     val result = for {
-      (occurence, semanticDb) <- symbolOccurrence
+      occurence <- symbolOccurrence
       soughtSymbols = Set(occurence.symbol) ++ companion(occurence.symbol)
       rename <- findRenamedImportForSymbol(
         source,
@@ -428,19 +419,56 @@ final class RenameProvider(
     fileChanges
       .find { file =>
         isOccurrence { str =>
-          str.owner.isPackage &&
-          (str.desc.isType || str.desc.isTerm) &&
-          file.toURI.toString.endsWith(s"/${str.desc.name.value}.scala")
+          val desc = constructorOwner(str)
+          val ext = if (file.isJava) "java" else "scala"
+          val name = desc.displayName
+          desc.owner.isPackage &&
+          (desc.isType || desc.isTerm) &&
+          file.toURI.toString.endsWith(s"/$name.$ext")
         }
       }
       .map { file =>
         val uri = file.toURI.toString
         val newFile =
-          uri.replaceAll("/[^/]+\\.scala$", s"/$newName.scala")
+          if (file.isJava)
+            uri.replaceAll("/[^/]+\\.java$", s"/$newName.java")
+          else
+            uri.replaceAll("/[^/]+\\.scala$", s"/$newName.scala")
         LSPEither.forRight[TextDocumentEdit, ResourceOperation](
           new RenameFile(uri, newFile)
         )
       }
+  }
+
+  /**
+   * Utility to be able to calculate a fallback symbol ooccurrence
+   */
+  private case class LspOccurrence(symbol: String, range: Option[LSPRange])
+
+  /**
+   * In case of macros semanticdb doesn't point correctly at definition.
+   */
+  private def occurrenceAtDefinition(
+      source: AbsolutePath,
+      definition: DefinitionResult,
+      pos: Position,
+  ): Option[LspOccurrence] = {
+    val all = for {
+      location <- definition.locations.asScala
+      if location.getUri().toAbsolutePath.equals(source) && location
+        .getRange()
+        .encloses(pos)
+    } yield LspOccurrence(definition.symbol, Some(location.getRange()))
+    all.headOption
+  }
+
+  private def constructorOwner(str: String): Symbol = {
+    Symbol(str) match {
+      case GlobalSymbol(clsSymbol, Descriptor.Method("<init>", _)) =>
+        clsSymbol
+      case symbol =>
+        symbol
+    }
   }
 
   private def companionReferences(
@@ -457,10 +485,11 @@ final class RenameProvider(
       // no companion objects in Java files
       if loc.getUri().isScalaFilename
     } yield {
-      referenceProvider
+      mbtReferenceProvider
         .references(
-          toReferenceParams(loc, includeDeclaration = false),
+          toReferenceParams(loc, includeDeclaration = true),
           findRealRange = AdjustRange(findRealRange(newName)),
+          withDefinitionfallback = Some(sym),
         )
         .map(_.flatMap(_.locations :+ loc))
     }
@@ -499,35 +528,6 @@ final class RenameProvider(
       .ignoreValue
   }
 
-  private def implementations(
-      textParams: TextDocumentPositionParams,
-      shouldCheckImplementation: Boolean,
-      newName: String,
-  ): Future[Seq[Location]] = {
-    if (shouldCheckImplementation) {
-      for {
-        implLocs <- implementationProvider.implementations(textParams)
-        result <- {
-          val result = for {
-            implLoc <- implLocs
-            locParams = toReferenceParams(implLoc, includeDeclaration = true)
-          } yield {
-            referenceProvider
-              .references(
-                locParams,
-                findRealRange = AdjustRange(findRealRange(newName)),
-                includeSynthetic,
-              )
-              .map(_.flatMap(_.locations))
-          }
-          Future.sequence(result)
-        }
-      } yield result.flatten
-    } else {
-      Future.successful(Nil)
-    }
-  }
-
   private def canRenameSymbol(
       symbol: String,
       newName: Option[String],
@@ -552,17 +552,14 @@ final class RenameProvider(
   private def findRenamedImportOccurrenceAtPosition(
       source: AbsolutePath,
       pos: Position,
-  ): Option[(SymbolOccurrence, TextDocument)] = {
+  ): Option[SymbolOccurrence] = {
     val renameOpt = trees.findLastEnclosingAt[Importee.Rename](source, pos)
-
     for {
       rename <- renameOpt
-      (occ, doc) <- definitionProvider.symbolOccurrence(
-        source,
-        rename.name.pos.toLsp.getStart(),
-      )
-
-    } yield (occ.copy(range = Some(rename.rename.pos.toSemanticdb)), doc)
+      occ <- mbtReferenceProvider
+        .enclosingOccurrences(rename.name.pos.toLsp.getStart(), source)
+        .headOption
+    } yield (occ.copy(range = Some(rename.rename.pos.toSemanticdb)))
   }
 
   private def findRenamedImportForSymbol(
@@ -572,9 +569,10 @@ final class RenameProvider(
   ): Option[Importee.Rename] = {
     // make sure it's not just a rename with the same base name
     def isCorrectSymbolOcccurrence(rename: Importee.Rename) = {
-      definitionProvider
-        .symbolOccurrence(source, rename.name.pos.toLsp.getStart())
-        .exists { case (occ, _) => isSymbol(occ.symbol) }
+      mbtReferenceProvider
+        .enclosingOccurrences(rename.name.pos.toLsp.getStart(), source)
+        .headOption
+        .exists { occ => isSymbol(occ.symbol) }
     }
     def findRename(tree: Tree): Option[Importee.Rename] = {
       tree match {
@@ -625,7 +623,9 @@ final class RenameProvider(
       symbol: String,
   ): Option[s.Range] = {
     val name = range.inString(text)
-    lazy val nameString = symbol.desc.name.toString()
+    lazy val owner = constructorOwner(symbol)
+    lazy val nameString = owner.displayName
+
     val isExplicitVarSetter =
       name.exists(nm => nm.endsWith("_=") || nm.endsWith("_=`"))
     val isBackticked = name.exists(_.isBackticked)
@@ -644,7 +644,6 @@ final class RenameProvider(
       if (symbolName == "apply" || symbolName == "unapply")
         Some(symbol.owner).filter(_ != Symbols.None).map(_.desc.name.toString())
       else None
-
     if (
       symbol.isLocal || realName
         .contains(symbolName) || alternativeName.exists(realName.contains)
@@ -691,9 +690,9 @@ final class RenameProvider(
       val textParams = new TextDocumentPositionParams
       textParams.setPosition(loc.getRange().getStart())
       val isImplicitApply =
-        definitionProvider
-          .symbolOccurrence(locSource, textParams.getPosition)
-          .exists(_._1.symbol.desc.name.value != "apply")
+        mbtReferenceProvider
+          .enclosingOccurrences(textParams.getPosition(), locSource)
+          .exists { occ => occ.symbol.desc.name.value != "apply" }
       if (isImplicitApply) {
         val range = loc.getRange()
         range.setStart(range.getEnd())
@@ -744,13 +743,6 @@ final class RenameProvider(
       params.getTextDocument(),
       params.getPosition(),
       includeDeclaration,
-    )
-  }
-
-  private def toTextParams(location: Location): TextDocumentPositionParams = {
-    new TextDocumentPositionParams(
-      new TextDocumentIdentifier(location.getUri()),
-      location.getRange().getStart(),
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -489,7 +489,7 @@ final class RenameProvider(
         .references(
           toReferenceParams(loc, includeDeclaration = true),
           findRealRange = AdjustRange(findRealRange(newName)),
-          withDefinitionfallback = Some(sym),
+          withDefinitionFallback = Some(sym),
         )
         .map(_.flatMap(_.locations :+ loc))
     }

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaRenameProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaRenameProvider.scala
@@ -49,7 +49,6 @@ class JavaRenameProvider(
         val trees = Trees.instance(compile.task)
         val element = trees.getElement(treePath)
 
-        // TODO also make sure that it's a local symbol
         def atIdentifier = compiler.isAtIdentifier(
           treePath,
           element,
@@ -58,7 +57,7 @@ class JavaRenameProvider(
           trees,
           compile.cu
         )
-        if (element != null && canRenameSymbol(element) && atIdentifier) {
+        if (element != null && atIdentifier) {
           val sourcePositions = trees.getSourcePositions()
           val start =
             sourcePositions.getStartPosition(compile.cu, treePath.getLeaf())

--- a/tests/javapc/src/test/scala/rename/JavaRenameSuite.scala
+++ b/tests/javapc/src/test/scala/rename/JavaRenameSuite.scala
@@ -155,7 +155,7 @@ class JavaRenameSuite extends BaseJavaPCSuite with RangeReplace {
        |    }
        |
        |    public static void main(String args[]){
-       |      fo@@o();
+       |      <<fo@@o>>();
        |    }
        |}
        |""".stripMargin,

--- a/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
@@ -11,7 +11,8 @@ abstract class BaseRenameLspSuite(name: String) extends BaseLspSuite(name) {
 
   protected def libraryDependencies: List[String] = Nil
   protected def compilerPlugins: List[String] = Nil
-
+  protected def defaultMbtJson: String = "{}"
+  protected def useMbt: Boolean = false
   def same(
       name: String,
       input: String,
@@ -87,9 +88,15 @@ abstract class BaseRenameLspSuite(name: String) extends BaseLspSuite(name) {
       val fullInput = input.replaceAll(allMarkersRegex, "")
       for {
         _ <- initialize(
-          s"""/metals.json
-             |${metalsJson.getOrElse(defaultMetalsJson(scalaVersion))}
-             |$fullInput""".stripMargin
+          if (useMbt) {
+            s"""|/.metals/mbt.json
+                |${metalsJson.getOrElse(defaultMbtJson)}
+                |$fullInput""".stripMargin
+          } else {
+            s"""/metals.json
+               |${metalsJson.getOrElse(defaultMetalsJson(scalaVersion))}
+               |$fullInput""".stripMargin
+          }
         )
         _ <- Future.sequence {
           openedFiles.map { file => server.didOpen(file) }

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -481,6 +481,8 @@ class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
        |}
        |""".stripMargin,
     newName = "Renamed",
+    fileRenames =
+      Map("a/src/main/java/a/Other.java" -> "a/src/main/java/a/Renamed.java"),
   )
 
   renamed(
@@ -501,6 +503,8 @@ class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
        |}
        |""".stripMargin,
     newName = "Renamed",
+    fileRenames =
+      Map("a/src/main/java/a/Other.java" -> "a/src/main/java/a/Renamed.java"),
   )
 
   renamed(

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -2,7 +2,7 @@ package tests
 
 import scala.meta.internal.metals.InitializationOptions
 
-class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
+class RenameLspSuite extends BaseRenameLspSuite("rename") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(TestingServer.TestDefault)

--- a/tests/unit/src/test/scala/tests/mbt/MbtReferenceSpec.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtReferenceSpec.scala
@@ -220,15 +220,36 @@ abstract class MbtReferenceSpec extends BaseMbtReferenceSuite("mbt-reference") {
            |a/src/main/scala/a/Upstream.java:2:14: reference
            |public class Upstream {
            |             ^^^^^^^^
+           |a/src/main/scala/a/Upstream.java:3:10: reference
+           |  public Upstream(int i) { }
+           |         ^^^^^^^^
+           |a/src/main/scala/a/Upstream.java:4:10: reference
+           |  public Upstream(int i, int j) { }
+           |         ^^^^^^^^
            |""".stripMargin,
       )
       // references on a constructor show exact usages of that overload
       _ <- server.assertReferencesSubquery(
         a,
         "public Up@@stream(int i, int j)",
-        """|a/src/main/scala/a/Downstream.java:5:9: reference
+        """|a/src/main/scala/a/Downstream.java:4:5: reference
+           |    Upstream a = new Upstream(1);
+           |    ^^^^^^^^
+           |a/src/main/scala/a/Downstream.java:4:22: reference
+           |    Upstream a = new Upstream(1);
+           |                     ^^^^^^^^
+           |a/src/main/scala/a/Downstream.java:5:9: reference
            |    new Upstream(1, 2);
            |        ^^^^^^^^
+           |a/src/main/scala/a/Downstream.java:6:9: reference
+           |    new Upstream.Upstream2().magic();
+           |        ^^^^^^^^
+           |a/src/main/scala/a/Upstream.java:2:14: reference
+           |public class Upstream {
+           |             ^^^^^^^^
+           |a/src/main/scala/a/Upstream.java:3:10: reference
+           |  public Upstream(int i) { }
+           |         ^^^^^^^^
            |a/src/main/scala/a/Upstream.java:4:10: reference
            |  public Upstream(int i, int j) { }
            |         ^^^^^^^^
@@ -561,13 +582,19 @@ abstract class MbtReferenceSpec extends BaseMbtReferenceSuite("mbt-reference") {
       _ <- server.assertReferencesSubquery(
         b,
         "class Do@@g",
-        """|a/src/main/scala/a/Mammal.java:4:23: reference
-           |  public static class Dog extends Mammal { @Override public String color() { return "brown" } }
-           |                      ^^^
-           |b/src/main/scala/b/Zoo.java:3:45: reference
-           |public class DogZoo implements Zoo<a.Mammal.Dog> {}
-           |                                            ^^^
-           |""".stripMargin,
+        if (withMbt)
+          """|a/src/main/scala/a/Mammal.java:4:23: reference
+             |  public static class Dog extends Mammal { @Override public String color() { return "brown" } }
+             |                      ^^^
+             |b/src/main/scala/b/Zoo.java:3:45: reference
+             |public class DogZoo implements Zoo<a.Mammal.Dog> {}
+             |                                            ^^^
+             |""".stripMargin
+        else
+          """|a/src/main/scala/a/Mammal.java:4:23: reference
+             |  public static class Dog extends Mammal { @Override public String color() { return "brown" } }
+             |                      ^^^
+             |""".stripMargin,
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/mbt/MbtRenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtRenameLspSuite.scala
@@ -11,7 +11,7 @@ import tests.BaseRenameLspSuite
 import tests.BuildInfo
 import tests.TestingServer
 
-class MbtRenameLspSuite extends BaseRenameLspSuite(s"rename") {
+class MbtRenameLspSuite extends BaseRenameLspSuite("mbt-rename") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(TestingServer.TestDefault)

--- a/tests/unit/src/test/scala/tests/mbt/MbtRenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtRenameLspSuite.scala
@@ -1,0 +1,110 @@
+package tests.mbt
+
+import scala.meta.internal.metals.AutoImportBuildKind
+import scala.meta.internal.metals.Configs.ReferenceProviderConfig
+import scala.meta.internal.metals.Configs.WorkspaceSymbolProviderConfig
+import scala.meta.internal.metals.InitializationOptions
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.mbt.MbtBuildServer
+
+import tests.BaseRenameLspSuite
+import tests.BuildInfo
+import tests.TestingServer
+
+class MbtRenameLspSuite extends BaseRenameLspSuite(s"rename") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(TestingServer.TestDefault)
+
+  override def initializeGitRepo: Boolean = true
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(
+      fallbackScalaVersion = Some(BuildInfo.scalaVersion),
+      workspaceSymbolProvider = WorkspaceSymbolProviderConfig.mbt,
+      referenceProvider = ReferenceProviderConfig.mbt,
+      preferredBuildServer = Some(MbtBuildServer.name),
+      automaticImportBuild = AutoImportBuildKind.All,
+    )
+
+  override def useMbt: Boolean = true
+  override def defaultMbtJson: String =
+    """|{
+       |  "namespaces" : {
+       |    "a" : {
+       |      "sources": ["a/src/main/java/**", "a/src/main/scala/**"]
+       |    }
+       |  }
+       |}""".stripMargin
+
+  renamed(
+    "basic",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  val <<toRename>> = 123
+       |}
+       |/a/src/main/scala/a/Main2.scala
+       |package a
+       |object Main2{
+       |  val toRename = Main.<<toR@@ename>>
+       |}
+       |""".stripMargin,
+    newName = "otherRename",
+  )
+
+  renamed(
+    "java",
+    """|/a/src/main/java/a/Other.java
+       |package a;
+       |public class <<Other>>{
+       |
+       |  <<Other>> other;
+       |  public <<Other>>(){
+       |
+       |  }
+       |}
+       |/a/src/main/java/a/Main.java
+       |package a;
+       |public class Main{
+       |  <<Other>> other = new <<Oth@@er>>();
+       |}
+       |""".stripMargin,
+    newName = "Renamed",
+    fileRenames =
+      Map("a/src/main/java/a/Other.java" -> "a/src/main/java/a/Renamed.java"),
+  )
+
+  renamed(
+    "java-constructor",
+    """|/a/src/main/java/a/Other.java
+       |package a;
+       |public class <<Other>>{
+       |
+       |  <<Other>> other;
+       |  public <<Other>>(){
+       |    this(42);
+       |  }
+       |  public <<Other>>(int x){
+       |    this.x = x;
+       |  }
+       |  
+       |  public <<Other>>(int x, String type)
+       |  {
+       |    this();
+       |  }
+       |
+       |  private int x;
+       |}
+       |/a/src/main/java/a/Main.java
+       |package a;
+       |public class Main{
+       |  <<Other>> other = new <<Oth@@er>>();
+       |}
+       |""".stripMargin,
+    newName = "Renamed",
+    fileRenames =
+      Map("a/src/main/java/a/Other.java" -> "a/src/main/java/a/Renamed.java"),
+  )
+
+}

--- a/tests/unit/src/test/scala/tests/mbt/ScalaReferenceSpec.scala
+++ b/tests/unit/src/test/scala/tests/mbt/ScalaReferenceSpec.scala
@@ -221,6 +221,9 @@ trait ScalaReferenceSpec { this: BaseMbtReferenceSuite =>
             |a/src/main/scala/a/Upstream.scala:2:7: reference
             |class Upstream(i: Int) {
             |      ^^^^^^^^
+            |a/src/main/scala/a/Upstream.scala:5:8: reference
+            |object Upstream {
+            |       ^^^^^^^^
             |""".stripMargin,
       )
       _ <- server.assertReferencesSubquery(


### PR DESCRIPTION
Previously, we would always require semanticdb to be present. Now we calculate it on demand if needed.

This also simplifies RenamePRovider a bit, since looking for implementations is done in MbtReferenceProvider.

Fixes https://github.com/scalameta/metals/issues/8496