### PR TITLE
Fix image links in docs

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -393,7 +393,7 @@ https://scalameta.org/scalafmt/docs/configuration.html.
 
 Fold ranges such as large multi-line expressions, import groups and comments.
 
-![Code folding](https://camo.githubusercontent.com/3fdd7ae28907ac61c0a1ac5fdc07d085245957aa/68747470733a2f2f692e696d6775722e636f6d2f667149554a54472e676966)
+![Code folding](https://user-images.githubusercontent.com/1408093/55667805-881a2e80-5861-11e9-8668-091c18b1aa64.gif)
 
 ## Document highlight
 

--- a/website/blog/2019-04-12-mercury.md
+++ b/website/blog/2019-04-12-mercury.md
@@ -62,7 +62,7 @@ arguments.
 It's now possible to fold ranges such as large expressions, import groups and
 comments.
 
-![Code folding](https://camo.githubusercontent.com/3fdd7ae28907ac61c0a1ac5fdc07d085245957aa/68747470733a2f2f692e696d6775722e636f6d2f667149554a54472e676966)
+![Code folding](https://user-images.githubusercontent.com/1408093/55667805-881a2e80-5861-11e9-8668-091c18b1aa64.gif)
 
 Big thanks to [@marek1840](https://github.com/marek1840) for contributing this
 feature!

--- a/website/blog/2020-01-10-cobalt.md
+++ b/website/blog/2020-01-10-cobalt.md
@@ -247,7 +247,7 @@ to implement all of the abstract members, you'd need to do each one
 individually. Now you'll see a new completion option in the scenario to
 Implement all members which will implement all the members at once.
 
-![implement-all](https://camo.githubusercontent.com/d698c2adb18a420fcb4259e4264b6417a5e4bb54/68747470733a2f2f692e696d6775722e636f6d2f617942614344552e676966)
+![implement-all](https://user-images.githubusercontent.com/13974112/67897352-81853880-fb5e-11e9-9563-8cd8f67deb62.gif)
 
 ### Support scaladoc auto completion on type `/**`
 
@@ -272,7 +272,7 @@ Metals + Vim users.
 - input box support
 - implementation of the decoration protocol (Neovim only)
 
-![coc-metals](https://camo.githubusercontent.com/0f56f5a3a874e7c69eff3aaeb2dfe47dc586e3d3/68747470733a2f2f692e696d6775722e636f6d2f7a6f66753456492e706e67)
+![coc-metals](https://camo.githubusercontent.com/d9d966e44744e6e91c52f0a62277490cebe16474b04d381d0df450e9c7227de5/68747470733a2f2f692e696d6775722e636f6d2f7a6f66753456492e706e67)
 
 ## Support for java 11
 

--- a/website/blog/2020-09-21-lithium.md
+++ b/website/blog/2020-09-21-lithium.md
@@ -75,7 +75,7 @@ stacktrace using code lenses. Keep in mind that you'll want to make sure you
 have codeLens.enable set to true in your configuration. Also, since this feature
 relies on code lenses (virtual text in Nvim), it's only supported in Nvim.
 
-![stacktrace-nvim](https://camo.githubusercontent.com/54a9cb68547532b2ff16cb6f95fdd8268d806b41/68747470733a2f2f692e696d6775722e636f6d2f74516a694147322e676966)
+![stacktrace-nvim](https://camo.githubusercontent.com/f6833f0f2e271d028ae74c331c48561a1c8bd226ca2a9162f92344383ea04b0b/68747470733a2f2f692e696d6775722e636f6d2f74516a694147322e676966)
 
 ### Other editors
 


### PR DESCRIPTION
This PR is meant to fix some outdated image links used in on the Metals website

Before
<img width="1050" height="258" alt="code_folding_before" src="https://github.com/user-attachments/assets/6eb2fb36-4fbc-4674-a7a4-fc1109d1569a" />

After
<img width="1255" height="701" alt="code_folding_after" src="https://github.com/user-attachments/assets/f725d384-b910-4fd9-8826-b9f989ee04ff" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several documentation and blog images to newer embedded GIFs/screenshots.
  * Refreshed visuals in the code folding section and multiple release note posts for clearer, more current examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->