### PR TITLE
Add "Implement all members" code action for Java

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImplementAbstractMembers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImplementAbstractMembers.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals.codeactions
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import scala.meta.internal.jpc.JavacDiagnostic
 import scala.meta.internal.metals.Compilers
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalacDiagnostic
@@ -19,31 +20,38 @@ class ImplementAbstractMembers(compilers: Compilers) extends CodeAction {
       params: l.CodeActionParams,
       token: CancelToken,
   )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = {
-    Future.sequence(
-      params
-        .getContext()
-        .getDiagnostics()
-        .asScala
-        .toSeq
-        .collect {
-          case d @ ScalacDiagnostic.ObjectCreationImpossible(_)
-              if params.getRange().overlapsWith(d.getRange()) =>
-            implementAbstractMembers(d, params, token)
-          case d @ ScalacDiagnostic.MissingImplementation(_)
-              if params.getRange().overlapsWith(d.getRange()) =>
-            implementAbstractMembers(d, params, token)
-          case d @ ScalacDiagnostic.DeclarationOfGivenInstanceNotAllowed(_)
-              if (params.getRange().overlapsWith(d.getRange())) =>
-            implementAbstractMembers(d, params, token)
-        }
-    )
+    Future
+      .sequence(
+        params
+          .getContext()
+          .getDiagnostics()
+          .asScala
+          .toSeq
+          .collect {
+            case d @ ScalacDiagnostic.ObjectCreationImpossible(_)
+                if params.getRange().overlapsWith(d.getRange()) =>
+              implementAbstractMembers(d, params, token)
+            case d @ ScalacDiagnostic.MissingImplementation(_)
+                if params.getRange().overlapsWith(d.getRange()) =>
+              implementAbstractMembers(d, params, token)
+            case d @ ScalacDiagnostic.DeclarationOfGivenInstanceNotAllowed(_)
+                if (params.getRange().overlapsWith(d.getRange())) =>
+              implementAbstractMembers(d, params, token)
+            case d @ JavacDiagnostic.DoesNotOverrideAbstract()
+                if params.getRange().overlapsWith(d.getRange()) =>
+              implementAbstractMembers(d, params, token)
+          }
+      )
+      .map(_.flatten)
   }
+
+  override def isJava: Boolean = true
 
   private def implementAbstractMembers(
       diagnostic: l.Diagnostic,
       params: l.CodeActionParams,
       token: CancelToken,
-  )(implicit ec: ExecutionContext): Future[l.CodeAction] = {
+  )(implicit ec: ExecutionContext): Future[Option[l.CodeAction]] = {
     val textDocumentPositionParams = new l.TextDocumentPositionParams(
       params.getTextDocument(),
       diagnostic.getRange.getStart(),
@@ -51,14 +59,18 @@ class ImplementAbstractMembers(compilers: Compilers) extends CodeAction {
     compilers
       .implementAbstractMembers(textDocumentPositionParams, token)
       .map { edits =>
-        val uri = params.getTextDocument().getUri()
-
-        CodeActionBuilder.build(
-          title = ImplementAbstractMembers.title,
-          kind = l.CodeActionKind.QuickFix,
-          changes = List(uri.toAbsolutePath -> edits.asScala.toSeq),
-          diagnostics = List(diagnostic),
-        )
+        if (edits.isEmpty) None
+        else {
+          val uri = params.getTextDocument().getUri()
+          Some(
+            CodeActionBuilder.build(
+              title = ImplementAbstractMembers.title,
+              kind = l.CodeActionKind.QuickFix,
+              changes = List(uri.toAbsolutePath -> edits.asScala.toSeq),
+              diagnostics = List(diagnostic),
+            )
+          )
+        }
       }
   }
 }

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaAutoImportEditor.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaAutoImportEditor.scala
@@ -77,3 +77,50 @@ class JavaAutoImportEditor(text: String, fqn: String) {
   }
 
 }
+
+object JavaAutoImportEditor {
+
+  /**
+   * A single edit that inserts the given imports as a block, placed after the
+   * last existing import, or after the package declaration, or at the top of
+   * the file. Returns `None` when there are no imports to add.
+   */
+  def imports(text: String, fqns: List[String]): Option[l.TextEdit] = {
+    if (fqns.isEmpty) None
+    else {
+      val block = fqns.map(fqn => s"import $fqn;").mkString("\n")
+      ImportLine.fromText(text).lastOption match {
+        case Some(lastImport) =>
+          Some(
+            insertAt(
+              lastImport.lineNumber,
+              lastImport.line.length(),
+              s"\n$block"
+            )
+          )
+        case None =>
+          packageLine(text) match {
+            case Some((lineNumber, length)) =>
+              Some(insertAt(lineNumber, length, s"\n\n$block"))
+            case None =>
+              Some(insertAt(0, 0, s"$block\n\n"))
+          }
+      }
+    }
+  }
+
+  private def packageLine(text: String): Option[(Int, Int)] =
+    text.linesIterator.zipWithIndex.collectFirst {
+      case (line, lineNumber) if line.startsWith("package ") =>
+        (lineNumber, line.length())
+    }
+
+  private def insertAt(
+      line: Int,
+      character: Int,
+      newText: String
+  ): l.TextEdit = {
+    val position = new l.Position(line, character)
+    new l.TextEdit(new l.Range(position, position), newText)
+  }
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaAutoImportEditor.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaAutoImportEditor.scala
@@ -109,9 +109,12 @@ object JavaAutoImportEditor {
     }
   }
 
+  private val PackageDeclaration = """^\s*package\s+.*""".r
+
   private def packageLine(text: String): Option[(Int, Int)] =
     text.linesIterator.zipWithIndex.collectFirst {
-      case (line, lineNumber) if line.startsWith("package ") =>
+      case (line, lineNumber)
+          if PackageDeclaration.pattern.matcher(line).matches() =>
         (lineNumber, line.length())
     }
 

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaImplementAbstractMembersProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaImplementAbstractMembersProvider.scala
@@ -1,0 +1,263 @@
+package scala.meta.internal.jpc
+
+import javax.lang.model.`type`.ArrayType
+import javax.lang.model.`type`.DeclaredType
+import javax.lang.model.`type`.ExecutableType
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.Modifier
+import javax.lang.model.element.TypeElement
+import javax.lang.model.element.TypeParameterElement
+
+import scala.jdk.CollectionConverters._
+
+import scala.meta.pc.OffsetParams
+
+import com.sun.source.tree.ClassTree
+import com.sun.source.tree.CompilationUnitTree
+import com.sun.source.util.JavacTask
+import com.sun.source.util.TreePath
+import com.sun.source.util.TreePathScanner
+import com.sun.source.util.Trees
+import org.eclipse.{lsp4j => l}
+
+/**
+ * Generates implementations for the abstract members that the class at the
+ * cursor position inherits but does not yet implement.
+ *
+ * The cursor is expected to be on the class declaration that triggers the
+ * `compiler.err.does.not.override.abstract` diagnostic.
+ */
+class JavaImplementAbstractMembersProvider(
+    compiler: JavaMetalsCompiler,
+    params: OffsetParams
+) {
+
+  private val placeholderBody =
+    """throw new UnsupportedOperationException("Not yet implemented");"""
+
+  def implementAbstractMembers(): List[l.TextEdit] = {
+    val compile = compiler.compilationTask(params).withAnalyzePhase()
+    val task = compile.task
+    val cu = compile.cu
+    val trees = Trees.instance(task)
+    val text = params.text()
+
+    enclosingClass(trees, cu).flatMap { classPath =>
+      trees.getElement(classPath) match {
+        case typeElement: TypeElement
+            if !typeElement.getModifiers.contains(Modifier.ABSTRACT) &&
+              typeElement.getKind() != ElementKind.INTERFACE &&
+              typeElement.getKind() != ElementKind.ANNOTATION_TYPE =>
+          val abstractMethods =
+            unimplementedAbstractMethods(task, typeElement)
+          if (abstractMethods.isEmpty) None
+          else
+            Some(
+              edit(
+                trees,
+                cu,
+                classPath.getLeaf().asInstanceOf[ClassTree],
+                text,
+                abstractMethods
+              )
+            )
+        case _ => None
+      }
+    }.toList
+  }
+
+  private def enclosingClass(
+      trees: Trees,
+      cu: CompilationUnitTree
+  ): Option[TreePath] = {
+    val finder = new EnclosingClassFinder(trees, cu, params.offset())
+    finder.scan(cu, ())
+    finder.result
+  }
+
+  /**
+   * Returns the abstract methods inherited by `typeElement` that are not
+   * implemented, paired with their type as seen from `typeElement` (so that
+   * generic type parameters are substituted). Sorted for deterministic output.
+   */
+  private def unimplementedAbstractMethods(
+      task: JavacTask,
+      typeElement: TypeElement
+  ): List[(ExecutableElement, ExecutableType)] = {
+    val elements = task.getElements()
+    val types = task.getTypes()
+    val declaredType = typeElement.asType().asInstanceOf[DeclaredType]
+    val methods =
+      for {
+        member <- elements.getAllMembers(typeElement).asScala.toList
+        if member.getKind() == ElementKind.METHOD &&
+          member.getModifiers().contains(Modifier.ABSTRACT)
+        method = member.asInstanceOf[ExecutableElement]
+        execType = types
+          .asMemberOf(declaredType, method)
+          .asInstanceOf[ExecutableType]
+      } yield (method, execType)
+    methods.sortBy { case (method, execType) => sortKey(method, execType) }
+  }
+
+  private def sortKey(
+      method: ExecutableElement,
+      execType: ExecutableType
+  ): String =
+    method.getSimpleName().toString() +
+      execType
+        .getParameterTypes()
+        .asScala
+        .map(JavaLabels.typeLabel)
+        .mkString("(", ",", ")")
+
+  private def edit(
+      trees: Trees,
+      cu: CompilationUnitTree,
+      classTree: ClassTree,
+      text: String,
+      methods: List[(ExecutableElement, ExecutableType)]
+  ): l.TextEdit = {
+    val lineMap = cu.getLineMap()
+    val sourcePositions = trees.getSourcePositions()
+    val classStart = sourcePositions.getStartPosition(cu, classTree).toInt
+    val classEnd = sourcePositions.getEndPosition(cu, classTree).toInt
+    val closeBrace = classEnd - 1
+
+    val classIndent = lineIndent(text, classStart)
+    val indentUnit = detectIndentUnit(text)
+    val memberIndent = classIndent + indentUnit
+    val bodyIndent = memberIndent + indentUnit
+
+    // Find the insertion point: right after the last non-whitespace character
+    // before the closing brace of the class body.
+    var lastNonWs = closeBrace - 1
+    while (lastNonWs > classStart && text.charAt(lastNonWs).isWhitespace)
+      lastNonWs -= 1
+    val isEmptyBody = text.charAt(lastNonWs) == '{'
+    val insertStart = lastNonWs + 1
+
+    val blocks =
+      methods
+        .map { case (method, execType) =>
+          methodStub(method, execType, memberIndent, bodyIndent)
+        }
+        .mkString("\n\n")
+
+    val prefix = if (isEmptyBody) "\n" else "\n\n"
+    val suffix = s"\n$classIndent"
+
+    new l.TextEdit(
+      Positions.toLspRange(lineMap, insertStart, closeBrace, text),
+      s"$prefix$blocks$suffix"
+    )
+  }
+
+  private def methodStub(
+      method: ExecutableElement,
+      execType: ExecutableType,
+      memberIndent: String,
+      bodyIndent: String
+  ): String = {
+    val signature = methodSignature(method, execType)
+    s"""$memberIndent@Override
+       |$memberIndent$signature {
+       |$bodyIndent$placeholderBody
+       |$memberIndent}""".stripMargin
+  }
+
+  private def methodSignature(
+      method: ExecutableElement,
+      execType: ExecutableType
+  ): String = {
+    val modifier =
+      if (method.getModifiers().contains(Modifier.PUBLIC)) "public "
+      else if (method.getModifiers().contains(Modifier.PROTECTED)) "protected "
+      else ""
+    val typeParams = typeParameters(method)
+    val returnType = JavaLabels.typeLabel(execType.getReturnType())
+    val name = method.getSimpleName().toString()
+    val params = parameters(method, execType)
+    s"$modifier$typeParams$returnType $name($params)"
+  }
+
+  private def typeParameters(method: ExecutableElement): String = {
+    val typeParams = method.getTypeParameters().asScala.toList
+    if (typeParams.isEmpty) ""
+    else {
+      val rendered = typeParams.map(renderTypeParameter).mkString(", ")
+      s"<$rendered> "
+    }
+  }
+
+  private def renderTypeParameter(tp: TypeParameterElement): String = {
+    val bounds = tp
+      .getBounds()
+      .asScala
+      .toList
+      .filterNot(b => JavaLabels.typeLabel(b) == "java.lang.Object")
+    if (bounds.isEmpty) tp.getSimpleName().toString()
+    else
+      s"${tp.getSimpleName()} extends ${bounds.map(JavaLabels.typeLabel).mkString(" & ")}"
+  }
+
+  private def parameters(
+      method: ExecutableElement,
+      execType: ExecutableType
+  ): String = {
+    val paramTypes = execType.getParameterTypes().asScala.toList
+    val paramNames = method.getParameters().asScala.toList
+    val isVarArgs = method.isVarArgs()
+    paramTypes
+      .zip(paramNames)
+      .zipWithIndex
+      .map { case ((paramType, param), index) =>
+        val name = param.getSimpleName().toString()
+        val isLast = index == paramTypes.length - 1
+        if (isVarArgs && isLast) {
+          paramType match {
+            case array: ArrayType =>
+              s"${JavaLabels.typeLabel(array.getComponentType())}... $name"
+            case _ => s"${JavaLabels.typeLabel(paramType)} $name"
+          }
+        } else s"${JavaLabels.typeLabel(paramType)} $name"
+      }
+      .mkString(", ")
+  }
+
+  private def lineIndent(text: String, offset: Int): String = {
+    val clamped = offset.min(text.length()).max(0)
+    val lineStart = text.lastIndexOf('\n', clamped - 1) + 1
+    text.substring(lineStart, clamped).takeWhile(_.isWhitespace)
+  }
+
+  private def detectIndentUnit(text: String): String =
+    text.linesIterator
+      .map(_.takeWhile(c => c == ' ' || c == '\t'))
+      .find(_.nonEmpty) match {
+      case Some(ws) if ws.startsWith("\t") => "\t"
+      case _ => "  "
+    }
+
+  private class EnclosingClassFinder(
+      trees: Trees,
+      cu: CompilationUnitTree,
+      offset: Int
+  ) extends TreePathScanner[Unit, Unit] {
+    private val sourcePositions = trees.getSourcePositions()
+    private var found: Option[TreePath] = None
+
+    def result: Option[TreePath] = found
+
+    override def visitClass(node: ClassTree, p: Unit): Unit = {
+      val start = sourcePositions.getStartPosition(cu, node)
+      val end = sourcePositions.getEndPosition(cu, node)
+      if (start >= 0 && end >= 0 && start <= offset && offset <= end) {
+        // The innermost enclosing class is visited last in pre-order traversal.
+        found = Some(getCurrentPath())
+      }
+      super.visitClass(node, p)
+    }
+  }
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaImplementAbstractMembersProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaImplementAbstractMembersProvider.scala
@@ -27,6 +27,9 @@ import org.eclipse.{lsp4j => l}
  *
  * The cursor is expected to be on the class declaration that triggers the
  * `compiler.err.does.not.override.abstract` diagnostic.
+ *
+ * Referenced types are rendered with simple names where it is safe, and the
+ * required imports are added as a separate text edit (see [[JavaTypeShortener]]).
  */
 class JavaImplementAbstractMembersProvider(
     compiler: JavaMetalsCompiler,
@@ -43,7 +46,7 @@ class JavaImplementAbstractMembersProvider(
     val trees = Trees.instance(task)
     val text = params.text()
 
-    enclosingClass(trees, cu).flatMap { classPath =>
+    enclosingClass(trees, cu).toList.flatMap { classPath =>
       trees.getElement(classPath) match {
         case typeElement: TypeElement
             if !typeElement.getModifiers.contains(Modifier.ABSTRACT) &&
@@ -51,20 +54,24 @@ class JavaImplementAbstractMembersProvider(
               typeElement.getKind() != ElementKind.ANNOTATION_TYPE =>
           val abstractMethods =
             unimplementedAbstractMethods(task, typeElement)
-          if (abstractMethods.isEmpty) None
-          else
-            Some(
-              edit(
-                trees,
-                cu,
-                classPath.getLeaf().asInstanceOf[ClassTree],
-                text,
-                abstractMethods
-              )
+          if (abstractMethods.isEmpty) Nil
+          else {
+            val shortener = newShortener(cu)
+            val bodyEdit = bodyEditFor(
+              trees,
+              cu,
+              classPath.getLeaf().asInstanceOf[ClassTree],
+              text,
+              abstractMethods,
+              shortener
             )
-        case _ => None
+            // The body edit must be computed before reading the imports, since
+            // rendering the stubs is what registers the needed imports.
+            importsEdit(text, shortener.newImports).toList :+ bodyEdit
+          }
+        case _ => Nil
       }
-    }.toList
+    }
   }
 
   private def enclosingClass(
@@ -112,12 +119,40 @@ class JavaImplementAbstractMembersProvider(
         .map(JavaLabels.typeLabel)
         .mkString("(", ",", ")")
 
-  private def edit(
+  private def newShortener(cu: CompilationUnitTree): JavaTypeShortener = {
+    val currentPackage =
+      Option(cu.getPackageName()).map(_.toString()).getOrElse("")
+    val imports = cu.getImports().asScala.toList.filterNot(_.isStatic())
+    val existingImports = imports.collect {
+      case imp if !imp.getQualifiedIdentifier().toString().endsWith(".*") =>
+        val fqn = imp.getQualifiedIdentifier().toString()
+        fqn.substring(fqn.lastIndexOf('.') + 1) -> fqn
+    }.toMap
+    val onDemandPackages = imports.collect {
+      case imp if imp.getQualifiedIdentifier().toString().endsWith(".*") =>
+        val qualified = imp.getQualifiedIdentifier().toString()
+        qualified.substring(0, qualified.lastIndexOf('.'))
+    }.toSet
+    val declaredTypeNames = cu
+      .getTypeDecls()
+      .asScala
+      .collect { case cls: ClassTree => cls.getSimpleName().toString() }
+      .toSet
+    new JavaTypeShortener(
+      currentPackage,
+      existingImports,
+      onDemandPackages,
+      declaredTypeNames
+    )
+  }
+
+  private def bodyEditFor(
       trees: Trees,
       cu: CompilationUnitTree,
       classTree: ClassTree,
       text: String,
-      methods: List[(ExecutableElement, ExecutableType)]
+      methods: List[(ExecutableElement, ExecutableType)],
+      shortener: JavaTypeShortener
   ): l.TextEdit = {
     val lineMap = cu.getLineMap()
     val sourcePositions = trees.getSourcePositions()
@@ -141,7 +176,7 @@ class JavaImplementAbstractMembersProvider(
     val blocks =
       methods
         .map { case (method, execType) =>
-          methodStub(method, execType, memberIndent, bodyIndent)
+          methodStub(method, execType, memberIndent, bodyIndent, shortener)
         }
         .mkString("\n\n")
 
@@ -158,9 +193,10 @@ class JavaImplementAbstractMembersProvider(
       method: ExecutableElement,
       execType: ExecutableType,
       memberIndent: String,
-      bodyIndent: String
+      bodyIndent: String,
+      shortener: JavaTypeShortener
   ): String = {
-    val signature = methodSignature(method, execType)
+    val signature = methodSignature(method, execType, shortener)
     s"""$memberIndent@Override
        |$memberIndent$signature {
        |$bodyIndent$placeholderBody
@@ -169,42 +205,51 @@ class JavaImplementAbstractMembersProvider(
 
   private def methodSignature(
       method: ExecutableElement,
-      execType: ExecutableType
+      execType: ExecutableType,
+      shortener: JavaTypeShortener
   ): String = {
     val modifier =
       if (method.getModifiers().contains(Modifier.PUBLIC)) "public "
       else if (method.getModifiers().contains(Modifier.PROTECTED)) "protected "
       else ""
-    val typeParams = typeParameters(method)
-    val returnType = JavaLabels.typeLabel(execType.getReturnType())
+    val typeParams = typeParameters(method, shortener)
+    val returnType = shortener.shorten(execType.getReturnType())
     val name = method.getSimpleName().toString()
-    val params = parameters(method, execType)
+    val params = parameters(method, execType, shortener)
     s"$modifier$typeParams$returnType $name($params)"
   }
 
-  private def typeParameters(method: ExecutableElement): String = {
+  private def typeParameters(
+      method: ExecutableElement,
+      shortener: JavaTypeShortener
+  ): String = {
     val typeParams = method.getTypeParameters().asScala.toList
     if (typeParams.isEmpty) ""
     else {
-      val rendered = typeParams.map(renderTypeParameter).mkString(", ")
+      val rendered =
+        typeParams.map(tp => renderTypeParameter(tp, shortener)).mkString(", ")
       s"<$rendered> "
     }
   }
 
-  private def renderTypeParameter(tp: TypeParameterElement): String = {
+  private def renderTypeParameter(
+      tp: TypeParameterElement,
+      shortener: JavaTypeShortener
+  ): String = {
     val bounds = tp
       .getBounds()
       .asScala
       .toList
-      .filterNot(b => JavaLabels.typeLabel(b) == "java.lang.Object")
+      .filterNot(bound => JavaLabels.typeLabel(bound) == "java.lang.Object")
     if (bounds.isEmpty) tp.getSimpleName().toString()
     else
-      s"${tp.getSimpleName()} extends ${bounds.map(JavaLabels.typeLabel).mkString(" & ")}"
+      s"${tp.getSimpleName()} extends ${bounds.map(shortener.shorten).mkString(" & ")}"
   }
 
   private def parameters(
       method: ExecutableElement,
-      execType: ExecutableType
+      execType: ExecutableType,
+      shortener: JavaTypeShortener
   ): String = {
     val paramTypes = execType.getParameterTypes().asScala.toList
     val paramNames = method.getParameters().asScala.toList
@@ -218,12 +263,54 @@ class JavaImplementAbstractMembersProvider(
         if (isVarArgs && isLast) {
           paramType match {
             case array: ArrayType =>
-              s"${JavaLabels.typeLabel(array.getComponentType())}... $name"
-            case _ => s"${JavaLabels.typeLabel(paramType)} $name"
+              s"${shortener.shorten(array.getComponentType())}... $name"
+            case _ => s"${shortener.shorten(paramType)} $name"
           }
-        } else s"${JavaLabels.typeLabel(paramType)} $name"
+        } else s"${shortener.shorten(paramType)} $name"
       }
       .mkString(", ")
+  }
+
+  /**
+   * Builds a single text edit that adds all the given imports, placed after the
+   * last existing import, or after the package declaration, or at the top of
+   * the file.
+   */
+  private def importsEdit(
+      text: String,
+      imports: List[String]
+  ): Option[l.TextEdit] = {
+    if (imports.isEmpty) None
+    else {
+      val block = imports.map(fqn => s"import $fqn;").mkString("\n")
+      val lines = text.linesIterator.zipWithIndex.toList
+      val lastImport =
+        lines.filter { case (line, _) =>
+          line.trim().startsWith("import ")
+        }.lastOption
+      lastImport match {
+        case Some((line, idx)) =>
+          Some(insertAt(idx, line.length(), s"\n$block"))
+        case None =>
+          lines.find { case (line, _) =>
+            line.trim().startsWith("package ")
+          } match {
+            case Some((line, idx)) =>
+              Some(insertAt(idx, line.length(), s"\n\n$block"))
+            case None =>
+              Some(insertAt(0, 0, s"$block\n\n"))
+          }
+      }
+    }
+  }
+
+  private def insertAt(
+      line: Int,
+      character: Int,
+      newText: String
+  ): l.TextEdit = {
+    val position = new l.Position(line, character)
+    new l.TextEdit(new l.Range(position, position), newText)
   }
 
   private def lineIndent(text: String, offset: Int): String = {

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaImplementAbstractMembersProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaImplementAbstractMembersProvider.scala
@@ -7,7 +7,6 @@ import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.Modifier
 import javax.lang.model.element.TypeElement
-import javax.lang.model.element.TypeParameterElement
 
 import scala.jdk.CollectionConverters._
 
@@ -56,11 +55,12 @@ class JavaImplementAbstractMembersProvider(
             unimplementedAbstractMethods(task, typeElement)
           if (abstractMethods.isEmpty) Nil
           else {
-            val shortener = newShortener(cu)
+            val classTree = classPath.getLeaf().asInstanceOf[ClassTree]
+            val shortener = newShortener(cu, classTree)
             val bodyEdit = bodyEditFor(
               trees,
               cu,
-              classPath.getLeaf().asInstanceOf[ClassTree],
+              classTree,
               text,
               abstractMethods,
               shortener
@@ -103,10 +103,16 @@ class JavaImplementAbstractMembersProvider(
         if member.getKind() == ElementKind.METHOD &&
           member.getModifiers().contains(Modifier.ABSTRACT)
         method = member.asInstanceOf[ExecutableElement]
-        execType = types
-          .asMemberOf(declaredType, method)
-          .asInstanceOf[ExecutableType]
+        (method, execType) <- (
+          method,
+          types.asMemberOf(declaredType, method)
+        ) match {
+          case (method: ExecutableElement, tpe: ExecutableType) =>
+            Some((method, tpe))
+          case _ => None
+        }
       } yield (method, execType)
+
     methods.sortBy { case (method, execType) => sortKey(method, execType) }
   }
 
@@ -121,7 +127,10 @@ class JavaImplementAbstractMembersProvider(
         .map(JavaLabels.typeLabel)
         .mkString("(", ",", ")")
 
-  private def newShortener(cu: CompilationUnitTree): JavaTypeShortener = {
+  private def newShortener(
+      cu: CompilationUnitTree,
+      targetClass: ClassTree
+  ): JavaTypeShortener = {
     val currentPackage =
       Option(cu.getPackageName()).map(_.toString()).getOrElse("")
     val imports = cu.getImports().asScala.toList.filterNot(_.isStatic())
@@ -130,23 +139,27 @@ class JavaImplementAbstractMembersProvider(
         val fqn = imp.getQualifiedIdentifier().toString()
         fqn.substring(fqn.lastIndexOf('.') + 1) -> fqn
     }.toMap
-    val onDemandPackages = imports.collect {
-      case imp if imp.getQualifiedIdentifier().toString().endsWith(".*") =>
-        val qualified = imp.getQualifiedIdentifier().toString()
-        qualified.substring(0, qualified.lastIndexOf('.'))
-    }.toSet
-    val declaredTypeNames = cu
+    val topLevelTypeNames = cu
       .getTypeDecls()
       .asScala
       .collect { case cls: ClassTree => cls.getSimpleName().toString() }
       .toSet
+    val memberTypeNames = collectMemberTypeNames(targetClass)
+    val declaredTypeNames = topLevelTypeNames ++ memberTypeNames
     new JavaTypeShortener(
       currentPackage,
       existingImports,
-      onDemandPackages,
       declaredTypeNames
     )
   }
+
+  /** Collects simple names of member types declared inside the given class. */
+  private def collectMemberTypeNames(classTree: ClassTree): Set[String] =
+    classTree
+      .getMembers()
+      .asScala
+      .collect { case cls: ClassTree => cls.getSimpleName().toString() }
+      .toSet
 
   private def bodyEditFor(
       trees: Trees,
@@ -229,23 +242,9 @@ class JavaImplementAbstractMembersProvider(
     if (typeParams.isEmpty) ""
     else {
       val rendered =
-        typeParams.map(tp => renderTypeParameter(tp, shortener)).mkString(", ")
+        typeParams.map(shortener.renderTypeParameter).mkString(", ")
       s"<$rendered> "
     }
-  }
-
-  private def renderTypeParameter(
-      tp: TypeParameterElement,
-      shortener: JavaTypeShortener
-  ): String = {
-    val bounds = tp
-      .getBounds()
-      .asScala
-      .toList
-      .filterNot(bound => JavaLabels.typeLabel(bound) == "java.lang.Object")
-    if (bounds.isEmpty) tp.getSimpleName().toString()
-    else
-      s"${tp.getSimpleName()} extends ${bounds.map(shortener.shorten).mkString(" & ")}"
   }
 
   private def parameters(

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaImplementAbstractMembersProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaImplementAbstractMembersProvider.scala
@@ -67,7 +67,9 @@ class JavaImplementAbstractMembersProvider(
             )
             // The body edit must be computed before reading the imports, since
             // rendering the stubs is what registers the needed imports.
-            importsEdit(text, shortener.newImports).toList :+ bodyEdit
+            JavaAutoImportEditor
+              .imports(text, shortener.newImports)
+              .toList :+ bodyEdit
           }
         case _ => Nil
       }
@@ -269,48 +271,6 @@ class JavaImplementAbstractMembersProvider(
         } else s"${shortener.shorten(paramType)} $name"
       }
       .mkString(", ")
-  }
-
-  /**
-   * Builds a single text edit that adds all the given imports, placed after the
-   * last existing import, or after the package declaration, or at the top of
-   * the file.
-   */
-  private def importsEdit(
-      text: String,
-      imports: List[String]
-  ): Option[l.TextEdit] = {
-    if (imports.isEmpty) None
-    else {
-      val block = imports.map(fqn => s"import $fqn;").mkString("\n")
-      val lines = text.linesIterator.zipWithIndex.toList
-      val lastImport =
-        lines.filter { case (line, _) =>
-          line.trim().startsWith("import ")
-        }.lastOption
-      lastImport match {
-        case Some((line, idx)) =>
-          Some(insertAt(idx, line.length(), s"\n$block"))
-        case None =>
-          lines.find { case (line, _) =>
-            line.trim().startsWith("package ")
-          } match {
-            case Some((line, idx)) =>
-              Some(insertAt(idx, line.length(), s"\n\n$block"))
-            case None =>
-              Some(insertAt(0, 0, s"$block\n\n"))
-          }
-      }
-    }
-  }
-
-  private def insertAt(
-      line: Int,
-      character: Int,
-      newText: String
-  ): l.TextEdit = {
-    val position = new l.Position(line, character)
-    new l.TextEdit(new l.Range(position, position), newText)
   }
 
   private def lineIndent(text: String, offset: Int): String = {

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPresentationCompiler.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPresentationCompiler.scala
@@ -234,7 +234,11 @@ case class JavaPresentationCompiler(
   override def implementAbstractMembers(
       params: OffsetParams
   ): CompletableFuture[util.List[TextEdit]] =
-    CompletableFuture.completedFuture(Nil.asJava)
+    request(params, util.Collections.emptyList[TextEdit]()) { pc =>
+      new JavaImplementAbstractMembersProvider(pc, params)
+        .implementAbstractMembers()
+        .asJava
+    }
 
   override def insertInferredType(
       params: OffsetParams

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaTypeShortener.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaTypeShortener.scala
@@ -1,12 +1,7 @@
 package scala.meta.internal.jpc
 
-import javax.lang.model.`type`.ArrayType
 import javax.lang.model.`type`.DeclaredType
-import javax.lang.model.`type`.IntersectionType
 import javax.lang.model.`type`.TypeMirror
-import javax.lang.model.`type`.TypeVariable
-import javax.lang.model.`type`.UnionType
-import javax.lang.model.`type`.WildcardType
 import javax.lang.model.element.Element
 import javax.lang.model.element.NestingKind
 import javax.lang.model.element.TypeElement
@@ -18,6 +13,11 @@ import scala.jdk.CollectionConverters._
 /**
  * Renders Java types using simple names where it is safe to do so, collecting
  * the imports that need to be added for the shortened names to resolve.
+ *
+ * Extends [[JavaTypeVisitor]] (which renders fully qualified names) and only
+ * overrides how declared types are rendered; the recursion over arrays,
+ * wildcards, intersections, type arguments, etc. is inherited and routes back
+ * through [[shorten]], so nested types are shortened too.
  *
  * Nested member types are rendered by importing the outermost enclosing
  * top-level type and qualifying the rest with simple names (for example
@@ -33,7 +33,7 @@ class JavaTypeShortener(
     existingImports: Map[String, String],
     onDemandPackages: Set[String],
     declaredTypeNames: Set[String]
-) {
+) extends JavaTypeVisitor {
   // simpleName -> fully qualified name that the simple name currently resolves to
   private val claimed = mutable.Map.empty[String, String] ++ existingImports
   private val collected = mutable.LinkedHashSet.empty[String]
@@ -41,31 +41,21 @@ class JavaTypeShortener(
   /** The imports that need to be added, sorted. */
   def newImports: List[String] = collected.toList.sorted
 
-  def shorten(tpe: TypeMirror): String =
-    tpe match {
-      case array: ArrayType => s"${shorten(array.getComponentType())}[]"
-      case declared: DeclaredType => shortenDeclared(declared)
-      case wildcard: WildcardType => shortenWildcard(wildcard)
-      case typeVar: TypeVariable =>
-        typeVar.asElement().getSimpleName().toString()
-      case intersection: IntersectionType =>
-        intersection.getBounds().asScala.map(shorten).mkString(" & ")
-      case union: UnionType =>
-        union.getAlternatives().asScala.map(shorten).mkString(" | ")
-      case other => other.toString()
-    }
+  def shorten(tpe: TypeMirror): String = visit(tpe)
 
-  private def shortenDeclared(declared: DeclaredType): String = {
-    val base = declared.asElement() match {
-      case element: TypeElement => shortenName(element)
-      case _ => declared.toString()
+  override def visitDeclared(t: DeclaredType, p: Void): String =
+    t.asElement() match {
+      case element: TypeElement =>
+        val typeArguments = t.getTypeArguments()
+        val args =
+          if (typeArguments.isEmpty) ""
+          else
+            typeArguments.asScala
+              .map(arg => visit(arg))
+              .mkString("<", ", ", ">")
+        s"${shortenName(element)}$args"
+      case _ => super.visitDeclared(t, p)
     }
-    val typeArgs = declared.getTypeArguments().asScala
-    val args =
-      if (typeArgs.isEmpty) ""
-      else typeArgs.map(shorten).mkString("<", ", ", ">")
-    s"$base$args"
-  }
 
   private def shortenName(element: TypeElement): String =
     if (element.getNestingKind() == NestingKind.TOP_LEVEL)
@@ -134,13 +124,5 @@ class JavaTypeShortener(
       case Nil => ""
       case names => names.mkString(".", ".", "")
     }
-  }
-
-  private def shortenWildcard(wildcard: WildcardType): String = {
-    val superBound = wildcard.getSuperBound()
-    val extendsBound = wildcard.getExtendsBound()
-    if (superBound != null) s"? super ${shorten(superBound)}"
-    else if (extendsBound != null) s"? extends ${shorten(extendsBound)}"
-    else "?"
   }
 }

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaTypeShortener.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaTypeShortener.scala
@@ -31,7 +31,6 @@ import scala.jdk.CollectionConverters._
 class JavaTypeShortener(
     currentPackage: String,
     existingImports: Map[String, String],
-    onDemandPackages: Set[String],
     declaredTypeNames: Set[String]
 ) extends JavaTypeVisitor {
   // simpleName -> fully qualified name that the simple name currently resolves to
@@ -89,7 +88,7 @@ class JavaTypeShortener(
           if (declaredTypeNames.contains(simpleName)) fqn
           else {
             claimed(simpleName) = fqn
-            if (!onDemandPackages.contains(pkg)) collected += fqn
+            collected += fqn
             simpleName
           }
       }

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaTypeShortener.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaTypeShortener.scala
@@ -1,0 +1,146 @@
+package scala.meta.internal.jpc
+
+import javax.lang.model.`type`.ArrayType
+import javax.lang.model.`type`.DeclaredType
+import javax.lang.model.`type`.IntersectionType
+import javax.lang.model.`type`.TypeMirror
+import javax.lang.model.`type`.TypeVariable
+import javax.lang.model.`type`.UnionType
+import javax.lang.model.`type`.WildcardType
+import javax.lang.model.element.Element
+import javax.lang.model.element.NestingKind
+import javax.lang.model.element.TypeElement
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+/**
+ * Renders Java types using simple names where it is safe to do so, collecting
+ * the imports that need to be added for the shortened names to resolve.
+ *
+ * Nested member types are rendered by importing the outermost enclosing
+ * top-level type and qualifying the rest with simple names (for example
+ * `java.util.Map.Entry` becomes `Map.Entry` with `import java.util.Map`).
+ *
+ * A type is kept fully qualified when shortening would be unsafe: simple names
+ * that clash with an existing import or a type declared in the file, and simple
+ * names already claimed by a different fully qualified name in the generated
+ * code.
+ */
+class JavaTypeShortener(
+    currentPackage: String,
+    existingImports: Map[String, String],
+    onDemandPackages: Set[String],
+    declaredTypeNames: Set[String]
+) {
+  // simpleName -> fully qualified name that the simple name currently resolves to
+  private val claimed = mutable.Map.empty[String, String] ++ existingImports
+  private val collected = mutable.LinkedHashSet.empty[String]
+
+  /** The imports that need to be added, sorted. */
+  def newImports: List[String] = collected.toList.sorted
+
+  def shorten(tpe: TypeMirror): String =
+    tpe match {
+      case array: ArrayType => s"${shorten(array.getComponentType())}[]"
+      case declared: DeclaredType => shortenDeclared(declared)
+      case wildcard: WildcardType => shortenWildcard(wildcard)
+      case typeVar: TypeVariable =>
+        typeVar.asElement().getSimpleName().toString()
+      case intersection: IntersectionType =>
+        intersection.getBounds().asScala.map(shorten).mkString(" & ")
+      case union: UnionType =>
+        union.getAlternatives().asScala.map(shorten).mkString(" | ")
+      case other => other.toString()
+    }
+
+  private def shortenDeclared(declared: DeclaredType): String = {
+    val base = declared.asElement() match {
+      case element: TypeElement => shortenName(element)
+      case _ => declared.toString()
+    }
+    val typeArgs = declared.getTypeArguments().asScala
+    val args =
+      if (typeArgs.isEmpty) ""
+      else typeArgs.map(shorten).mkString("<", ", ", ">")
+    s"$base$args"
+  }
+
+  private def shortenName(element: TypeElement): String =
+    if (element.getNestingKind() == NestingKind.TOP_LEVEL)
+      shortenTopLevel(element)
+    else
+      enclosingTopLevel(element) match {
+        case Some(outer) =>
+          // Import the outermost type and qualify the nested path by simple
+          // names, e.g. `java.util.Map.Entry` -> `Map.Entry`.
+          shortenTopLevel(outer) + nestedTail(element, outer)
+        case None =>
+          // Local or anonymous enclosing type that cannot be imported.
+          element.getQualifiedName().toString()
+      }
+
+  private def shortenTopLevel(element: TypeElement): String = {
+    val fqn = element.getQualifiedName().toString()
+    val simpleName = element.getSimpleName().toString()
+    val pkg =
+      if (fqn.contains(".")) fqn.substring(0, fqn.lastIndexOf('.')) else ""
+    if (pkg == "java.lang" || pkg == currentPackage) {
+      // Accessible without an import, but still claim the name so that a
+      // later type with the same simple name stays fully qualified.
+      claimed.getOrElseUpdate(simpleName, fqn)
+      if (claimed(simpleName) == fqn) simpleName else fqn
+    } else
+      claimed.get(simpleName) match {
+        case Some(claimedFqn) =>
+          if (claimedFqn == fqn) simpleName else fqn
+        case None =>
+          if (declaredTypeNames.contains(simpleName)) fqn
+          else {
+            claimed(simpleName) = fqn
+            if (!onDemandPackages.contains(pkg)) collected += fqn
+            simpleName
+          }
+      }
+  }
+
+  @tailrec
+  private def enclosingTopLevel(
+      element: TypeElement
+  ): Option[TypeElement] =
+    if (element.getNestingKind() == NestingKind.TOP_LEVEL) Some(element)
+    else
+      element.getEnclosingElement() match {
+        case parent: TypeElement => enclosingTopLevel(parent)
+        case _ => None
+      }
+
+  /** The `.`-prefixed path of simple names from `outer` (exclusive) to `element`. */
+  private def nestedTail(element: TypeElement, outer: TypeElement): String = {
+    @tailrec
+    def loop(current: Element, acc: List[String]): List[String] =
+      if (current == outer) acc
+      else
+        current match {
+          case typeElement: TypeElement =>
+            loop(
+              typeElement.getEnclosingElement(),
+              typeElement.getSimpleName().toString() :: acc
+            )
+          case _ => acc
+        }
+    loop(element, Nil) match {
+      case Nil => ""
+      case names => names.mkString(".", ".", "")
+    }
+  }
+
+  private def shortenWildcard(wildcard: WildcardType): String = {
+    val superBound = wildcard.getSuperBound()
+    val extendsBound = wildcard.getExtendsBound()
+    if (superBound != null) s"? super ${shorten(superBound)}"
+    else if (extendsBound != null) s"? extends ${shorten(extendsBound)}"
+    else "?"
+  }
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaTypeVisitor.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaTypeVisitor.scala
@@ -14,6 +14,7 @@ import javax.lang.model.`type`.TypeVisitor
 import javax.lang.model.`type`.UnionType
 import javax.lang.model.`type`.UnknownTypeException
 import javax.lang.model.`type`.WildcardType
+import javax.lang.model.element.TypeParameterElement
 
 import scala.jdk.CollectionConverters._
 
@@ -72,4 +73,13 @@ class JavaTypeVisitor extends TypeVisitor[String, Void] {
 
   override def visitIntersection(t: IntersectionType, p: Void): String =
     t.getBounds.asScala.map(visit).mkString(" & ")
+
+  def renderTypeParameter(tp: TypeParameterElement): String = {
+    val bounds = tp
+      .getBounds()
+      .asScala
+      .filterNot(b => JavaLabels.typeLabel(b) == "java.lang.Object")
+    if (bounds.isEmpty) tp.getSimpleName().toString()
+    else s"${tp.getSimpleName()} extends ${bounds.map(visit).mkString(" & ")}"
+  }
 }

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavacDiagnostic.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavacDiagnostic.scala
@@ -41,4 +41,21 @@ object JavacDiagnostic {
       }
   }
 
+  // Example error:
+  // error: Foo is not abstract and does not override abstract method bar() in Baz
+  object DoesNotOverrideAbstract {
+    private val Code = "compiler.err.does.not.override.abstract"
+    private val Message =
+      """(?s).* is not abstract and does not override abstract method .*""".r
+    def unapply(d: l.Diagnostic): Boolean = {
+      val matchesCode =
+        d.getCode() != null && d.getCode().isLeft() &&
+          d.getCode().getLeft() == Code
+      matchesCode || (d.getMessageAsString.trim() match {
+        case Message() => true
+        case _ => false
+      })
+    }
+  }
+
 }

--- a/tests/unit/src/test/scala/tests/codeactions/JavaImplementAbstractMembersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/JavaImplementAbstractMembersLspSuite.scala
@@ -40,7 +40,7 @@ class JavaImplementAbstractMembersLspSuite
        |
        |public class Main implements Greeter {
        |  @Override
-       |  public java.lang.String greet(java.lang.String name) {
+       |  public String greet(String name) {
        |    throw new UnsupportedOperationException("Not yet implemented");
        |  }
        |}
@@ -75,12 +75,12 @@ class JavaImplementAbstractMembersLspSuite
        |
        |public class Main extends Base {
        |  @Override
-       |  int count(java.lang.String s) {
+       |  int count(String s) {
        |    throw new UnsupportedOperationException("Not yet implemented");
        |  }
        |
        |  @Override
-       |  java.lang.String value() {
+       |  String value() {
        |    throw new UnsupportedOperationException("Not yet implemented");
        |  }
        |}
@@ -113,12 +113,12 @@ class JavaImplementAbstractMembersLspSuite
        |
        |public class Main implements Box<String> {
        |  @Override
-       |  public void store(java.lang.String value) {
+       |  public void store(String value) {
        |    throw new UnsupportedOperationException("Not yet implemented");
        |  }
        |
        |  @Override
-       |  public java.lang.String unwrap() {
+       |  public String unwrap() {
        |    throw new UnsupportedOperationException("Not yet implemented");
        |  }
        |}
@@ -152,7 +152,7 @@ class JavaImplementAbstractMembersLspSuite
        |  private final String prefix = "Hello";
        |
        |  @Override
-       |  public java.lang.String greet(java.lang.String name) {
+       |  public String greet(String name) {
        |    throw new UnsupportedOperationException("Not yet implemented");
        |  }
        |}
@@ -183,7 +183,151 @@ class JavaImplementAbstractMembersLspSuite
        |
        |public class Main implements Formatter {
        |  @Override
-       |  public java.lang.String format(java.lang.String pattern, java.lang.Object... args) {
+       |  public String format(String pattern, Object... args) {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
+  )
+
+  check(
+    "adds-import",
+    """|package a;
+       |
+       |interface Source {
+       |  java.util.List<String> values();
+       |}
+       |
+       |public class <<Main>> implements Source {
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |import java.util.List;
+       |
+       |interface Source {
+       |  java.util.List<String> values();
+       |}
+       |
+       |public class Main implements Source {
+       |  @Override
+       |  public List<String> values() {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
+  )
+
+  check(
+    "existing-and-new-import",
+    """|package a;
+       |
+       |import java.util.List;
+       |
+       |interface Repo {
+       |  List<String> all();
+       |  java.util.Map<String, Integer> index();
+       |}
+       |
+       |public class <<Main>> implements Repo {
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |import java.util.List;
+       |import java.util.Map;
+       |
+       |interface Repo {
+       |  List<String> all();
+       |  java.util.Map<String, Integer> index();
+       |}
+       |
+       |public class Main implements Repo {
+       |  @Override
+       |  public List<String> all() {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |
+       |  @Override
+       |  public Map<String, Integer> index() {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
+  )
+
+  // A nested member type is shortened by importing its outermost enclosing
+  // type and qualifying the rest with simple names.
+  check(
+    "nested-type",
+    """|package a;
+       |
+       |interface Source {
+       |  java.util.Map.Entry<String, String> entry();
+       |}
+       |
+       |public class <<Main>> implements Source {
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |import java.util.Map;
+       |
+       |interface Source {
+       |  java.util.Map.Entry<String, String> entry();
+       |}
+       |
+       |public class Main implements Source {
+       |  @Override
+       |  public Map.Entry<String, String> entry() {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
+  )
+
+  // The file declares a type named `List`, so the inherited `java.util.List`
+  // must stay fully qualified to avoid a clash.
+  check(
+    "clash-keeps-fqn",
+    """|package a;
+       |
+       |interface List {
+       |  java.util.List<String> values();
+       |}
+       |
+       |public class <<Main>> implements List {
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |interface List {
+       |  java.util.List<String> values();
+       |}
+       |
+       |public class Main implements List {
+       |  @Override
+       |  public java.util.List<String> values() {
        |    throw new UnsupportedOperationException("Not yet implemented");
        |  }
        |}

--- a/tests/unit/src/test/scala/tests/codeactions/JavaImplementAbstractMembersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/JavaImplementAbstractMembersLspSuite.scala
@@ -1,0 +1,213 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.codeactions.ImplementAbstractMembers
+
+class JavaImplementAbstractMembersLspSuite
+    extends BaseCodeActionLspSuite("java-implement-abstract-members") {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(presentationCompilerDiagnostics = true)
+
+  override protected def toPath(
+      fileName: String,
+      isSource: Boolean = true,
+  ): String =
+    if (isSource) s"a/src/main/java/a/$fileName"
+    else s"a/$fileName"
+
+  private val onlyImplementAll: org.eclipse.lsp4j.CodeAction => Boolean =
+    _.getTitle() == ImplementAbstractMembers.title
+
+  check(
+    "interface",
+    """|package a;
+       |
+       |interface Greeter {
+       |  String greet(String name);
+       |}
+       |
+       |public class <<Main>> implements Greeter {
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |interface Greeter {
+       |  String greet(String name);
+       |}
+       |
+       |public class Main implements Greeter {
+       |  @Override
+       |  public java.lang.String greet(java.lang.String name) {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
+  )
+
+  check(
+    "abstract-class",
+    """|package a;
+       |
+       |abstract class Base {
+       |  abstract int count(String s);
+       |  abstract String value();
+       |  void concrete() {}
+       |}
+       |
+       |public class <<Main>> extends Base {
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |abstract class Base {
+       |  abstract int count(String s);
+       |  abstract String value();
+       |  void concrete() {}
+       |}
+       |
+       |public class Main extends Base {
+       |  @Override
+       |  int count(java.lang.String s) {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |
+       |  @Override
+       |  java.lang.String value() {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
+  )
+
+  check(
+    "generics",
+    """|package a;
+       |
+       |interface Box<T> {
+       |  T unwrap();
+       |  void store(T value);
+       |}
+       |
+       |public class <<Main>> implements Box<String> {
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |interface Box<T> {
+       |  T unwrap();
+       |  void store(T value);
+       |}
+       |
+       |public class Main implements Box<String> {
+       |  @Override
+       |  public void store(java.lang.String value) {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |
+       |  @Override
+       |  public java.lang.String unwrap() {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
+  )
+
+  check(
+    "with-existing-members",
+    """|package a;
+       |
+       |interface Greeter {
+       |  String greet(String name);
+       |}
+       |
+       |public class <<Main>> implements Greeter {
+       |  private final String prefix = "Hello";
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |interface Greeter {
+       |  String greet(String name);
+       |}
+       |
+       |public class Main implements Greeter {
+       |  private final String prefix = "Hello";
+       |
+       |  @Override
+       |  public java.lang.String greet(java.lang.String name) {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
+  )
+
+  check(
+    "varargs",
+    """|package a;
+       |
+       |interface Formatter {
+       |  String format(String pattern, Object... args);
+       |}
+       |
+       |public class <<Main>> implements Formatter {
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |interface Formatter {
+       |  String format(String pattern, Object... args);
+       |}
+       |
+       |public class Main implements Formatter {
+       |  @Override
+       |  public java.lang.String format(java.lang.String pattern, java.lang.Object... args) {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
+  )
+
+  checkNoAction(
+    "already-implemented",
+    """|package a;
+       |
+       |interface Greeter {
+       |  String greet(String name);
+       |}
+       |
+       |public class <<Main>> implements Greeter {
+       |  public String greet(String name) {
+       |    return name;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+  )
+}

--- a/tests/unit/src/test/scala/tests/codeactions/JavaImplementAbstractMembersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/JavaImplementAbstractMembersLspSuite.scala
@@ -346,6 +346,7 @@ class JavaImplementAbstractMembersLspSuite
        |}
        |
        |public class <<Main>> implements Greeter {
+       |  @Override
        |  public String greet(String name) {
        |    return name;
        |  }
@@ -353,5 +354,91 @@ class JavaImplementAbstractMembersLspSuite
        |""".stripMargin,
     fileName = "Main.java",
     filterAction = onlyImplementAll,
+  )
+
+  check(
+    "method-type-params-with-bounds",
+    """|   package a;
+       |
+       |import java.io.Serializable;
+       |
+       |interface Processor {
+       |  <T extends Number> T findMax(T a, T b);
+       |  <K, V extends java.util.List<K> > V transform(K key);
+       |  <E extends Serializable & Cloneable> E process(E input);
+       |}
+       |
+       |public class <<Main>> implements Processor {
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|   package a;
+       |
+       |import java.io.Serializable;
+       |import java.util.List;
+       |
+       |interface Processor {
+       |  <T extends Number> T findMax(T a, T b);
+       |  <K, V extends java.util.List<K> > V transform(K key);
+       |  <E extends Serializable & Cloneable> E process(E input);
+       |}
+       |
+       |public class Main implements Processor {
+       |  @Override
+       |  public <T extends Number> T findMax(T a, T b) {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |
+       |  @Override
+       |  public <E extends Serializable & Cloneable> E process(E input) {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |
+       |  @Override
+       |  public <K, V extends List<K>> V transform(K key) {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
+  )
+
+  // A member type inside the target class named `List` should prevent
+  // shortening `java.util.List` to avoid a collision with the nested class.
+  check(
+    "member-type-clash-keeps-fqn",
+    """|package a;
+       |
+       |interface Source {
+       |  java.util.List<String> values();
+       |}
+       |
+       |public class <<Main>> implements Source {
+       |  class List {}
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |interface Source {
+       |  java.util.List<String> values();
+       |}
+       |
+       |public class Main implements Source {
+       |  class List {}
+       |
+       |  @Override
+       |  public java.util.List<String> values() {
+       |    throw new UnsupportedOperationException("Not yet implemented");
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Main.java",
+    filterAction = onlyImplementAll,
+    retryAction = 3,
   )
 }


### PR DESCRIPTION
Implements ImplementAbstractMembers for JavaPC (issue #8499). When javac reports `compiler.err.does.not.override.abstract`, the quick-fix offers "Implement all members", inserting `@Override` stubs for every inherited but unimplemented abstract method, with
`throw new UnsupportedOperationException("Not yet implemented");` bodies and fully-qualified type names.

- JavaImplementAbstractMembersProvider: compiles + analyzes the file, finds the enclosing class at the cursor, enumerates unimplemented abstract methods via Elements.getAllMembers + Types.asMemberOf (so generics are substituted), and produces a TextEdit. Handles generics, varargs, method type parameters, access modifiers, and indentation.
- JavaPresentationCompiler.implementAbstractMembers now calls the provider instead of returning an empty list.
- JavacDiagnostic.DoesNotOverrideAbstract extractor matches by javac code (PC diagnostics) or message (BSP-published diagnostics).
- ImplementAbstractMembers code action is now isJava=true and matches the javac diagnostic, dispatching through compilers.implementAbstractMembers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Java code actions can now generate missing abstract method implementations for classes and interfaces.
  * Added support for inserting required imports automatically when generated methods use new types.

* **Bug Fixes**
  * Improved detection of abstract-method errors so the action appears for more Java compiler messages.
  * Prevented empty code actions from being shown when no edits are available.

* **Tests**
  * Added coverage for Java implementation scenarios, including generics, nested types, imports, and cases where no action should be offered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->