### PR TITLE
mbt(bazel): resolve maven deps from rules_jvm_external hub locks

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDependencyModule.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDependencyModule.scala
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 import java.util.ArrayList
 import javax.annotation.Nullable
 
-import scala.util.control.NonFatal
+import scala.util.Try
 
 import ch.epfl.scala.bsp4j
 
@@ -58,11 +58,9 @@ object MbtDependencyModule {
   /**
    * Parse a string that should be a URI but may accidentally be a file path.
    */
-  def parseUri(value: String): URI = try {
-    URI.create(value)
-  } catch {
-    case NonFatal(_) =>
-      Paths.get(value).toUri
-  }
+  private def parseUri(value: String): URI =
+    Try(URI.create(value)).toOption
+      .filterNot(_.getScheme == null)
+      .getOrElse(Paths.get(value).toUri)
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMavenJsonImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMavenJsonImporter.scala
@@ -8,9 +8,11 @@ import scala.util.Try
 
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.mbt.MbtDependencyModule
+import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 
 import com.google.gson.Gson
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 
@@ -31,43 +33,79 @@ object BazelMavenJsonImporter {
       entries: List[AbsolutePath],
   )
 
+  /**
+   * Resolve the project's Maven dependency modules from the materialized
+   * rules_jvm_external hubs.
+   *
+   * Each discovered hub's `imported_maven_install.json` is the authoritative
+   * lock Bazel actually materialized and built against, so it is the primary
+   * module source – more reliable than scanning the source tree
+   * for a checked-in `maven_install.json`: a project that pins but does not check
+   * the lock into the tree (or stores it somewhere unexpected) still resolves.
+   * The heuristic [[findAllMavenInstallJson]] kept as a fallback
+   * for when no hub is materialized.
+   */
   def importMaven(
       projectDir: AbsolutePath,
       outputBase: Option[Path],
-      repositoryName: String,
+      hubs: List[MavenHub],
   ): Seq[MbtDependencyModule] = {
-    val mavenInstallPaths =
-      findAllMavenInstallJson(projectDir)
+    val repositoryNames =
+      if (hubs.isEmpty) Seq(DefaultRepositoryName.value)
+      else hubs.map(_.name.value).distinct
 
-    if (mavenInstallPaths.isEmpty) {
+    val lockFiles = lockFilesFor(projectDir, hubs)
+
+    if (lockFiles.isEmpty) {
       scribe.error(
         "No maven_install.json found. Make sure rules_jvm_external is configured and pinned. You might need to run `REPIN=1 bazel run @maven//:pin`."
       )
       Seq.empty[MbtDependencyModule]
     } else {
-      val allModules = mavenInstallPaths.flatMap { path =>
+      val allModules = lockFiles.flatMap { path =>
         scribe.info(s"bazel-mbt: processing maven lock file: $path")
-        val content = path.readText
-        val json = gson.fromJson(content, classOf[JsonObject])
-        extractArtifacts(
-          json,
-          outputBase.map(AbsolutePath.apply),
-          projectDir,
-          repositoryName,
+        Try {
+          val content = path.readText
+          val json = gson.fromJson(content, classOf[JsonObject])
+          extractArtifacts(
+            json,
+            outputBase.map(AbsolutePath.apply),
+            projectDir,
+            repositoryNames,
+            path,
+          )
+        }.fold(
+          e => {
+            scribe.error(
+              s"bazel-mbt: failed to parse maven lock file $path; skipping it: ${e.getMessage}"
+            )
+            Seq.empty[MbtDependencyModule]
+          },
+          identity,
         )
       }
-
-      allModules
-        .groupBy(_.id)
-        .values
-        .map { modules =>
-          modules.maxBy(m => if (m.sourcesURI.isDefined) 1 else 0)
-        }
-        .toSeq
-        .sortBy(_.id)
+      dedupModulesById(allModules)
     }
-
   }
+
+  private def lockFilesFor(
+      projectDir: AbsolutePath,
+      hubs: List[MavenHub],
+  ): Seq[AbsolutePath] = {
+    val hubLocks = hubs.map(_.importedLock).filter(_.exists)
+    if (hubLocks.nonEmpty) hubLocks
+    else findAllMavenInstallJson(projectDir).toSeq
+  }
+
+  private def dedupModulesById(
+      modules: Seq[MbtDependencyModule]
+  ): Seq[MbtDependencyModule] =
+    modules
+      .groupBy(_.id)
+      .values
+      .map(_.maxBy(_.sourcesURI.isDefined))
+      .toSeq
+      .sortBy(_.id)
 
   /**
    * Find all maven_install.json files in various possible locations.
@@ -154,52 +192,230 @@ object BazelMavenJsonImporter {
     }
   }
 
+  private val DefaultRepositoryName = HubName("maven")
+
   /**
-   * Tries to extract the repository name from the Bazel config files.
-   * If maven.install is not found in the main config files, it will also
-   * search through included files.
-   *
-   * @return the repository name, or "maven" if not found
+   * rules_jvm_external's own internal dependency hub. It is a pinned
+   * `maven_install` hub and therefore carries the same generated marker as a
+   * project hub, but it holds the ruleset's dependencies — not the project's —
+   * so it must never be reported as the project's Maven repository.
    */
-  def extractRepositoryNameFromBazelConfig(
-      projectDir: AbsolutePath
-  ): String = {
-    val namePattern = """name\s*=\s*"([^"]+)"""".r
-    val configFiles = possibleConfigFiles(projectDir)
+  private val internalHubNames = Set(HubName("rules_jvm_external_deps"))
 
-    def extractFromContent(content: String): Option[String] = {
-      val indexOfMavenInstall = content.indexOf("maven_install") match {
-        case -1 => content.indexOf("maven.install")
-        case index => index
+  /**
+   * A rules_jvm_external hub's apparent repository name, already canonicalized
+   * (trailing `+`/`~` segment, `unpinned_` prefix stripped) via
+   * [[HubName.fromDirOrLabel]].
+   */
+  final case class HubName(value: String) extends AnyVal
+
+  object HubName {
+    def fromDirOrLabel(raw: String): HubName =
+      HubName(apparentRepoName(raw).stripPrefix("unpinned_"))
+  }
+
+  case class MavenHub(name: HubName, importedLock: AbsolutePath)
+
+  /**
+   * Discover the materialized rules_jvm_external Maven hubs from the `external/`
+   * directories, each with its repository name and the path to its
+   * `imported_maven_install.json`.
+   *
+   * A pinned hub is identified by the marker rules_jvm_external writes into
+   * every hub it generates: an `imported_maven_install.json` file. The repo
+   * name is the directory name itself in WORKSPACE mode (`maven`,
+   * `custom_repo`), or the trailing `+`/`~`-separated segment of a bzlmod
+   * canonical name (`rules_jvm_external++maven+maven` /
+   * `rules_jvm_external~6.2~maven~maven` -> `maven`). A leading `unpinned_` is
+   * stripped, and the ruleset's internal [[internalHubNames]] hub is excluded.
+   */
+  def discoverMavenHubs(extDirs: Seq[AbsolutePath]): List[MavenHub] = {
+    val hubs = for {
+      extDir <- extDirs if extDir.exists
+      entry <- Try(extDir.list.toList).getOrElse(Nil) if isPinnedMavenHub(entry)
+      apparent = HubName.fromDirOrLabel(entry.filename)
+      if !internalHubNames.contains(apparent)
+    } yield MavenHub(apparent, entry.resolve("imported_maven_install.json"))
+    hubs.distinctBy(_.name).toList
+  }
+
+  private def sanitizeCoordinate(group: String, artifact: String): String = {
+    def sanitize(s: String): String = s.replace('.', '_').replace('-', '_')
+    s"${sanitize(group)}_${sanitize(artifact)}"
+  }
+
+  /**
+   * Parse a hub's `imported_maven_install.json` into a
+   * `sanitizedCoordinate -> version` map. Handles both lock formats, mirroring
+   * [[extractArtifacts]]:
+   *   - new (v5+): `{"artifacts": {"group:artifact": {"version": ...}}}`
+   *   - legacy (v4 and earlier): `{"dependency_tree": {"dependencies":
+   *     [{"coord": "group:artifact:version"}]}}`
+   * Tolerates a missing/empty/unknown shape by returning the empty map.
+   */
+  private def hubCoordinateVersions(hub: MavenHub): Map[String, String] = {
+    val parsed = Try {
+      val json = gson.fromJson(hub.importedLock.readText, classOf[JsonObject])
+      MavenLockFormat.of(json) match {
+        case MavenLockFormat.NewFormat(artifacts) =>
+          coordinateVersionsFromNewFormat(artifacts)
+        case MavenLockFormat.LegacyFormat(dependencies) =>
+          coordinateVersionsFromLegacyFormat(dependencies)
+        case MavenLockFormat.Unknown => Nil
       }
-      if (indexOfMavenInstall == -1) None
-      else
-        namePattern
-          .findAllMatchIn(content.substring(indexOfMavenInstall))
-          .map(_.group(1))
-          .headOption
+    }.getOrElse(Nil)
+    parsed.toMap
+  }
+
+  private sealed trait MavenLockFormat
+  private object MavenLockFormat {
+
+    /** New (v5+): `{"artifacts": {"group:artifact": {"version": ...}}}`. */
+    case class NewFormat(artifacts: JsonObject) extends MavenLockFormat
+
+    /** Legacy (v4 and earlier): `{"dependency_tree": {"dependencies": [...]}}`. */
+    case class LegacyFormat(dependencies: JsonArray) extends MavenLockFormat
+
+    case object Unknown extends MavenLockFormat
+
+    def of(json: JsonObject): MavenLockFormat =
+      Option(json.getAsJsonObject("artifacts")) match {
+        case Some(artifacts) => NewFormat(artifacts)
+        case None =>
+          Option(json.getAsJsonObject("dependency_tree"))
+            .flatMap(dt => Option(dt.getAsJsonArray("dependencies"))) match {
+            case Some(dependencies) => LegacyFormat(dependencies)
+            case None => Unknown
+          }
+      }
+  }
+
+  private def coordinateVersionsFromNewFormat(
+      artifacts: JsonObject
+  ): List[(String, String)] =
+    for {
+      entry <- artifacts.entrySet().asScala.toList
+      parts = entry.getKey.split(":") if parts.length == 2
+      value = entry.getValue if value.isJsonObject
+      versionElem <- Option(value.getAsJsonObject.get("version")).toList
+      if versionElem.isJsonPrimitive
+    } yield sanitizeCoordinate(parts(0), parts(1)) -> versionElem.getAsString
+
+  /**
+   * `dependency_tree.dependencies` array (legacy format) -> sanitized
+   * `coordinate -> version`. Coords are
+   * `group:artifact[:packaging[:classifier]]:version`;
+   * sources entries (`group:artifact:jar:sources:version`) are skipped.
+   */
+  private def coordinateVersionsFromLegacyFormat(
+      dependencies: JsonArray
+  ): List[(String, String)] =
+    for {
+      elem <- dependencies.iterator().asScala.toList if elem.isJsonObject
+      coord <- Option(elem.getAsJsonObject.get("coord"))
+        .filter(_.isJsonPrimitive)
+        .map(_.getAsString)
+        .toList
+      if !coord.contains(":jar:sources:")
+      parts = coord.split(":") if parts.length >= 3
+    } yield sanitizeCoordinate(parts(0), parts(1)) -> parts.last
+
+  /** The coordinate suffix of a dep label: the part after `//:`. */
+  private def labelCoordinate(label: String): Option[String] =
+    label.split("//:", 2).toList match {
+      case _ :: "" :: _ => None
+      case _ :: coord :: _ => Some(coord)
+      case _ => None
     }
 
-    val loadedFile = TrieMap.empty[AbsolutePath, String]
-    // First, try to find in main config files
-    val fromMainConfigs = configFiles.flatMap { configFile =>
-      val content = configFile.readText
-      loadedFile.put(configFile, content)
-      extractFromContent(content)
-    }.headOption
+  /**
+   * The apparent hub name of a dep label: the repo part before `//`, with any
+   * leading `@`/`@@` stripped and reduced to its trailing `+`/`~` segment.
+   * Example: `@@rules_jvm_external++maven+maven//:org_scalameta_trees_2_13` ->
+   * `maven`. [[None]] when there is no repo part.
+   */
+  private def labelHubName(label: String): Option[HubName] = {
+    val stripped = label.stripPrefix("@@").stripPrefix("@")
+    val sep = stripped.indexOf("//")
+    val repoPart = if (sep < 0) stripped else stripped.substring(0, sep)
+    if (repoPart.isEmpty) None
+    else Some(HubName.fromDirOrLabel(repoPart))
+  }
 
-    fromMainConfigs.getOrElse {
-      // If not found, search through includes
-      val fromIncludes = configFiles.flatMap { configFile =>
-        val content = loadedFile.getOrElse(configFile, configFile.readText)
-        val includedFiles = extractIncludePaths(content, projectDir)
-        includedFiles.flatMap { includedFile =>
-          Try(includedFile.readText).toOption.flatMap(extractFromContent)
-        }
-      }.headOption
+  private val versionOrdering: Ordering[String] =
+    Ordering.by(v => (Try(SemVer.Version.fromString(v)).toOption, v))
 
-      fromIncludes.getOrElse("maven")
+  /**
+   * Match Bazel external dep labels to resolved Maven module ids by coordinate
+   * suffix, using the hub when one coordinate maps to several module versions.
+   *
+   * @param externalDeps target -> external dep labels (`@<hub>//:<coord>`)
+   * @param modules      resolved Maven modules
+   * @param hubs         materialized hubs, providing per-hub `coordinate -> version`
+   * @return target -> matched module ids (distinct, order-preserving)
+   */
+  def matchExternalDeps(
+      externalDeps: Map[String, List[String]],
+      modules: Seq[MbtDependencyModule],
+      hubs: List[MavenHub],
+  ): Map[String, List[String]] = {
+    val modulesBySuffix: Map[String, List[MbtDependencyModule]] =
+      modules.toList.groupBy(m => sanitizeCoordinate(m.organization, m.name))
+    val hubVersions: Map[HubName, Map[String, String]] =
+      hubs.map(hub => hub.name -> hubCoordinateVersions(hub)).toMap
+
+    def pick(label: String, coord: String): Option[String] = {
+      val candidates = modulesBySuffix.getOrElse(coord, Nil)
+      if (candidates.sizeIs <= 1) candidates.headOption.map(_.id)
+      else {
+        val wanted = labelHubName(label)
+          .flatMap(hubVersions.get)
+          .flatMap(_.get(coord))
+        val chosen = wanted
+          .flatMap(v => candidates.find(_.version == v))
+          .orElse {
+            val fallback = candidates.maxBy(_.version)(versionOrdering)
+            scribe.warn(
+              s"""|bazel-mbt: ambiguous external dep '$label' (coordinate '$coord')
+                  |matched ${candidates.size} module versions
+                  |[${candidates.map(_.version).mkString(", ")}];
+                  |no per-hub version match, picking '${fallback.version}'""".stripMargin
+            )
+            Some(fallback)
+          }
+        chosen.map(_.id)
+      }
     }
+
+    externalDeps.map { case (target, labels) =>
+      val matched = for {
+        label <- labels
+        coord <- labelCoordinate(label).toList
+        id <- pick(label, coord).toList
+      } yield id
+      target -> matched.distinct
+    }
+  }
+
+  private def isPinnedMavenHub(dir: AbsolutePath): Boolean =
+    dir.isDirectory && dir.resolve("imported_maven_install.json").exists
+
+  private def apparentRepoName(dirName: String): String =
+    dirName.split("[+~]").lastOption.getOrElse(dirName)
+
+  def externalDirs(
+      projectDir: AbsolutePath,
+      outputBase: Option[AbsolutePath],
+  ): Seq[AbsolutePath] = {
+    val externalDirOpt = outputBase.map(_.resolve("external"))
+    val bazelProjectExtDirOpt = Try {
+      val bazelLink = projectDir.resolve(s"bazel-${projectDir.filename}")
+      if (bazelLink.exists) {
+        val d = bazelLink.resolve("external")
+        if (d.exists) Some(d) else None
+      } else None
+    }.getOrElse(None)
+    Seq(externalDirOpt, bazelProjectExtDirOpt).flatten.filter(_.exists)
   }
 
   /**
@@ -331,43 +547,27 @@ object BazelMavenJsonImporter {
       json: JsonObject,
       outputBase: Option[AbsolutePath],
       projectDir: AbsolutePath,
-      repositoryName: String,
+      repositoryNames: Seq[String],
+      lockFile: AbsolutePath,
   ): Seq[MbtDependencyModule] = {
-    scribe.debug(s"Using repository name: $repositoryName")
+    scribe.debug(s"Using repository names: ${repositoryNames.mkString(", ")}")
 
     // Pre-scan external directories once so per-artifact lookups avoid repeated Files.list() calls.
-    val externalDirOpt = outputBase.map(_.resolve("external"))
-    val bazelProjectExtDirOpt = Try {
-      val bazelLink = projectDir.resolve(s"bazel-${projectDir.filename}")
-      if (bazelLink.exists) {
-        val d = bazelLink.resolve("external")
-        if (d.exists) Some(d) else None
-      } else None
-    }.getOrElse(None)
-
     val extDirs: Seq[ScannedExtDir] =
-      Seq(externalDirOpt, bazelProjectExtDirOpt).flatten
+      externalDirs(projectDir, outputBase)
         .flatMap(d => Try(ScannedExtDir(d, d.list.toList)).toOption)
 
-    // Try new format first (artifacts key at root)
-    val artifactsObj = Option(json.getAsJsonObject("artifacts"))
-    if (artifactsObj.isDefined) {
-      extractFromNewFormat(artifactsObj.get, repositoryName, extDirs)
-    } else {
-      // Try legacy format (dependency_tree.dependencies array)
-      val dependencyTree = Option(json.getAsJsonObject("dependency_tree"))
-      dependencyTree.flatMap { dt =>
-        Option(dt.getAsJsonArray("dependencies"))
-      } match {
-        case Some(deps) =>
-          scribe.debug("Using legacy dependency_tree format")
-          extractFromLegacyFormat(deps, repositoryName, extDirs)
-        case None =>
-          scribe.debug(
-            "No 'artifacts' or 'dependency_tree.dependencies' found in maven_install.json"
-          )
-          Seq.empty
-      }
+    MavenLockFormat.of(json) match {
+      case MavenLockFormat.NewFormat(artifacts) =>
+        extractFromNewFormat(artifacts, repositoryNames, extDirs)
+      case MavenLockFormat.LegacyFormat(deps) =>
+        scribe.debug("Using legacy dependency_tree format")
+        extractFromLegacyFormat(deps, repositoryNames, extDirs)
+      case MavenLockFormat.Unknown =>
+        scribe.debug(
+          s"No 'artifacts' or 'dependency_tree.dependencies' found in $lockFile"
+        )
+        Seq.empty
     }
   }
 
@@ -376,7 +576,7 @@ object BazelMavenJsonImporter {
    */
   private def extractFromNewFormat(
       artifacts: JsonObject,
-      repositoryName: String,
+      repositoryNames: Seq[String],
       extDirs: Seq[ScannedExtDir],
   ): Seq[MbtDependencyModule] = {
     artifacts.entrySet().asScala.toSeq.flatMap { entry =>
@@ -387,7 +587,7 @@ object BazelMavenJsonImporter {
         parseArtifact(
           coordKey,
           artifactInfo,
-          repositoryName,
+          repositoryNames,
           extDirs,
         )
     }
@@ -397,8 +597,8 @@ object BazelMavenJsonImporter {
    * Extract from legacy format: { "dependency_tree": { "dependencies": [...] } }
    */
   private def extractFromLegacyFormat(
-      dependencies: com.google.gson.JsonArray,
-      repositoryName: String,
+      dependencies: JsonArray,
+      repositoryNames: Seq[String],
       extDirs: Seq[ScannedExtDir],
   ): Seq[MbtDependencyModule] = {
     val deps = dependencies.iterator().asScala.toSeq
@@ -408,6 +608,7 @@ object BazelMavenJsonImporter {
       if (!elem.isJsonObject) false
       else {
         val coord = Option(elem.getAsJsonObject.get("coord"))
+          .filter(_.isJsonPrimitive)
           .map(_.getAsString)
           .getOrElse("")
         !coord.contains(":jar:sources:") && !coord.contains("-sources.")
@@ -415,14 +616,14 @@ object BazelMavenJsonImporter {
     }
 
     jarDeps.flatMap { elem =>
-      parseLegacyDependency(elem, deps, repositoryName, extDirs)
+      parseLegacyDependency(elem, deps, repositoryNames, extDirs)
     }
   }
 
   private def parseLegacyDependency(
       elem: JsonElement,
       allDeps: Seq[JsonElement],
-      repositoryName: String,
+      repositoryNames: Seq[String],
       extDirs: Seq[ScannedExtDir],
   ): Option[MbtDependencyModule] = {
     Try {
@@ -432,11 +633,11 @@ object BazelMavenJsonImporter {
       val file = Option(obj.get("file")).map(_.getAsString)
       val url = Option(obj.get("url")).map(_.getAsString)
 
-      // Parse coordinate: group:artifact:version
+      // Parse coordinate: group:artifact[:packaging[:classifier]]:version
       val parts = coord.split(":")
       if (parts.length < 3) None
       else {
-        val (groupId, artifactId, version) = (parts(0), parts(1), parts(2))
+        val (groupId, artifactId, version) = (parts(0), parts(1), parts.last)
 
         if (version.contains("SNAPSHOT")) {
           scribe.debug(s"Skipping SNAPSHOT: $coord")
@@ -449,10 +650,16 @@ object BazelMavenJsonImporter {
           // Find JAR path - try local paths first
           val jarPath = file
             .flatMap { f =>
-              findJarFromLegacyPath(f, repositoryName, extDirs)
+              findJarFromLegacyPath(f, repositoryNames, extDirs)
             }
             .orElse {
-              findJarPath(groupId, artifactId, version, repositoryName, extDirs)
+              findJarPath(
+                groupId,
+                artifactId,
+                version,
+                repositoryNames,
+                extDirs,
+              )
             }
             .orElse {
               scribe.warn(s"Downloading from URL, could not find locally: $url")
@@ -481,14 +688,14 @@ object BazelMavenJsonImporter {
             val sourcesJarName = s"$artifactId-$version-sources.jar"
             val sourcesPath = sourcesFile
               .flatMap { f =>
-                findJarFromLegacyPath(f, repositoryName, extDirs)
+                findJarFromLegacyPath(f, repositoryNames, extDirs)
               }
               .orElse {
                 findSourcesPath(
                   groupId,
                   artifactId,
                   version,
-                  repositoryName,
+                  repositoryNames,
                   extDirs,
                 )
               }
@@ -539,7 +746,7 @@ object BazelMavenJsonImporter {
 
       // Check if already exists
       if (Files.exists(targetPath)) {
-        Some(targetPath.toString)
+        Some(targetPath.toUri.toString)
       } else {
         scribe.debug(s"Downloading: $url")
 
@@ -565,7 +772,7 @@ object BazelMavenJsonImporter {
           try {
             Files.copy(in, targetPath)
             scribe.debug(s"Downloaded to: $targetPath")
-            Some(targetPath.toString)
+            Some(targetPath.toUri.toString)
           } finally {
             in.close()
           }
@@ -580,25 +787,23 @@ object BazelMavenJsonImporter {
    */
   private def findJarFromLegacyPath(
       filePath: String,
-      repositoryName: String,
+      repositoryNames: Seq[String],
       extDirs: Seq[ScannedExtDir],
   ): Option[String] = {
-    val patterns = Seq(
-      s"$repositoryName/$filePath",
-      s"maven/$filePath",
-      filePath,
-    )
+    val patterns =
+      (repositoryNames.map(repo => s"$repo/$filePath") ++
+        Seq(s"maven/$filePath", filePath)).distinct
 
     extDirs.view
-      .flatMap(findInExternalRepositories(_, patterns, repositoryName))
+      .flatMap(findInExternalRepositories(_, patterns, repositoryNames))
       .headOption
-      .map(_.toString)
+      .map(_.toURI.toString)
   }
 
   private def parseArtifact(
       coordKey: String,
       artifactInfo: JsonElement,
-      repositoryName: String,
+      repositoryNames: Seq[String],
       extDirs: Seq[ScannedExtDir],
   ): Option[MbtDependencyModule] = {
     val info = artifactInfo.getAsJsonObject
@@ -621,11 +826,11 @@ object BazelMavenJsonImporter {
 
           // Find JAR file path
           val jarPath =
-            findJarPath(groupId, artifactId, v, repositoryName, extDirs)
+            findJarPath(groupId, artifactId, v, repositoryNames, extDirs)
 
           jarPath.map { jar =>
             val sourcesPath =
-              findSourcesPath(groupId, artifactId, v, repositoryName, extDirs)
+              findSourcesPath(groupId, artifactId, v, repositoryNames, extDirs)
 
             MbtDependencyModule(
               id = id,
@@ -637,6 +842,20 @@ object BazelMavenJsonImporter {
       }
     }
   }
+
+  private def workspaceArtifactPatterns(
+      repositoryNames: Seq[String],
+      groupPath: String,
+      artifactId: String,
+      version: String,
+      fileName: String,
+  ): Seq[String] =
+    (repositoryNames.map(repo =>
+      s"$repo/v1/https/repo1.maven.org/maven2/$groupPath/$artifactId/$version/$fileName"
+    ) ++ Seq(
+      s"maven/v1/https/repo1.maven.org/maven2/$groupPath/$artifactId/$version/$fileName",
+      s"maven/$groupPath/$artifactId/$version/$fileName",
+    )).distinct
 
   /**
    * Find the JAR file in the Bazel external directory.
@@ -654,7 +873,7 @@ object BazelMavenJsonImporter {
       groupId: String,
       artifactId: String,
       version: String,
-      repositoryName: String,
+      repositoryNames: Seq[String],
       extDirs: Seq[ScannedExtDir],
   ): Option[String] = {
     val groupPath = groupId.replace('.', '/')
@@ -662,11 +881,14 @@ object BazelMavenJsonImporter {
 
     val bzlmodArtifactDir = toBzlmodArtifactDir(groupId, artifactId, version)
 
-    val workspacePatterns = Seq(
-      s"$repositoryName/v1/https/repo1.maven.org/maven2/$groupPath/$artifactId/$version/$jarName",
-      s"maven/v1/https/repo1.maven.org/maven2/$groupPath/$artifactId/$version/$jarName",
-      s"maven/$groupPath/$artifactId/$version/$jarName",
-    ).distinct
+    val workspacePatterns =
+      workspaceArtifactPatterns(
+        repositoryNames,
+        groupPath,
+        artifactId,
+        version,
+        jarName,
+      )
 
     extDirs.view
       .flatMap { scanned =>
@@ -682,7 +904,7 @@ object BazelMavenJsonImporter {
             findInExternalRepositories(
               scanned,
               workspacePatterns,
-              repositoryName,
+              repositoryNames,
             )
           )
       }
@@ -774,14 +996,14 @@ object BazelMavenJsonImporter {
   private def findInExternalRepositories(
       scanned: ScannedExtDir,
       relativePaths: Seq[String],
-      repositoryName: String,
+      repositoryNames: Seq[String],
   ): Option[AbsolutePath] = {
     val directMatch =
       relativePaths.map(path => scanned.dir.resolve(path)).find(_.exists)
 
     directMatch.orElse {
       val bzlmodRepositoryNames =
-        Seq(repositoryName, s"unpinned_$repositoryName").distinct
+        repositoryNames.flatMap(repo => Seq(repo, s"unpinned_$repo")).distinct
 
       val candidateRepositories = scanned.entries.filter { entry =>
         val name = entry.filename.toString
@@ -793,13 +1015,7 @@ object BazelMavenJsonImporter {
       }
 
       val repositoryRelativePaths = relativePaths.flatMap { path =>
-        bzlmodRepositoryNames.flatMap { repo =>
-          Seq(
-            path,
-            path.stripPrefix(s"$repo/"),
-            path.stripPrefix(s"$repositoryName/"),
-          )
-        }
+        path +: bzlmodRepositoryNames.map(repo => path.stripPrefix(s"$repo/"))
       }.distinct
 
       val found = candidateRepositories.flatMap { repo =>
@@ -827,7 +1043,7 @@ object BazelMavenJsonImporter {
       groupId: String,
       artifactId: String,
       version: String,
-      repositoryName: String,
+      repositoryNames: Seq[String],
       extDirs: Seq[ScannedExtDir],
   ): Option[String] = {
     val groupPath = groupId.replace('.', '/')
@@ -835,10 +1051,14 @@ object BazelMavenJsonImporter {
 
     val bzlmodSourcesDirs = toBzlmodSourcesDirs(groupId, artifactId, version)
 
-    val workspacePatterns = Seq(
-      s"$repositoryName/v1/https/repo1.maven.org/maven2/$groupPath/$artifactId/$version/$sourcesJarName",
-      s"maven/v1/https/repo1.maven.org/maven2/$groupPath/$artifactId/$version/$sourcesJarName",
-    ).distinct
+    val workspacePatterns =
+      workspaceArtifactPatterns(
+        repositoryNames,
+        groupPath,
+        artifactId,
+        version,
+        sourcesJarName,
+      )
 
     extDirs.view
       .flatMap { scanned =>
@@ -858,7 +1078,7 @@ object BazelMavenJsonImporter {
             findInExternalRepositories(
               scanned,
               workspacePatterns,
-              repositoryName,
+              repositoryNames,
             )
           )
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
@@ -16,7 +16,6 @@ import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.mbt.MbtBuild
-import scala.meta.internal.metals.mbt.MbtDependencyModule
 import scala.meta.internal.process.ExitCodes
 import scala.meta.io.AbsolutePath
 
@@ -52,12 +51,19 @@ abstract class BazelMbtImporter(
     for {
       outputBase <- queryOutputBase()
       bazelBin <- queryBazelBin()
-      repositoryName = BazelMavenJsonImporter
-        .extractRepositoryNameFromBazelConfig(projectRoot)
-      _ = scribe.info(s"bazel-mbt: found repository name: $repositoryName")
+      mavenHubs = BazelMavenJsonImporter
+        .discoverMavenHubs(
+          BazelMavenJsonImporter.externalDirs(
+            projectRoot,
+            outputBase.map(AbsolutePath.apply),
+          )
+        )
+      _ = scribe.info(
+        s"bazel-mbt: found maven hubs: ${mavenHubs.map(_.name.value).mkString(", ")}"
+      )
       mavenImportStart = System.nanoTime()
       dependencyModules = BazelMavenJsonImporter
-        .importMaven(projectRoot, outputBase, repositoryName)
+        .importMaven(projectRoot, outputBase, mavenHubs)
       _ = scribe.debug(
         s"bazel-mbt: importMaven took ${(System.nanoTime() - mavenImportStart) / 1_000_000}ms"
       )
@@ -97,10 +103,10 @@ abstract class BazelMbtImporter(
       )
       deps = queryDeps(targets.toSet, targets, targetsXmlDump)
       externalDeps = targetsXmlDump.externalDepsByTarget(targets)
-      externalDepModules = matchExternalDepsToModules(
+      externalDepModules = BazelMavenJsonImporter.matchExternalDeps(
         externalDeps,
         dependencyModules,
-        repositoryName,
+        mavenHubs,
       )
       scalaVersionFromDeps <- queryScalaVersionFromDeps()
       effectiveScalaVersion <- scalaVersionFromDeps match {
@@ -202,45 +208,6 @@ abstract class BazelMbtImporter(
     orderedTargets.map { target =>
       target -> targetsXml.depsByTarget.getOrElse(target, Nil).filter(targetSet)
     }.toMap
-  }
-
-  private def matchExternalDepsToModules(
-      externalDeps: Map[String, List[String]],
-      dependencyModules: Seq[MbtDependencyModule],
-      repositoryName: String,
-  ): Map[String, List[String]] = {
-    val modulesByBazelLabel = dependencyModules.flatMap { module =>
-      bazelLabelFromModuleId(module.id, repositoryName).map(_ -> module.id)
-    }.toMap
-
-    externalDeps.map { case (target, deps) =>
-      val matchedModuleIds = for {
-        dep <- deps
-        normalizedDep = normalizeBazelLabel(dep)
-        moduleId <- modulesByBazelLabel.get(normalizedDep)
-      } yield moduleId
-      target -> matchedModuleIds
-    }
-  }
-
-  private def bazelLabelFromModuleId(
-      moduleId: String,
-      repositoryName: String,
-  ): Option[String] = {
-    val parts = moduleId.split(":")
-    if (parts.length >= 2) {
-      val groupId = parts(0)
-      val artifactId = parts(1)
-      val sanitizedGroup = groupId.replace('.', '_').replace('-', '_')
-      val sanitizedArtifact = artifactId.replace('.', '_').replace('-', '_')
-      Some(s"@$repositoryName//:${sanitizedGroup}_$sanitizedArtifact")
-    } else None
-  }
-
-  private def normalizeBazelLabel(label: String): String = {
-    val withoutDoubleAt =
-      if (label.startsWith("@@")) label.substring(1) else label
-    withoutDoubleAt.replaceAll("~[^/]+", "")
   }
 
   private def queryScalaVersionFromDeps(): Future[Option[String]] = for {

--- a/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
@@ -59,37 +59,9 @@ class BazelMbtLspSuite
         |    //...
         |
         |""".stripMargin
-    val rulesAndSources =
-      s"""|/core/BUILD
-          |load("@rules_scala//scala:scala.bzl", "scala_library")
-          |
-          |scala_library(
-          |    name = "hello_lib",
-          |    srcs = ["Hello.scala", "Bar.scala"],
-          |    visibility = ["//visibility:public"],
-          |    scalacopts = ["-deprecation"],
-          |    deps = ["@maven//:org_typelevel_cats_core_2_13"],
-          |)
-          |
-          |/core/Hello.scala
-          |package core
-          |
-          |import cats.syntax.all._
-          |
-          |class Hello {
-          |  def hello: String = "Hello"
-          |  def catOption: Option[Int] = 1.some
-          |
-          |}
-          |
-          |/core/Bar.scala
-          |package core
-          |
-          |class Bar {
-          |  def bar: String = "bar"
-          |  def hi = new Hello().hello
-          |}
-          |
+    val rulesAndSources1 = rulesAndSources("maven")
+    val rulesAndSources2 =
+      s"""|
           |/app/BUILD
           |load("@rules_scala//scala:scala.bzl", "scala_binary")
           |
@@ -118,12 +90,54 @@ class BazelMbtLspSuite
           | def decode: String = "decode"
           |}
           |""".stripMargin
-    projectView + rulesAndSources
+    projectView + rulesAndSources1 + rulesAndSources2
   }
 
   private val mavenDeps: List[String] = List(
     s"org.typelevel:cats-core_2.13:$catsVersion"
   )
+
+  private val singleCoreMbtJson: String =
+    """|{
+       |  "dependencyModules": [
+       |    {
+       |      "id": "org.scala-lang:scala-library:2.13.16",
+       |      "jar": "<jar-path>",
+       |      "sources": "<sources-path>"
+       |    },
+       |    {
+       |      "id": "org.typelevel:cats-core_2.13:2.13.0",
+       |      "jar": "<jar-path>",
+       |      "sources": "<sources-path>"
+       |    },
+       |    {
+       |      "id": "org.typelevel:cats-kernel_2.13:2.13.0",
+       |      "jar": "<jar-path>",
+       |      "sources": "<sources-path>"
+       |    }
+       |  ],
+       |  "namespaces": {
+       |    "//core": {
+       |      "sources": [
+       |        "core/Bar.scala",
+       |        "core/Hello.scala"
+       |      ],
+       |      "scalacOptions": [
+       |        "-deprecation"
+       |      ],
+       |      "javacOptions": [],
+       |      "dependencyModules": [
+       |        "org.scala-lang:scala-library:2.13.16",
+       |        "org.typelevel:cats-core_2.13:2.13.0",
+       |        "org.typelevel:cats-kernel_2.13:2.13.0"
+       |      ],
+       |      "scalaVersion": "2.13.16",
+       |      "dependsOn": [],
+       |      "classDirectories": []
+       |    }
+       |  },
+       |  "uncheckedSources": []
+       |}""".stripMargin
 
   private val javaMavenDeps: List[String] = List(
     s"org.jsoup:jsoup:$jsoupVersion"
@@ -213,14 +227,222 @@ class BazelMbtLspSuite
        |}
        |""".stripMargin
 
-  private def pinMaven(workspace: AbsolutePath): Unit = {
+  private def pinMaven(workspace: AbsolutePath): Unit =
+    pinHub("maven")(workspace)
+
+  private def pinHub(hubName: String)(workspace: AbsolutePath): Unit = {
     workspace.resolve("maven_install.json").touch()
     ShellRunner.runSync(
-      List("bazel", "run", "@maven//:pin"),
+      List("bazel", "run", s"@$hubName//:pin"),
       workspace,
       redirectErrorOutput = false,
       timeout = 1.minute,
     )
+  }
+
+  private def rulesAndSources(hubName: String) =
+    s"""|/core/BUILD
+        |load("@rules_scala//scala:scala.bzl", "scala_library")
+        |
+        |scala_library(
+        |    name = "hello_lib",
+        |    srcs = ["Hello.scala", "Bar.scala"],
+        |    visibility = ["//visibility:public"],
+        |    scalacopts = ["-deprecation"],
+        |    deps = ["@$hubName//:org_typelevel_cats_core_2_13"],
+        |)
+        |
+        |/core/Hello.scala
+        |package core
+        |
+        |import cats.syntax.all._
+        |
+        |class Hello {
+        |  def hello: String = "Hello"
+        |  def catOption: Option[Int] = 1.some
+        |
+        |}
+        |
+        |/core/Bar.scala
+        |package core
+        |
+        |class Bar {
+        |  def bar: String = "bar"
+        |  def hi = new Hello().hello
+        |}
+        |""".stripMargin
+
+  private def customHubWorkspaceLayout(hubName: String): String = {
+    val projectView =
+      """|/.bazelproject
+         |targets:
+         |    //core/...
+         |
+         |""".stripMargin
+
+    projectView + rulesAndSources(hubName)
+  }
+
+  private val skewHubA = "cats_a"
+  private val skewHubB = "cats_b"
+  private val skewVersionA = "2.12.0"
+  private val skewVersionB = "2.13.0"
+
+  private def multiHubWorkspaceLayout: String = {
+    val projectView =
+      """|/.bazelproject
+         |targets:
+         |    //...
+         |
+         |""".stripMargin
+    val coreA =
+      s"""|/core_a/BUILD
+          |load("@rules_scala//scala:scala.bzl", "scala_library")
+          |
+          |scala_library(
+          |    name = "cats_a",
+          |    srcs = ["A.scala"],
+          |    deps = ["@$skewHubA//:org_typelevel_cats_core_2_13"],
+          |)
+          |
+          |/core_a/A.scala
+          |package a
+          |
+          |import cats.syntax.all._
+          |
+          |class A {
+          |  def value: Option[Int] = 1.some
+          |}
+          |""".stripMargin
+    val coreB =
+      s"""|/core_b/BUILD
+          |load("@rules_scala//scala:scala.bzl", "scala_library")
+          |
+          |scala_library(
+          |    name = "cats_b",
+          |    srcs = ["B.scala"],
+          |    deps = ["@$skewHubB//:org_typelevel_cats_core_2_13"],
+          |)
+          |
+          |/core_b/B.scala
+          |package b
+          |
+          |import cats.syntax.all._
+          |
+          |class B {
+          |  def value: Option[Int] = 2.some
+          |}
+          |""".stripMargin
+    projectView + coreA + coreB
+  }
+
+  private def pinHubs(hubNames: List[String])(workspace: AbsolutePath): Unit = {
+    for (hubName <- hubNames)
+      workspace.resolve(s"${hubName}_install.json").touch()
+    // Pinning two hubs fetches two sets of Maven artifacts, so allow more time
+    // than the single-hub `pinHub`.
+    for (hubName <- hubNames)
+      ShellRunner.runSync(
+        List("bazel", "run", s"@$hubName//:pin"),
+        workspace,
+        redirectErrorOutput = false,
+        timeout = 3.minutes,
+      )
+  }
+
+  test("bazel-import-mbt-multi-hub-version-skew") {
+    client.selectedServer = Messages.ChooseBuildServer.mbt
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        BazelBuildLayout.multiHub(
+          multiHubWorkspaceLayout,
+          V.scala213,
+          bazelVersion,
+          List(
+            skewHubA -> List(s"org.typelevel:cats-core_2.13:$skewVersionA"),
+            skewHubB -> List(s"org.typelevel:cats-core_2.13:$skewVersionB"),
+          ),
+        ),
+        runAdditionalCommands = pinHubs(List(skewHubA, skewHubB)),
+      )
+      _ <- server.headServer.connectionProvider.buildServerPromise.future
+      mbtFile = workspace.resolve(".metals/mbt.json").readText
+      // Each namespace references the cats (and transitively cats-kernel /
+      // scala-library) version from its own hub: //core_a -> 2.12.0, //core_b ->
+      // 2.13.0, even though both hubs share the coordinate
+      // `org_typelevel_cats_core_2_13`.
+      _ = assertNoDiff(
+        escapeMbtFile(mbtFile),
+        s"""|{
+            |  "dependencyModules": [
+            |    {
+            |      "id": "org.scala-lang:scala-library:2.13.14",
+            |      "jar": "<jar-path>",
+            |      "sources": "<sources-path>"
+            |    },
+            |    {
+            |      "id": "org.scala-lang:scala-library:2.13.16",
+            |      "jar": "<jar-path>",
+            |      "sources": "<sources-path>"
+            |    },
+            |    {
+            |      "id": "org.typelevel:cats-core_2.13:2.12.0",
+            |      "jar": "<jar-path>",
+            |      "sources": "<sources-path>"
+            |    },
+            |    {
+            |      "id": "org.typelevel:cats-core_2.13:2.13.0",
+            |      "jar": "<jar-path>",
+            |      "sources": "<sources-path>"
+            |    },
+            |    {
+            |      "id": "org.typelevel:cats-kernel_2.13:2.12.0",
+            |      "jar": "<jar-path>",
+            |      "sources": "<sources-path>"
+            |    },
+            |    {
+            |      "id": "org.typelevel:cats-kernel_2.13:2.13.0",
+            |      "jar": "<jar-path>",
+            |      "sources": "<sources-path>"
+            |    }
+            |  ],
+            |  "namespaces": {
+            |    "//core_a": {
+            |      "sources": [
+            |        "core_a/A.scala"
+            |      ],
+            |      "scalacOptions": [],
+            |      "javacOptions": [],
+            |      "dependencyModules": [
+            |        "org.scala-lang:scala-library:2.13.14",
+            |        "org.typelevel:cats-core_2.13:2.12.0",
+            |        "org.typelevel:cats-kernel_2.13:2.12.0"
+            |      ],
+            |      "scalaVersion": "2.13.14",
+            |      "dependsOn": [],
+            |      "classDirectories": []
+            |    },
+            |    "//core_b": {
+            |      "sources": [
+            |        "core_b/B.scala"
+            |      ],
+            |      "scalacOptions": [],
+            |      "javacOptions": [],
+            |      "dependencyModules": [
+            |        "org.scala-lang:scala-library:2.13.16",
+            |        "org.typelevel:cats-core_2.13:2.13.0",
+            |        "org.typelevel:cats-kernel_2.13:2.13.0"
+            |      ],
+            |      "scalaVersion": "2.13.14",
+            |      "dependsOn": [],
+            |      "classDirectories": []
+            |    }
+            |  },
+            |  "uncheckedSources": []
+            |}""".stripMargin,
+      )
+    } yield ()
   }
 
   test("bazel-import-mbt-server-hover") {
@@ -409,49 +631,7 @@ class BazelMbtLspSuite
       )
       _ <- server.headServer.connectionProvider.buildServerPromise.future
       mbtFile = workspace.resolve(".metals/mbt.json").readText
-      _ = assertNoDiff(
-        escapeMbtFile(mbtFile),
-        s"""|{
-            |  "dependencyModules": [
-            |    {
-            |      "id": "org.scala-lang:scala-library:2.13.16",
-            |      "jar": "<jar-path>",
-            |      "sources": "<sources-path>"
-            |    },
-            |    {
-            |      "id": "org.typelevel:cats-core_2.13:2.13.0",
-            |      "jar": "<jar-path>",
-            |      "sources": "<sources-path>"
-            |    },
-            |    {
-            |      "id": "org.typelevel:cats-kernel_2.13:2.13.0",
-            |      "jar": "<jar-path>",
-            |      "sources": "<sources-path>"
-            |    }
-            |  ],
-            |  "namespaces": {
-            |    "//core": {
-            |      "sources": [
-            |        "core/Bar.scala",
-            |        "core/Hello.scala"
-            |      ],
-            |      "scalacOptions": [
-            |        "-deprecation"
-            |      ],
-            |      "javacOptions": [],
-            |      "dependencyModules": [
-            |        "org.scala-lang:scala-library:2.13.16",
-            |        "org.typelevel:cats-core_2.13:2.13.0",
-            |        "org.typelevel:cats-kernel_2.13:2.13.0"
-            |      ],
-            |      "scalaVersion": "2.13.16",
-            |      "dependsOn": [],
-            |      "classDirectories": []
-            |    }
-            |  },
-            |  "uncheckedSources": []
-            |}""".stripMargin,
-      )
+      _ = assertNoDiff(escapeMbtFile(mbtFile), singleCoreMbtJson)
       _ <- server.didOpen("core/Hello.scala")
       _ <- server.assertHover(
         "core/Hello.scala",
@@ -660,6 +840,29 @@ class BazelMbtLspSuite
             |  "uncheckedSources": []
             |}""".stripMargin,
       )
+    } yield ()
+  }
+
+  test("bazel-import-mbt-custom-maven-hub") {
+    val hub = "custom_maven"
+    client.selectedServer = Messages.ChooseBuildServer.mbt
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        BazelBuildLayout(
+          customHubWorkspaceLayout(hub),
+          V.scala213,
+          bazelVersion,
+          mavenDeps,
+          Some(hub),
+        ),
+        runAdditionalCommands = pinHub(hub),
+      )
+      _ <- server.headServer.connectionProvider.buildServerPromise.future
+      mbtFile = workspace.resolve(".metals/mbt.json").readText
+      // Identical to the single-target result: the hub name
+      // does not appear in the imported model.
+      _ = assertNoDiff(escapeMbtFile(mbtFile), singleCoreMbtJson)
     } yield ()
   }
 

--- a/tests/unit/src/main/scala/tests/BuildServerLayout.scala
+++ b/tests/unit/src/main/scala/tests/BuildServerLayout.scala
@@ -127,20 +127,36 @@ object BazelBuildLayout extends BuildToolLayout {
       sourceLayout: String,
       scalaVersion: String,
       bazelVersion: String,
-  ): String = apply(sourceLayout, scalaVersion, bazelVersion, Nil)
+  ): String = apply(sourceLayout, scalaVersion, bazelVersion, Nil, None)
 
   def apply(
       sourceLayout: String,
       scalaVersion: String,
       bazelVersion: String,
       mavenDeps: List[String],
+      mavenHubName: Option[String] = None,
+  ): String =
+    bazelLayout(
+      sourceLayout,
+      scalaVersion,
+      bazelVersion,
+      mavenDeps,
+      mavenHubName,
+    )
+
+  private def bazelLayout(
+      sourceLayout: String,
+      scalaVersion: String,
+      bazelVersion: String,
+      mavenDeps: List[String],
+      mavenHubName: Option[String],
   ): String =
     s"""|/.metals/txt.txt
         |initialize the project for metals
         |/.bazelversion
         |$bazelVersion
         |/MODULE.bazel
-        |${moduleFileLayout(scalaVersion, mavenDeps)}
+        |${moduleFileLayout(scalaVersion, mavenDeps, mavenHubName)}
         |/BUILD
         |
         |/WORKSPACE
@@ -151,7 +167,10 @@ object BazelBuildLayout extends BuildToolLayout {
   def moduleFileLayout(
       scalaVersion: String,
       mavenDeps: List[String] = Nil,
+      mavenHubName: Option[String] = None,
   ): String = {
+    val hubName = mavenHubName.getOrElse("maven")
+    val nameLine = mavenHubName.fold("")(n => s"""    name = "$n",\n""")
     val mavenSection =
       if (mavenDeps.isEmpty) ""
       else {
@@ -161,15 +180,76 @@ object BazelBuildLayout extends BuildToolLayout {
             |
             |maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
             |maven.install(
-            |    artifacts = [
+            |$nameLine    artifacts = [
             |        $artifacts
             |    ],
             |    fetch_sources = True,
             |    lock_file = "//:maven_install.json",
             |)
-            |use_repo(maven, "maven")
+            |use_repo(maven, "$hubName")
             |""".stripMargin
       }
+    s"""|${scalaModulePrefix(scalaVersion)}
+        |
+        |$mavenSection""".stripMargin
+  }
+
+  /**
+   * A layout with several independent rules_jvm_external Maven hubs, each with
+   * its own `maven.install` and lock file. Used to exercise hub-based
+   * disambiguation when the same coordinate is pinned to different versions in
+   * different hubs.
+   */
+  def multiHub(
+      sourceLayout: String,
+      scalaVersion: String,
+      bazelVersion: String,
+      mavenHubs: List[(String, List[String])],
+  ): String =
+    s"""|/.metals/txt.txt
+        |initialize the project for metals
+        |/.bazelversion
+        |$bazelVersion
+        |/MODULE.bazel
+        |${multiHubModuleFileLayout(scalaVersion, mavenHubs)}
+        |/BUILD
+        |
+        |/WORKSPACE
+        |# Empty WORKSPACE file for compatibility
+        |$sourceLayout
+        |""".stripMargin
+
+  def multiHubModuleFileLayout(
+      scalaVersion: String,
+      mavenHubs: List[(String, List[String])],
+  ): String = {
+    val installs =
+      mavenHubs
+        .map { case (hubName, deps) =>
+          val artifacts = deps.map(d => s""""$d"""").mkString(",\n        ")
+          s"""|maven.install(
+              |    name = "$hubName",
+              |    artifacts = [
+              |        $artifacts
+              |    ],
+              |    fetch_sources = True,
+              |    lock_file = "//:${hubName}_install.json",
+              |)""".stripMargin
+        }
+        .mkString("\n")
+    val repos =
+      mavenHubs.map { case (name, _) => s""""$name"""" }.mkString(", ")
+    s"""|${scalaModulePrefix(scalaVersion)}
+        |
+        |bazel_dep(name = "rules_jvm_external", version = "6.6")
+        |
+        |maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+        |$installs
+        |use_repo(maven, $repos)
+        |""".stripMargin
+  }
+
+  private def scalaModulePrefix(scalaVersion: String): String =
     s"""|bazel_dep(name = "rules_scala", version = "7.2.4")
         |
         |scala_config = use_extension("@rules_scala//scala/extensions:config.bzl", "scala_config")
@@ -180,10 +260,7 @@ object BazelBuildLayout extends BuildToolLayout {
         |scala_deps.scala()
         |use_repo(scala_deps, "rules_scala_toolchains")
         |
-        |register_toolchains("@rules_scala_toolchains//...:all")
-        |
-        |$mavenSection""".stripMargin
-  }
+        |register_toolchains("@rules_scala_toolchains//...:all")""".stripMargin
 
   def workspaceFileLayout(scalaVersion: String): String =
     s"""|# WORKSPACE


### PR DESCRIPTION
Improve detection of maven_install for Bazel projects imported as MBT

https://github.com/scalameta/metals/pull/8494/files#r3435257964

The issue can be observed in

sdk/WORKSPACE

pinned_maven_install()  line matches .indexOf("maven_install")

https://github.com/digital-asset/daml/blob/0ae72fe9b2f0c66b56e17ab188c9993516669ef9/sdk/WORKSPACE#L667

then code searching for the next "name =" is going to yield incorrect result


https://github.com/digital-asset/daml/blob/0ae72fe9b2f0c66b56e17ab188c9993516669ef9/sdk/WORKSPACE#L693

```scala
http_archive(
    name = "scalapb",
```

example minimal repo:
[0001-Minimal-Bazel-Scala-example-reproducing-the-custom-m.patch](https://github.com/user-attachments/files/29372529/0001-Minimal-Bazel-Scala-example-reproducing-the-custom-m.patch)

After importing the project as MBT in main-v2 cats library is not recognized.

Solution:
We can avoid parsing source files to extract a name by extracting it from directory structure

  The bug: extractRepositoryNameFromBazelConfig used content.indexOf("maven_install") — which on DAML's WORKSPACE matched the substring inside pinned_maven_install, then
  grabbed the next name = "…" in the file, which happened to be an unrelated http_archive(name = "scalapb"). So the detected Maven repo name was scalapb instead of maven,
  causing 0 external deps to match.


With current version DAML import is not fully fixed yet.
Changes from this PR partially overlap with https://github.com/scalameta/metals/pull/8494
The scope of this PR is narrower than PoC PR.

__________

Detect the rules_jvm_external hub name from the materialized `external/` directory (discoverMavenHubs) instead of a source regex, then resolve each maven dependency against that hub's `imported_maven
_install.json` lock. Match external deps to modules by coordinate suffix, tie-break across multiple hubs by semantic version, and dedup by id (preferring entries with a sources jar). Supports both the modern and legacy-v4 (`dependency_tree`) lock formats and bzlmod jar-path discovery for non-default hubs.

Fixed bug: the previous source-regex hub-name detection plus exact `@maven//:<coord>` matching resolved zero modules whenever the hub was not named `maven` (e.g. `@custom_maven//:...`). Directory-based discovery plus coordinate-suffix matching now resolves such deps to the same modules a `@maven` hub would. Additionally:
- findJarFromLegacyPath / downloadToM2Cache now return a `file:` URI like every sibling resolver; a bare path violated MbtDependencyModule's URI contract and made jarPath's `Paths.get(uri)` throw "Missing scheme".
- parseUri normalizes a scheme-less value to a `file:` URI (URI.create does not throw on a bare Unix path, so the old self-heal fallback never fired).
- importMaven tolerates an empty/truncated/malformed lock per-file instead of letting gson's NPE/JsonSyntaxException abort the whole import.
- lockFilesFor falls back to the project-tree search when discovered hubs' locks have vanished, not only when no hub was discovered.

Tests: BazelMavenRepoNameSuite, BazelMavenImportSuite (importMaven end-to-end, custom-hub + legacy-v4 fixtures), BazelMbtLspSuite custom-hub scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bazel imports now support Maven dependencies from custom hubs, not just the default repository.
  * Importing is more robust across different Bazel layouts and lock file formats.

* **Bug Fixes**
  * Improved detection of Maven artifacts and sources in Bazel external directories.
  * Fixed dependency matching for hubs with overlapping coordinates and version differences.
  * Better handling of invalid or missing URI-style paths during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->