### PR TITLE
feature: Add extract method refactor

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/callHierarchy/CallHierarchyProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/callHierarchy/CallHierarchyProvider.scala
@@ -184,7 +184,7 @@ final case class CallHierarchyProvider(
     } else if (source.isJavaFilename) {
       javaTrees
         .findEnclosingJavaMethod(source, range.getStart)
-        .map(method => (method.nameRange.range, method.range.range, source))
+        .map(method => (method.nameRange, method.bodyRange, source))
     } else None
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/callHierarchy/CallHierarchyProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/callHierarchy/CallHierarchyProvider.scala
@@ -184,7 +184,7 @@ final case class CallHierarchyProvider(
     } else if (source.isJavaFilename) {
       javaTrees
         .findEnclosingJavaMethod(source, range.getStart)
-        .map(method => (method.nameRange, method.bodyRange, source))
+        .map(method => (method.nameRange.range, method.range.range, source))
     } else None
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -66,6 +66,7 @@ final class CodeActionProvider(
     new GenerateGettersSetters(javaTrees, buffers),
     new GenerateEqualsHashCodeToString(javaTrees, buffers),
     new AddMissingReturnStatement(javaTrees, buffers),
+    new JavaExtractMethodCodeAction(javaTrees, compilers),
   )
 
   def actionsForParams(params: l.CodeActionParams): List[CodeAction] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaExtractMethodCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaExtractMethodCodeAction.scala
@@ -74,12 +74,12 @@ class JavaExtractMethodCodeAction(
         method <- javaTrees
           .findEnclosingJavaMethod(path, range.getStart())
           .toSeq
-        if range.overlapsWith(method.bodyRange)
+        if range.overlapsWith(method.range.range)
       } yield {
         val data = ExtractMethodData(
           params.getTextDocument(),
           range,
-          method.declarationStart,
+          method.range.getStart(),
         )
         CodeActionBuilder.build(
           title = JavaExtractMethodCodeAction.title(method.name),

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaExtractMethodCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaExtractMethodCodeAction.scala
@@ -1,0 +1,97 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.metals.Compilers
+import scala.meta.internal.metals.JsonParser.XtensionSerializableToJson
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.logging
+import scala.meta.internal.parsing.JavaTrees
+import scala.meta.pc.CancelToken
+import scala.meta.pc.CodeActionId
+
+import org.eclipse.lsp4j.CodeActionParams
+import org.eclipse.{lsp4j => l}
+
+class JavaExtractMethodCodeAction(
+    javaTrees: JavaTrees,
+    compilers: Compilers,
+) extends CodeAction {
+
+  private case class ExtractMethodData(
+      param: l.TextDocumentIdentifier,
+      range: l.Range,
+      extractPosition: l.Position,
+  ) extends CodeActionResolveData
+
+  override def kind: String = l.CodeActionKind.RefactorExtract
+
+  override def isScala: Boolean = false
+
+  override def isJava: Boolean = true
+
+  override def maybeCodeActionId: Option[String] = Some(
+    CodeActionId.ExtractMethod
+  )
+
+  override def resolveCodeAction(codeAction: l.CodeAction, token: CancelToken)(
+      implicit ec: ExecutionContext
+  ): Option[Future[l.CodeAction]] = {
+    parseData[ExtractMethodData](codeAction) match {
+      case Some(data) =>
+        val doc = data.param
+        val uri = doc.getUri()
+        val modifiedCodeAction = for {
+          edits <- compilers.extractMethod(
+            doc,
+            data.range,
+            data.extractPosition,
+            token,
+          )
+          _ = logging.logErrorWhen(
+            edits.isEmpty(),
+            s"Could not extract method from range \n${data.range}\nin file ${uri.toAbsolutePath}",
+          )
+          workspaceEdit = new l.WorkspaceEdit(Map(uri -> edits).asJava)
+          _ = codeAction.setEdit(workspaceEdit)
+        } yield codeAction
+        Some(modifiedCodeAction)
+      case _ =>
+        None
+    }
+  }
+
+  override def contribute(params: CodeActionParams, token: CancelToken)(implicit
+      ec: ExecutionContext
+  ): Future[Seq[l.CodeAction]] = Future {
+    val path = params.getTextDocument().getUri().toAbsolutePath
+    val range = params.getRange()
+    if (range.getStart() == range.getEnd()) {
+      Nil
+    } else {
+      for {
+        method <- javaTrees
+          .findEnclosingJavaMethod(path, range.getStart())
+          .toSeq
+        if range.overlapsWith(method.bodyRange)
+      } yield {
+        val data = ExtractMethodData(
+          params.getTextDocument(),
+          range,
+          method.declarationStart,
+        )
+        CodeActionBuilder.build(
+          title = JavaExtractMethodCodeAction.title(method.name),
+          kind = this.kind,
+          data = Some(data.toJsonObject),
+        )
+      }
+    }
+  }
+}
+
+object JavaExtractMethodCodeAction {
+  def title(methodName: String): String =
+    s"Extract selection as method before `$methodName`"
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaAutoImportEditor.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaAutoImportEditor.scala
@@ -27,7 +27,7 @@ class JavaAutoImportEditor(text: String, fqn: String) {
         new l.Position(lineNumber, line.length()),
         new l.Position(lineNumber, line.length())
       ),
-      s"\n\nimport $fqn;\n"
+      s"\n\nimport $fqn;"
     )
 
     // Scala supports multiple package lines, while Java only supports one so we

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaExtractMethodProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaExtractMethodProvider.scala
@@ -1,0 +1,807 @@
+package scala.meta.internal.jpc
+
+import javax.lang.model.`type`.ArrayType
+import javax.lang.model.`type`.DeclaredType
+import javax.lang.model.`type`.TypeKind
+import javax.lang.model.`type`.TypeMirror
+import javax.lang.model.`type`.TypeVariable
+import javax.lang.model.`type`.WildcardType
+import javax.lang.model.element.Element
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.Modifier
+import javax.lang.model.element.TypeElement
+import javax.lang.model.element.TypeParameterElement
+import javax.lang.model.element.VariableElement
+import javax.lang.model.util.Types
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+import scala.meta.internal.pc.ExtractMethodUtils
+import scala.meta.pc.DisplayableException
+import scala.meta.pc.OffsetParams
+import scala.meta.pc.RangeParams
+
+import com.sun.source.tree.ArrayAccessTree
+import com.sun.source.tree.BinaryTree
+import com.sun.source.tree.BlockTree
+import com.sun.source.tree.BreakTree
+import com.sun.source.tree.ClassTree
+import com.sun.source.tree.CompilationUnitTree
+import com.sun.source.tree.ConditionalExpressionTree
+import com.sun.source.tree.ContinueTree
+import com.sun.source.tree.ExpressionStatementTree
+import com.sun.source.tree.ExpressionTree
+import com.sun.source.tree.IdentifierTree
+import com.sun.source.tree.InstanceOfTree
+import com.sun.source.tree.LiteralTree
+import com.sun.source.tree.MemberSelectTree
+import com.sun.source.tree.MethodInvocationTree
+import com.sun.source.tree.MethodTree
+import com.sun.source.tree.NewClassTree
+import com.sun.source.tree.ParenthesizedTree
+import com.sun.source.tree.ReturnTree
+import com.sun.source.tree.Tree
+import com.sun.source.tree.TypeCastTree
+import com.sun.source.tree.UnaryTree
+import com.sun.source.tree.VariableTree
+import com.sun.source.util.TreePath
+import com.sun.source.util.TreePathScanner
+import com.sun.source.util.TreeScanner
+import com.sun.source.util.Trees
+import org.eclipse.{lsp4j => l}
+
+final class JavaExtractMethodProvider(
+    compiler: JavaMetalsCompiler,
+    rangeParams: RangeParams,
+    extractionPos: OffsetParams
+) extends ExtractMethodUtils {
+
+  def extractMethod: List[l.TextEdit] = {
+    rangeParams.checkCanceled()
+    val compile = compiler.compilationTask(rangeParams).withAnalyzePhase()
+    rangeParams.checkCanceled()
+
+    val javacTrees = Trees.instance(compile.task)
+    val cu = compile.cu
+    val text = cu.getSourceFile().getCharContent(true).toString()
+    val originalStart = rangeParams.offset()
+    val originalEnd = rangeParams.endOffset()
+    val insertOffset = extractionPos.offset()
+    if (originalStart >= originalEnd || insertOffset < 0) Nil
+    else {
+      val ctx = Context(
+        javacTrees,
+        compile.task.getTypes(),
+        cu,
+        text,
+        originalStart,
+        originalEnd,
+        originalStart,
+        originalEnd
+      )
+      findSelection(ctx).fold(List.empty[l.TextEdit]) { selection =>
+        generateEdits(selection, ctx, insertOffset)
+      }
+    }
+  }
+
+  private case class Context(
+      trees: Trees,
+      types: Types,
+      cu: CompilationUnitTree,
+      text: String,
+      rangeStart: Int,
+      rangeEnd: Int,
+      originalStart: Int,
+      originalEnd: Int
+  ) {
+    val packageName: Option[String] =
+      Option(cu.getPackageName()).map(_.toString).filter(_.nonEmpty)
+    val existingImports: Set[String] =
+      ImportLine
+        .fromText(text)
+        .map(_.line.stripPrefix("import ").stripSuffix(";").trim)
+        .toSet
+    val importedSimpleNames: Map[String, String] =
+      existingImports.flatMap { imp =>
+        val simple = imp.split('.').last
+        if (simple == "*") None else Some(simple -> imp)
+      }.toMap
+
+    def encloses(start: Int, end: Int): Boolean =
+      rangeStart <= start && end <= rangeEnd
+
+    def startOf(tree: Tree): Int =
+      trees.getSourcePositions().getStartPosition(cu, tree).toInt
+
+    def endOf(tree: Tree): Int =
+      trees.getSourcePositions().getEndPosition(cu, tree).toInt
+
+    def elementAt(path: TreePath): Option[Element] =
+      Option(trees.getElement(path))
+
+    def typeAt(path: TreePath): Option[TypeMirror] =
+      Option(trees.getTypeMirror(path))
+  }
+
+  private case class Selection(
+      methodPath: TreePath,
+      classPath: TreePath,
+      statements: List[Tree],
+      exprPath: Option[TreePath],
+      asStatement: Boolean
+  )
+
+  private def findSelection(ctx: Context): Option[Selection] = {
+    val finder = new SelectionFinder(ctx)
+    finder.scan(ctx.cu, ())
+    finder.found.collect { case selection =>
+      hasInvalid(selection).foreach { message =>
+        throw new DisplayableException(message)
+      }
+      selection
+    }
+  }
+
+  /**
+   * IT might be tto tricky to get it right with return statements.
+   */
+  private def hasInvalid(selection: Selection): Option[String] = {
+    var hasInvalid: Option[String] = None
+    val scanner = new TreeScanner[Unit, Unit] {
+      override def visitReturn(node: ReturnTree, p: Unit): Unit = {
+        hasInvalid = Some(
+          "Cannot extract selection that contains return statements"
+        )
+      }
+      override def visitIdentifier(node: IdentifierTree, p: Unit): Unit = {
+        if (node.getName().toString() == "super")
+          hasInvalid = Some(
+            "Cannot extract selection that contains super calls"
+          )
+        super.visitIdentifier(node, p)
+      }
+      override def visitBreak(node: BreakTree, p: Unit): Unit =
+        hasInvalid = Some(
+          "Cannot extract selection that contains break statements"
+        )
+      override def visitContinue(node: ContinueTree, p: Unit): Unit =
+        hasInvalid = Some(
+          "Cannot extract selection that contains continue statements"
+        )
+    }
+    for (stmt <- selection.statements if hasInvalid.isEmpty) {
+      scanner.scan(stmt, ())
+    }
+    hasInvalid
+  }
+
+  private final class SelectionFinder(ctx: Context)
+      extends TreePathScanner[Unit, Unit] {
+    private var result: Option[Selection] = None
+    private var methodPath: Option[TreePath] = None
+    private var classPath: Option[TreePath] = None
+    private var bestExpr: Option[(TreePath, Int)] = None
+
+    override def visitCompilationUnit(
+        node: CompilationUnitTree,
+        p: Unit
+    ): Unit =
+      scan(node.getTypeDecls(), p)
+
+    override def visitClass(node: ClassTree, p: Unit): Unit = {
+      if (overlaps(ctx.startOf(node), ctx.endOf(node))) {
+        val previous = classPath
+        classPath = Some(getCurrentPath())
+        try super.visitClass(node, p)
+        finally {
+          if (previous.isDefined)
+            classPath = previous
+        }
+      }
+    }
+
+    override def visitMethod(node: MethodTree, p: Unit): Unit = {
+      if (overlaps(ctx.startOf(node), ctx.endOf(node))) {
+        val previous = methodPath
+        methodPath = Some(getCurrentPath())
+        try super.visitMethod(node, p)
+        finally {
+          if (previous.isDefined)
+            methodPath = previous
+        }
+      }
+    }
+
+    override def visitMemberSelect(node: MemberSelectTree, p: Unit): Unit = {
+      super.visitMemberSelect(node, p)
+    }
+    override def visitExpressionStatement(
+        node: ExpressionStatementTree,
+        p: Unit
+    ): Unit = {
+      if (result.isEmpty && ctx.encloses(ctx.startOf(node), ctx.endOf(node))) {
+        setExpression(node.getExpression(), asStatement = true)
+      }
+      super.visitExpressionStatement(node, p)
+    }
+
+    override def visitBlock(node: BlockTree, p: Unit): Unit = {
+      if (result.isEmpty) {
+        val selected = node
+          .getStatements()
+          .asScala
+          .filter { stmt =>
+            val (s, e) = (ctx.startOf(stmt), ctx.endOf(stmt))
+            ctx.encloses(s, e)
+          }
+          .toList
+        if (selected.size > 1) {
+          for {
+            method <- methodPath
+            cls <- classPath
+          } result = Some(
+            Selection(method, cls, selected, None, asStatement = false)
+          )
+        }
+      }
+      super.visitBlock(node, p)
+      if (result.isEmpty) {
+        val selected = node
+          .getStatements()
+          .asScala
+          .filter { stmt =>
+            val (s, e) = (ctx.startOf(stmt), ctx.endOf(stmt))
+            ctx.encloses(s, e) && !stmt.isInstanceOf[ExpressionStatementTree]
+          }
+          .toList
+        if (selected.nonEmpty) {
+          for {
+            method <- methodPath
+            cls <- classPath
+          } result = Some(
+            Selection(method, cls, selected, None, asStatement = false)
+          )
+        }
+      }
+    }
+
+    override def scan(tree: Tree, p: Unit): Unit = {
+      tree match {
+        case expr: ExpressionTree if isExtractableExpression(expr) =>
+          val (start, end) = (ctx.startOf(expr), ctx.endOf(expr))
+          if (ctx.encloses(start, end)) {
+            val span = end - start
+            if (bestExpr.forall(_._2 < span)) {
+              bestExpr = Some((new TreePath(getCurrentPath(), expr), span))
+            }
+          }
+        case _ =>
+      }
+      super.scan(tree, p)
+    }
+
+    def found: Option[Selection] = {
+      if (result.isEmpty) {
+        for {
+          (path, _) <- bestExpr
+          method <- methodPath
+          cls <- classPath
+        } result = Some(
+          Selection(
+            method,
+            cls,
+            List(path.getLeaf()),
+            Some(path),
+            asStatement = false
+          )
+        )
+      }
+      result
+    }
+
+    private def setExpression(
+        expr: ExpressionTree,
+        asStatement: Boolean
+    ): Unit = {
+      for {
+        method <- methodPath
+        cls <- classPath
+      } {
+        val path = new TreePath(getCurrentPath(), expr)
+        result = Some(
+          Selection(method, cls, List(expr), Some(path), asStatement)
+        )
+      }
+    }
+
+    private def overlaps(start: Int, end: Int): Boolean =
+      start <= ctx.rangeEnd && ctx.rangeStart <= end
+  }
+
+  private def generateEdits(
+      selection: Selection,
+      ctx: Context,
+      insertOffset: Int
+  ): List[l.TextEdit] = {
+    val methodElement = ctx.elementAt(selection.methodPath).collect {
+      case e: ExecutableElement => e
+    }
+    if (methodElement.isEmpty) Nil
+    else generateEdits(selection, ctx, insertOffset, methodElement.get)
+
+  }
+
+  private def generateEdits(
+      selection: Selection,
+      ctx: Context,
+      insertOffset: Int,
+      methodElement: ExecutableElement
+  ): List[l.TextEdit] = {
+    val classTree = selection.classPath.getLeaf().asInstanceOf[ClassTree]
+    val typePrinter = new TypePrinter(ctx)
+    val freeVariables = collectFreeVariables(ctx, methodElement)
+    val usedNames = classTree
+      .getMembers()
+      .asScala
+      .collect { case m: MethodTree =>
+        m.getName().toString()
+      }
+      .toSet
+    val methodName = genName(usedNames, "newMethod")
+    val paramsText = freeVariables
+      .map(v => s"${typePrinter.print(v.asType())} ${v.getSimpleName()}")
+      .mkString(", ")
+    val argsText =
+      freeVariables.map(_.getSimpleName().toString()).mkString(", ")
+
+    val lineStart = lineStartAt(ctx.text, insertOffset)
+    val indent = lineIndent(ctx.text, lineStart)
+    val bodyIndent = indent + indentUnit(ctx.text, lineStart)
+
+    val extractStart = ctx.startOf(selection.statements.head)
+    val extractEnd = ctx.endOf(selection.statements.last)
+    val (returnType, callText, methodBody) =
+      selection.exprPath match {
+        case Some(path) =>
+          val tpe =
+            ctx.typeAt(path).getOrElse(ctx.types.getNoType(TypeKind.VOID))
+          val isVoid = tpe.getKind == TypeKind.VOID
+          val call =
+            if (selection.asStatement || isVoid) s"$methodName($argsText)"
+            else s"$methodName($argsText)"
+          val exprText = ctx.text.slice(extractStart, extractEnd).trim
+          val body =
+            if (isVoid) s"$bodyIndent$exprText"
+            else {
+              val stripped =
+                if (selection.asStatement) exprText.stripSuffix(";")
+                else exprText
+              s"${bodyIndent}return $stripped;"
+            }
+          (tpe, call, body)
+        case None =>
+          val method = selection.methodPath.getLeaf().asInstanceOf[MethodTree]
+          inferStatementReturn(selection, ctx, method) match {
+            case Some((tpe, outputName)) =>
+              val call =
+                if (tpe.getKind == TypeKind.VOID) s"$methodName($argsText);"
+                else
+                  s"${typePrinter.print(tpe)} ${outputName} = $methodName($argsText);"
+              val body =
+                if (tpe.getKind == TypeKind.VOID)
+                  statementBody(
+                    ctx,
+                    insertOffset,
+                    extractStart,
+                    extractEnd
+                  )
+                else
+                  s"${statementBody(ctx, insertOffset, extractStart, extractEnd)}\n${bodyIndent}return $outputName;"
+              (tpe, call, body)
+            case None =>
+              throw new DisplayableException(
+                "No return type can be inferred, multiple variables are used after the selection."
+              )
+          }
+      }
+
+    val returnTypeText = typePrinter.print(returnType)
+    val signatureReturn =
+      if (returnType.getKind == TypeKind.VOID) "void" else returnTypeText
+    val isStatic = methodElement.getModifiers().contains(Modifier.STATIC)
+    val staticModifier = if (isStatic) "static " else ""
+
+    val usedTypeVars = collectTypeVariables(returnType) ++
+      freeVariables.flatMap(v => collectTypeVariables(v.asType()))
+    val methodTypeParams = methodElement.getTypeParameters().asScala.toList
+    val usedTypeVarNames =
+      usedTypeVars.map(_.asElement().getSimpleName().toString())
+    val requiredTypeParams = methodTypeParams.filter { tp =>
+      usedTypeVarNames.contains(tp.getSimpleName().toString())
+    }
+    val typeParamClause =
+      if (requiredTypeParams.isEmpty) ""
+      else {
+        val printed =
+          requiredTypeParams.map(tp => printTypeParameter(tp, typePrinter))
+        s"<${printed.mkString(", ")}> "
+      }
+
+    val methodText =
+      s"${indent}private ${staticModifier}${typeParamClause}$signatureReturn $methodName($paramsText) {\n$methodBody\n$indent}\n\n"
+
+    val importEdits = typePrinter.importEditsFor(
+      returnType +: freeVariables.map(_.asType())
+    )
+
+    importEdits :+
+      new l.TextEdit(
+        new l.Range(
+          Positions.toLspPosition(ctx.cu.getLineMap(), lineStart, ctx.text),
+          Positions.toLspPosition(ctx.cu.getLineMap(), lineStart, ctx.text)
+        ),
+        methodText
+      ) :+
+      new l.TextEdit(
+        Positions.toLspRange(
+          ctx.cu.getLineMap(),
+          extractStart,
+          extractEnd,
+          ctx.text
+        ),
+        callText
+      )
+  }
+
+  private def statementBody(
+      ctx: Context,
+      insertOffset: Int,
+      extractStart: Int,
+      extractEnd: Int
+  ): String = {
+    val bodyIndent = lineIndent(ctx.text, lineStartAt(ctx.text, insertOffset)) +
+      indentUnit(ctx.text, lineStartAt(ctx.text, insertOffset))
+    reindent(ctx.text.slice(extractStart, extractEnd), bodyIndent)
+  }
+
+  private def reindent(text: String, bodyIndent: String): String = {
+    val minIndent = text.linesIterator
+      .map(_.takeWhile(c => c == ' ' || c == '\t').length)
+      .filter(_ > 0)
+      .minOption
+      .getOrElse(0)
+    text.linesIterator
+      .map { line =>
+        val trimmed = line.trim
+        if (trimmed.isEmpty) ""
+        else {
+          val leading = line.takeWhile(c => c == ' ' || c == '\t')
+          val dedented =
+            if (leading.length >= minIndent) line.drop(minIndent).trim
+            else trimmed
+          s"$bodyIndent$dedented"
+        }
+      }
+      .filter(_.nonEmpty)
+      .mkString("\n")
+  }
+
+  private def inferStatementReturn(
+      selection: Selection,
+      ctx: Context,
+      method: MethodTree
+  ): Option[(TypeMirror, String)] = {
+    val declared = mutable.Map.empty[String, VariableElement]
+    val declScanner = new TreePathScanner[Unit, Unit] {
+      override def visitVariable(node: VariableTree, p: Unit): Unit = {
+        val (start, end) = (ctx.startOf(node), ctx.endOf(node))
+        if (ctx.encloses(start, end)) {
+          ctx.elementAt(getCurrentPath()).foreach {
+            case v: VariableElement if isLocalLike(v) =>
+              declared(v.getSimpleName().toString()) = v
+            case _ =>
+          }
+        }
+        super.visitVariable(node, p)
+      }
+    }
+    declScanner.scan(ctx.cu, ())
+
+    val selectionEnd = ctx.endOf(selection.statements.last)
+    val usedAfter = mutable.Set.empty[String]
+    Option(method.getBody()).foreach { block =>
+      block.getStatements().asScala.foreach { stmt =>
+        if (ctx.startOf(stmt) >= selectionEnd) {
+          usedAfter ++= identifierNames(stmt)
+        }
+      }
+    }
+
+    declared.keys.filter(usedAfter.contains).toList match {
+      case Nil => Some((ctx.types.getNoType(TypeKind.VOID), ""))
+      case name :: Nil => declared.get(name).map(v => (v.asType(), name))
+      case _ => None
+    }
+  }
+
+  private def collectFreeVariables(
+      ctx: Context,
+      methodElement: ExecutableElement
+  ): List[VariableElement] = {
+    val params = mutable.LinkedHashMap.empty[String, VariableElement]
+    val scanner = new TreePathScanner[Unit, Unit] {
+      override def visitIdentifier(node: IdentifierTree, p: Unit): Unit = {
+        val (start, end) = (ctx.startOf(node), ctx.endOf(node))
+        if (ctx.rangeStart <= start && end <= ctx.rangeEnd) {
+          ctx.elementAt(getCurrentPath()).foreach {
+            case v: VariableElement if isFreeVariable(v, ctx, methodElement) =>
+              params.getOrElseUpdate(v.getSimpleName().toString(), v)
+            case _ =>
+          }
+        }
+        super.visitIdentifier(node, p)
+      }
+    }
+    scanner.scan(ctx.cu, ())
+    params.values.toList
+  }
+
+  private def isFreeVariable(
+      variable: VariableElement,
+      ctx: Context,
+      methodElement: ExecutableElement
+  ): Boolean =
+    if (!isLocalLike(variable) && variable.getKind != ElementKind.PARAMETER)
+      false
+    else if (!isEnclosedBy(variable, methodElement)) false
+    else
+      declarationTree(variable, ctx).forall { tree =>
+        !ctx.encloses(ctx.startOf(tree), ctx.endOf(tree))
+      }
+
+  private def declarationTree(
+      variable: VariableElement,
+      ctx: Context
+  ): Option[Tree] = {
+    object finder extends TreePathScanner[Unit, Unit] {
+      var found: Option[Tree] = None
+      override def visitVariable(node: VariableTree, p: Unit): Unit = {
+        ctx.elementAt(getCurrentPath()).foreach { elem =>
+          if (elem == variable) found = Some(node)
+        }
+        super.visitVariable(node, p)
+      }
+    }
+    finder.scan(ctx.cu, ())
+    finder.found
+  }
+
+  private def identifierNames(tree: Tree): Set[String] = {
+    val names = mutable.Set.empty[String]
+    tree.accept(
+      new TreeScanner[Unit, Unit] {
+        override def visitIdentifier(node: IdentifierTree, p: Unit): Unit = {
+          names += node.getName().toString()
+          super.visitIdentifier(node, p)
+        }
+      },
+      ()
+    )
+    names.toSet
+  }
+
+  private def isLocalLike(element: VariableElement): Boolean =
+    Set(
+      ElementKind.LOCAL_VARIABLE,
+      ElementKind.PARAMETER,
+      ElementKind.EXCEPTION_PARAMETER,
+      ElementKind.RESOURCE_VARIABLE,
+      ElementKind.BINDING_VARIABLE
+    ).contains(element.getKind)
+
+  private def isEnclosedBy(element: Element, enclosing: Element): Boolean =
+    Iterator
+      .iterate(Option(element))(_.flatMap(e => Option(e.getEnclosingElement())))
+      .takeWhile(_.nonEmpty)
+      .flatten
+      .exists(_ == enclosing)
+
+  private def isExtractableExpression(tree: ExpressionTree): Boolean =
+    tree match {
+      case _: IdentifierTree => true
+      case _: LiteralTree => true
+      case _: MethodInvocationTree => true
+      case _: MemberSelectTree => true
+      case _: BinaryTree => true
+      case _: UnaryTree => true
+      case _: ConditionalExpressionTree => true
+      case _: NewClassTree => true
+      case _: ArrayAccessTree => true
+      case _: TypeCastTree => true
+      case _: InstanceOfTree => true
+      case _: ParenthesizedTree => true
+      case _ => false
+    }
+
+  private def lineStartAt(text: String, offset: Int): Int =
+    text.lastIndexOf('\n', math.max(0, offset - 1)) + 1
+
+  private def lineIndent(text: String, lineStart: Int): String =
+    text.slice(lineStart, text.length()).takeWhile(c => c == ' ' || c == '\t')
+
+  private def indentUnit(text: String, lineStart: Int): String =
+    if (lineIndent(text, lineStart).contains('\t')) "\t" else "  "
+
+  private def collectTypeVariables(tpe: TypeMirror): Set[TypeVariable] =
+    tpe.getKind match {
+      case TypeKind.TYPEVAR =>
+        Set(tpe.asInstanceOf[TypeVariable])
+      case TypeKind.DECLARED =>
+        tpe
+          .asInstanceOf[DeclaredType]
+          .getTypeArguments()
+          .asScala
+          .flatMap(collectTypeVariables)
+          .toSet
+      case TypeKind.ARRAY =>
+        collectTypeVariables(tpe.asInstanceOf[ArrayType].getComponentType)
+      case TypeKind.WILDCARD =>
+        val wildcard = tpe.asInstanceOf[WildcardType]
+        Option(wildcard.getExtendsBound())
+          .map(collectTypeVariables)
+          .getOrElse(Set.empty) ++
+          Option(wildcard.getSuperBound())
+            .map(collectTypeVariables)
+            .getOrElse(Set.empty)
+      case _ => Set.empty
+    }
+
+  private def printTypeParameter(
+      tp: TypeParameterElement,
+      typePrinter: TypePrinter
+  ): String = {
+    val name = tp.getSimpleName().toString()
+    val bounds = tp.getBounds().asScala.toList
+    bounds match {
+      case Nil => name
+      case head :: Nil if head.toString == "java.lang.Object" => name
+      case _ =>
+        val boundStrs = bounds.map(typePrinter.print)
+        s"$name extends ${boundStrs.mkString(" & ")}"
+    }
+  }
+
+  private final class TypePrinter(ctx: Context) {
+    private val importsNeeded = mutable.LinkedHashSet.empty[String]
+    private val forcedFqn = mutable.Set.empty[String]
+
+    def print(tpe: TypeMirror): String = {
+      collectImportCandidates(tpe)
+      printType(tpe)
+    }
+
+    def importEditsFor(types: Seq[TypeMirror]): List[l.TextEdit] = {
+      types.foreach(collectImportCandidates)
+      if (importsNeeded.isEmpty) Nil
+      else {
+        val lines = importsNeeded.toList.sorted.map(fqn => s"import $fqn;")
+        val firstFqn = lines.head.stripPrefix("import ").stripSuffix(";")
+        val anchor = new JavaAutoImportEditor(ctx.text, firstFqn).textEdit()
+        if (lines.size == 1) List(anchor)
+        else
+          List(
+            new l.TextEdit(
+              anchor.getRange(),
+              anchor.getNewText() + lines.tail.mkString("\n", "\n", "\n")
+            )
+          )
+      }
+    }
+
+    private def collectImportCandidates(tpe: TypeMirror): Unit =
+      tpe.getKind match {
+        case TypeKind.DECLARED =>
+          tpe match {
+            case declared: DeclaredType =>
+              Option(declared.asElement()).collect { case t: TypeElement =>
+                collectTypeElement(t)
+              }
+              declared
+                .getTypeArguments()
+                .asScala
+            case _ =>
+          }
+
+        case TypeKind.ARRAY =>
+          tpe match {
+            case array: ArrayType =>
+              collectImportCandidates(array.getComponentType)
+            case _ =>
+          }
+        case TypeKind.TYPEVAR =>
+          tpe match {
+            case typevar: TypeVariable =>
+              collectImportCandidates(typevar.getUpperBound)
+            case _ =>
+          }
+        case TypeKind.WILDCARD =>
+          tpe match {
+            case wildcard: WildcardType =>
+              Option(wildcard.getExtendsBound())
+                .foreach(collectImportCandidates)
+              Option(wildcard.getSuperBound()).foreach(collectImportCandidates)
+            case _ =>
+          }
+        case _ =>
+      }
+
+    private def collectTypeElement(elem: TypeElement): Unit = {
+      val qn = elem.getQualifiedName().toString()
+      if (needsImport(qn, elem.getSimpleName().toString())) importsNeeded += qn
+    }
+
+    private def needsImport(fqn: String, simple: String): Boolean =
+      if (fqn.startsWith("java.lang.")) false
+      else if (ctx.packageName.contains(fqn.split('.').init.mkString(".")))
+        false
+      else if (ctx.existingImports.contains(fqn)) false
+      else
+        ctx.importedSimpleNames.get(simple) match {
+          case Some(existing) if existing != fqn =>
+            forcedFqn += simple
+            false
+          case Some(_) => false
+          case None => true
+        }
+
+    private def printType(tpe: TypeMirror): String =
+      tpe.getKind match {
+        case TypeKind.VOID => "void"
+        case TypeKind.BOOLEAN => "boolean"
+        case TypeKind.BYTE => "byte"
+        case TypeKind.SHORT => "short"
+        case TypeKind.INT => "int"
+        case TypeKind.LONG => "long"
+        case TypeKind.CHAR => "char"
+        case TypeKind.FLOAT => "float"
+        case TypeKind.DOUBLE => "double"
+        case TypeKind.NULL => "null"
+        case TypeKind.DECLARED =>
+          val declared = tpe.asInstanceOf[DeclaredType]
+          val elem = declared.asElement().asInstanceOf[TypeElement]
+          val qn = elem.getQualifiedName().toString()
+          val simple = elem.getSimpleName().toString()
+          val base =
+            if (forcedFqn.contains(simple) || shouldUseFqn(qn, simple)) qn
+            else simple
+          val args = declared.getTypeArguments().asScala
+          if (args.isEmpty) base
+          else s"$base<${args.map(printType).mkString(", ")}>"
+        case TypeKind.ARRAY =>
+          s"${printType(tpe.asInstanceOf[ArrayType].getComponentType)}[]"
+        case TypeKind.TYPEVAR =>
+          tpe.asInstanceOf[TypeVariable].asElement().getSimpleName().toString()
+        case TypeKind.WILDCARD =>
+          val wildcard = tpe.asInstanceOf[WildcardType]
+          Option(wildcard.getExtendsBound()) match {
+            case Some(bound) => s"? extends ${printType(bound)}"
+            case None =>
+              Option(wildcard.getSuperBound()) match {
+                case Some(bound) => s"? super ${printType(bound)}"
+                case None => "?"
+              }
+          }
+        case _ => tpe.toString
+      }
+
+    private def shouldUseFqn(fqn: String, simple: String): Boolean =
+      forcedFqn.contains(simple) ||
+        (!fqn.startsWith("java.lang.") &&
+          !ctx.packageName.contains(fqn.split('.').init.mkString(".")) &&
+          !ctx.existingImports.contains(fqn) &&
+          !importsNeeded.contains(fqn))
+  }
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaExtractMethodProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaExtractMethodProvider.scala
@@ -139,7 +139,7 @@ final class JavaExtractMethodProvider(
   private def findSelection(ctx: Context): Option[Selection] = {
     val finder = new SelectionFinder(ctx)
     finder.scan(ctx.cu, ())
-    finder.found.collect { case selection =>
+    finder.found.map { selection =>
       hasInvalid(selection).foreach { message =>
         throw new DisplayableException(message)
       }
@@ -148,7 +148,7 @@ final class JavaExtractMethodProvider(
   }
 
   /**
-   * IT might be tto tricky to get it right with return statements.
+   * It might be too tricky to get it right with return statements.
    */
   private def hasInvalid(selection: Selection): Option[String] = {
     var hasInvalid: Option[String] = None
@@ -217,9 +217,6 @@ final class JavaExtractMethodProvider(
       }
     }
 
-    override def visitMemberSelect(node: MemberSelectTree, p: Unit): Unit = {
-      super.visitMemberSelect(node, p)
-    }
     override def visitExpressionStatement(
         node: ExpressionStatementTree,
         p: Unit
@@ -230,7 +227,10 @@ final class JavaExtractMethodProvider(
       super.visitExpressionStatement(node, p)
     }
 
-    override def visitBlock(node: BlockTree, p: Unit): Unit = {
+    private def checkBlockStatements(
+        node: BlockTree,
+        minimumStatements: Int
+    ): Unit =
       if (result.isEmpty) {
         val selected = node
           .getStatements()
@@ -240,7 +240,7 @@ final class JavaExtractMethodProvider(
             ctx.encloses(s, e)
           }
           .toList
-        if (selected.size > 1) {
+        if (selected.size >= minimumStatements) {
           for {
             method <- methodPath
             cls <- classPath
@@ -249,25 +249,11 @@ final class JavaExtractMethodProvider(
           )
         }
       }
+
+    override def visitBlock(node: BlockTree, p: Unit): Unit = {
+      checkBlockStatements(node, minimumStatements = 2)
       super.visitBlock(node, p)
-      if (result.isEmpty) {
-        val selected = node
-          .getStatements()
-          .asScala
-          .filter { stmt =>
-            val (s, e) = (ctx.startOf(stmt), ctx.endOf(stmt))
-            ctx.encloses(s, e) && !stmt.isInstanceOf[ExpressionStatementTree]
-          }
-          .toList
-        if (selected.nonEmpty) {
-          for {
-            method <- methodPath
-            cls <- classPath
-          } result = Some(
-            Selection(method, cls, selected, None, asStatement = false)
-          )
-        }
-      }
+      checkBlockStatements(node, minimumStatements = 1)
     }
 
     override def scan(tree: Tree, p: Unit): Unit = {
@@ -331,9 +317,9 @@ final class JavaExtractMethodProvider(
     val methodElement = ctx.elementAt(selection.methodPath).collect {
       case e: ExecutableElement => e
     }
-    if (methodElement.isEmpty) Nil
-    else generateEdits(selection, ctx, insertOffset, methodElement.get)
-
+    methodElement
+      .map(generateEdits(selection, ctx, insertOffset, _))
+      .getOrElse(Nil)
   }
 
   private def generateEdits(
@@ -344,8 +330,11 @@ final class JavaExtractMethodProvider(
   ): List[l.TextEdit] = {
     val classTree = selection.classPath.getLeaf().asInstanceOf[ClassTree]
     val typePrinter = new TypePrinter(ctx)
-    val freeVariables = collectFreeVariables(ctx, methodElement)
-    val mutatedFreeVars = collectMutatedFreeVariables(ctx, methodElement)
+    val enclosedVariables = collectEnclosedVariables(ctx)
+    val freeVariables =
+      collectFreeVariables(ctx, methodElement, enclosedVariables)
+    val mutatedFreeVars =
+      collectMutatedFreeVariables(ctx, methodElement, enclosedVariables)
     if (mutatedFreeVars.nonEmpty) {
       val varNames = mutatedFreeVars.toList.sorted.mkString(", ")
       throw new DisplayableException(
@@ -378,12 +367,10 @@ final class JavaExtractMethodProvider(
           val tpe =
             ctx.typeAt(path).getOrElse(ctx.types.getNoType(TypeKind.VOID))
           val isVoid = tpe.getKind == TypeKind.VOID
-          val call =
-            if (selection.asStatement || isVoid) s"$methodName($argsText)"
-            else s"$methodName($argsText)"
+          val call = s"$methodName($argsText)"
           val exprText = ctx.text.slice(extractStart, extractEnd).trim
           val body =
-            if (isVoid) s"$bodyIndent$exprText"
+            if (isVoid) s"$bodyIndent$exprText;"
             else {
               val stripped =
                 if (selection.asStatement) exprText.stripSuffix(";")
@@ -393,7 +380,12 @@ final class JavaExtractMethodProvider(
           (tpe, call, body)
         case None =>
           val method = selection.methodPath.getLeaf().asInstanceOf[MethodTree]
-          inferStatementReturn(selection, ctx, method) match {
+          inferStatementReturn(
+            selection,
+            ctx,
+            method,
+            enclosedVariables
+          ) match {
             case Some((tpe, outputName)) =>
               val call =
                 if (tpe.getKind == TypeKind.VOID) s"$methodName($argsText);"
@@ -501,24 +493,9 @@ final class JavaExtractMethodProvider(
   private def inferStatementReturn(
       selection: Selection,
       ctx: Context,
-      method: MethodTree
+      method: MethodTree,
+      declaredVariables: Set[VariableElement]
   ): Option[(TypeMirror, String)] = {
-    val declared = mutable.Map.empty[String, VariableElement]
-    val declScanner = new TreePathScanner[Unit, Unit] {
-      override def visitVariable(node: VariableTree, p: Unit): Unit = {
-        val (start, end) = (ctx.startOf(node), ctx.endOf(node))
-        if (ctx.encloses(start, end)) {
-          ctx.elementAt(getCurrentPath()).foreach {
-            case v: VariableElement if isLocalLike(v) =>
-              declared(v.getSimpleName().toString()) = v
-            case _ =>
-          }
-        }
-        super.visitVariable(node, p)
-      }
-    }
-    declScanner.scan(ctx.cu, ())
-
     val selectionEnd = ctx.endOf(selection.statements.last)
     val usedAfter = mutable.Set.empty[String]
     Option(method.getBody()).foreach { block =>
@@ -529,16 +506,22 @@ final class JavaExtractMethodProvider(
       }
     }
 
-    declared.keys.filter(usedAfter.contains).toList match {
+    declaredVariables
+      .filter(variable =>
+        usedAfter.contains(variable.getSimpleName().toString())
+      )
+      .toList match {
       case Nil => Some((ctx.types.getNoType(TypeKind.VOID), ""))
-      case name :: Nil => declared.get(name).map(v => (v.asType(), name))
+      case declared :: Nil =>
+        Some((declared.asType(), declared.getSimpleName().toString()))
       case _ => None
     }
   }
 
   private def collectFreeVariables(
       ctx: Context,
-      methodElement: ExecutableElement
+      methodElement: ExecutableElement,
+      enclosedVariables: Set[VariableElement]
   ): List[VariableElement] = {
     val params = mutable.LinkedHashMap.empty[String, VariableElement]
     val scanner = new TreePathScanner[Unit, Unit] {
@@ -546,7 +529,8 @@ final class JavaExtractMethodProvider(
         val (start, end) = (ctx.startOf(node), ctx.endOf(node))
         if (ctx.rangeStart <= start && end <= ctx.rangeEnd) {
           ctx.elementAt(getCurrentPath()).foreach {
-            case v: VariableElement if isFreeVariable(v, ctx, methodElement) =>
+            case v: VariableElement
+                if isFreeVariable(v, methodElement, enclosedVariables) =>
               params.getOrElseUpdate(v.getSimpleName().toString(), v)
             case _ =>
           }
@@ -558,9 +542,31 @@ final class JavaExtractMethodProvider(
     params.values.toList
   }
 
+  private def collectEnclosedVariables(
+      ctx: Context
+  ): Set[VariableElement] = {
+    val enclosed = mutable.Set.empty[VariableElement]
+    val scanner = new TreePathScanner[Unit, Unit] {
+      override def visitVariable(node: VariableTree, p: Unit): Unit = {
+        val (start, end) = (ctx.startOf(node), ctx.endOf(node))
+        if (ctx.rangeStart <= start && end <= ctx.rangeEnd) {
+          ctx.elementAt(getCurrentPath()).foreach {
+            case v: VariableElement =>
+              enclosed += v
+            case _ =>
+          }
+        }
+        super.visitVariable(node, p)
+      }
+    }
+    scanner.scan(ctx.cu, ())
+    enclosed.toSet
+  }
+
   private def collectMutatedFreeVariables(
       ctx: Context,
-      methodElement: ExecutableElement
+      methodElement: ExecutableElement,
+      enclosedVariables: Set[VariableElement]
   ): Set[String] = {
     val mutated = mutable.Set.empty[String]
     val scanner = new TreePathScanner[Unit, Unit] {
@@ -592,7 +598,8 @@ final class JavaExtractMethodProvider(
         val (start, end) = (ctx.startOf(target), ctx.endOf(target))
         if (ctx.rangeStart <= start && end <= ctx.rangeEnd) {
           ctx.elementAt(targetPath).foreach {
-            case v: VariableElement if isFreeVariable(v, ctx, methodElement) =>
+            case v: VariableElement
+                if isFreeVariable(v, methodElement, enclosedVariables) =>
               mutated += v.getSimpleName().toString()
             case _ =>
           }
@@ -603,35 +610,18 @@ final class JavaExtractMethodProvider(
     mutated.toSet
   }
 
+  /*
+   * A variable is free if it is not local, not a parameter, and not enclosed by the method.
+   */
   private def isFreeVariable(
       variable: VariableElement,
-      ctx: Context,
-      methodElement: ExecutableElement
+      methodElement: ExecutableElement,
+      enclosedVariables: Set[VariableElement]
   ): Boolean =
     if (!isLocalLike(variable) && variable.getKind != ElementKind.PARAMETER)
       false
     else if (!isEnclosedBy(variable, methodElement)) false
-    else
-      declarationTree(variable, ctx).forall { tree =>
-        !ctx.encloses(ctx.startOf(tree), ctx.endOf(tree))
-      }
-
-  private def declarationTree(
-      variable: VariableElement,
-      ctx: Context
-  ): Option[Tree] = {
-    object finder extends TreePathScanner[Unit, Unit] {
-      var found: Option[Tree] = None
-      override def visitVariable(node: VariableTree, p: Unit): Unit = {
-        ctx.elementAt(getCurrentPath()).foreach { elem =>
-          if (elem == variable) found = Some(node)
-        }
-        super.visitVariable(node, p)
-      }
-    }
-    finder.scan(ctx.cu, ())
-    finder.found
-  }
+    else !enclosedVariables.contains(variable)
 
   private def identifierNames(tree: Tree): Set[String] = {
     val names = mutable.Set.empty[String]

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaExtractMethodProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaExtractMethodProvider.scala
@@ -570,40 +570,32 @@ final class JavaExtractMethodProvider(
   ): Set[String] = {
     val mutated = mutable.Set.empty[String]
     val scanner = new TreePathScanner[Unit, Unit] {
-      override def visitAssignment(node: AssignmentTree, p: Unit): Unit = {
-        checkMutatedTarget(node.getVariable())
-        super.visitAssignment(node, p)
-      }
-
-      override def visitCompoundAssignment(
-          node: CompoundAssignmentTree,
-          p: Unit
-      ): Unit = {
-        checkMutatedTarget(node.getVariable())
-        super.visitCompoundAssignment(node, p)
-      }
-
-      override def visitUnary(node: UnaryTree, p: Unit): Unit = {
-        node.getKind() match {
-          case Tree.Kind.PREFIX_INCREMENT | Tree.Kind.PREFIX_DECREMENT |
-              Tree.Kind.POSTFIX_INCREMENT | Tree.Kind.POSTFIX_DECREMENT =>
-            checkMutatedTarget(node.getExpression())
-          case _ =>
-        }
-        super.visitUnary(node, p)
-      }
-
-      private def checkMutatedTarget(target: ExpressionTree): Unit = {
-        val targetPath = new TreePath(getCurrentPath(), target)
-        val (start, end) = (ctx.startOf(target), ctx.endOf(target))
+      override def visitIdentifier(node: IdentifierTree, p: Unit): Unit = {
+        val (start, end) = (ctx.startOf(node), ctx.endOf(node))
         if (ctx.rangeStart <= start && end <= ctx.rangeEnd) {
-          ctx.elementAt(targetPath).foreach {
-            case v: VariableElement
-                if isFreeVariable(v, methodElement, enclosedVariables) =>
-              mutated += v.getSimpleName().toString()
-            case _ =>
+          val parentPath = getCurrentPath().getParentPath()
+          if (parentPath != null && isMutationContext(parentPath.getLeaf())) {
+            ctx.elementAt(getCurrentPath()).foreach {
+              case v: VariableElement
+                  if isFreeVariable(v, methodElement, enclosedVariables) =>
+                mutated += v.getSimpleName().toString()
+              case _ =>
+            }
           }
         }
+        super.visitIdentifier(node, p)
+      }
+
+      private def isMutationContext(parent: Tree): Boolean = parent match {
+        case _: AssignmentTree | _: CompoundAssignmentTree => true
+        case u: UnaryTree =>
+          u.getKind() match {
+            case Tree.Kind.PREFIX_INCREMENT | Tree.Kind.PREFIX_DECREMENT |
+                Tree.Kind.POSTFIX_INCREMENT | Tree.Kind.POSTFIX_DECREMENT =>
+              true
+            case _ => false
+          }
+        case _ => false
       }
     }
     scanner.scan(ctx.cu, ())

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaExtractMethodProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaExtractMethodProvider.scala
@@ -24,11 +24,13 @@ import scala.meta.pc.OffsetParams
 import scala.meta.pc.RangeParams
 
 import com.sun.source.tree.ArrayAccessTree
+import com.sun.source.tree.AssignmentTree
 import com.sun.source.tree.BinaryTree
 import com.sun.source.tree.BlockTree
 import com.sun.source.tree.BreakTree
 import com.sun.source.tree.ClassTree
 import com.sun.source.tree.CompilationUnitTree
+import com.sun.source.tree.CompoundAssignmentTree
 import com.sun.source.tree.ConditionalExpressionTree
 import com.sun.source.tree.ContinueTree
 import com.sun.source.tree.ExpressionStatementTree
@@ -343,6 +345,13 @@ final class JavaExtractMethodProvider(
     val classTree = selection.classPath.getLeaf().asInstanceOf[ClassTree]
     val typePrinter = new TypePrinter(ctx)
     val freeVariables = collectFreeVariables(ctx, methodElement)
+    val mutatedFreeVars = collectMutatedFreeVariables(ctx, methodElement)
+    if (mutatedFreeVars.nonEmpty) {
+      val varNames = mutatedFreeVars.toList.sorted.mkString(", ")
+      throw new DisplayableException(
+        s"Cannot extract selection that modifies captured variable(s): $varNames"
+      )
+    }
     val usedNames = classTree
       .getMembers()
       .asScala
@@ -547,6 +556,51 @@ final class JavaExtractMethodProvider(
     }
     scanner.scan(ctx.cu, ())
     params.values.toList
+  }
+
+  private def collectMutatedFreeVariables(
+      ctx: Context,
+      methodElement: ExecutableElement
+  ): Set[String] = {
+    val mutated = mutable.Set.empty[String]
+    val scanner = new TreePathScanner[Unit, Unit] {
+      override def visitAssignment(node: AssignmentTree, p: Unit): Unit = {
+        checkMutatedTarget(node.getVariable())
+        super.visitAssignment(node, p)
+      }
+
+      override def visitCompoundAssignment(
+          node: CompoundAssignmentTree,
+          p: Unit
+      ): Unit = {
+        checkMutatedTarget(node.getVariable())
+        super.visitCompoundAssignment(node, p)
+      }
+
+      override def visitUnary(node: UnaryTree, p: Unit): Unit = {
+        node.getKind() match {
+          case Tree.Kind.PREFIX_INCREMENT | Tree.Kind.PREFIX_DECREMENT |
+              Tree.Kind.POSTFIX_INCREMENT | Tree.Kind.POSTFIX_DECREMENT =>
+            checkMutatedTarget(node.getExpression())
+          case _ =>
+        }
+        super.visitUnary(node, p)
+      }
+
+      private def checkMutatedTarget(target: ExpressionTree): Unit = {
+        val targetPath = new TreePath(getCurrentPath(), target)
+        val (start, end) = (ctx.startOf(target), ctx.endOf(target))
+        if (ctx.rangeStart <= start && end <= ctx.rangeEnd) {
+          ctx.elementAt(targetPath).foreach {
+            case v: VariableElement if isFreeVariable(v, ctx, methodElement) =>
+              mutated += v.getSimpleName().toString()
+            case _ =>
+          }
+        }
+      }
+    }
+    scanner.scan(ctx.cu, ())
+    mutated.toSet
   }
 
   private def isFreeVariable(

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPresentationCompiler.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPresentationCompiler.scala
@@ -33,6 +33,7 @@ import scala.meta.internal.pc.JavaReferencesProvider
 import scala.meta.internal.pc.JavaRenameProvider
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.AutoImportsResult
+import scala.meta.pc.CodeActionId
 import scala.meta.pc.DefinitionResult
 import scala.meta.pc.EmbeddedClient
 import scala.meta.pc.HoverSignature
@@ -255,7 +256,13 @@ case class JavaPresentationCompiler(
       range: RangeParams,
       extractionPos: OffsetParams
   ): CompletableFuture[util.List[TextEdit]] =
-    CompletableFuture.completedFuture(Nil.asJava)
+    request(range, util.Collections.emptyList[TextEdit]()) { pc =>
+      new JavaExtractMethodProvider(
+        pc,
+        range,
+        extractionPos
+      ).extractMethod.asJava
+    }
 
   override def convertToNamedArguments(
       params: OffsetParams,
@@ -281,7 +288,7 @@ case class JavaPresentationCompiler(
   }
 
   override def supportedCodeActions(): util.List[String] = {
-    util.Collections.emptyList()
+    List(CodeActionId.ExtractMethod).asJava
   }
 
   override def didClose(uri: URI): Unit = ()

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPresentationCompilerAccess.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPresentationCompilerAccess.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.ScheduledExecutorService
 import scala.concurrent.ExecutionContextExecutor
 
 import scala.meta.internal.pc.CompilerAccess
+import scala.meta.pc.DisplayableException
 import scala.meta.pc.PresentationCompilerConfig
 
 import org.slf4j.Logger
@@ -27,7 +28,10 @@ class JavaPresentationCompilerAccess(
   override protected def newReporter: Unit = ()
   override protected def handleSharedCompilerException(
       t: Throwable
-  ): Option[String] = Some(s"an error in the Java compiler: ${t}")
+  ): Option[String] = t match {
+    case _: DisplayableException => throw t
+    case _ => Some(s"an error in the Java compiler: ${t}")
+  }
 
   override protected def ignoreException(t: Throwable): Boolean = false
 

--- a/tests/javapc/src/main/scala/tests/pc/BaseJavaExtractMethodSuite.scala
+++ b/tests/javapc/src/main/scala/tests/pc/BaseJavaExtractMethodSuite.scala
@@ -1,0 +1,93 @@
+package tests.pc
+
+import java.net.URI
+import java.util.concurrent.ExecutionException
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.CompilerOffsetParams
+import scala.meta.internal.metals.CompilerRangeParams
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.internal.metals.TextEdits
+import scala.meta.pc.CancelToken
+import scala.meta.pc.DisplayableException
+
+import munit.Location
+import munit.TestOptions
+import org.eclipse.{lsp4j => l}
+
+trait BaseJavaExtractMethodSuite extends BaseJavaPCSuite {
+
+  protected def cancelToken: CancelToken = EmptyCancelToken
+
+  def checkEdit(
+      name: TestOptions,
+      original: String,
+      expected: String,
+      filename: String = "A.java",
+  )(implicit location: Location): Unit =
+    test(name) {
+      val (edits, code) = extractMethodEdits(original, filename)
+      val obtained = TextEdits.applyEdits(code, edits)
+      assertNoDiff(obtained, expected)
+    }
+
+  def checkError(
+      name: TestOptions,
+      original: String,
+      expectedError: String,
+      filename: String = "A.java",
+  )(implicit location: Location): Unit =
+    test(name) {
+      try {
+        extractMethodEdits(original, filename)
+        fail("Expected DisplayableException but none was thrown")
+      } catch {
+        case e: ExecutionException =>
+          e.getCause() match {
+            case cause: DisplayableException =>
+              assertNoDiff(cause.getMessage(), expectedError)
+            case other =>
+              fail(s"Expected DisplayableException but got: $other")
+          }
+      }
+    }
+
+  def extractMethodEdits(
+      original: String,
+      filename: String = "A.java",
+  ): (List[l.TextEdit], String) = {
+    val withoutExtractionPos = original.replace("@@", "")
+    val onlyRangeClose = withoutExtractionPos.replace("<<", "")
+    val code = onlyRangeClose.replace(">>", "")
+    val extractionOffset = markerOffset(original, "@@")
+    val rangeStart = markerOffset(withoutExtractionPos, "<<")
+    val rangeEnd = markerOffset(onlyRangeClose, ">>")
+    val extractionPos = CompilerOffsetParams(
+      URI.create(s"file:///$filename"),
+      code,
+      extractionOffset,
+      cancelToken,
+    )
+    val rangeParams = CompilerRangeParams(
+      URI.create(s"file:///$filename"),
+      code,
+      rangeStart,
+      rangeEnd,
+      cancelToken,
+    )
+    val result =
+      presentationCompiler.extractMethod(rangeParams, extractionPos).get()
+    (result.asScala.toList, code)
+  }
+
+  private def markerOffset(text: String, marker: String): Int = {
+    val index = text.indexOf(marker)
+    if (index < 0) fail(s"missing $marker")
+    text
+      .take(index)
+      .replace("@@", "")
+      .replace("<<", "")
+      .replace(">>", "")
+      .length
+  }
+}

--- a/tests/javapc/src/test/scala/pc/CompletionImportsSuite.scala
+++ b/tests/javapc/src/test/scala/pc/CompletionImportsSuite.scala
@@ -6,6 +6,7 @@ class CompletionImportsSuite extends BaseJavaCompletionSuite {
   check(
     "package-only",
     """package a;
+      |
       |class A {
       |  public void foo() {
       |    return StandardChar@@

--- a/tests/javapc/src/test/scala/pc/JavaExtractMethodSuite.scala
+++ b/tests/javapc/src/test/scala/pc/JavaExtractMethodSuite.scala
@@ -1,0 +1,388 @@
+package pc
+
+import tests.pc.BaseJavaExtractMethodSuite
+
+class JavaExtractMethodSuite extends BaseJavaExtractMethodSuite {
+
+  checkEdit(
+    "simple-expr",
+    """|class A {
+       |  int method(int i) {
+       |    return i + 1;
+       |  }
+       |
+       |  @@void main() {
+       |    int a = <<123 + method(4)>>;
+       |  }
+       |}
+       |""".stripMargin,
+    """|class A {
+       |  int method(int i) {
+       |    return i + 1;
+       |  }
+       |
+       |  private int newMethod() {
+       |    return 123 + method(4);
+       |  }
+       |
+       |  void main() {
+       |    int a = newMethod();
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "no-param",
+    """|class A {
+       |  @@void foo() {
+       |    int c = 1;
+       |    <<int b = 2;
+       |    System.out.println(b);>>
+       |  }
+       |}
+       |""".stripMargin,
+    """|class A {
+       |  private void newMethod() {
+       |    int b = 2;
+       |    System.out.println(b);
+       |  }
+       |
+       |  void foo() {
+       |    int c = 1;
+       |    newMethod();
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "single-param",
+    """|class A {
+       |  @@void foo() {
+       |    int c = 1;
+       |    <<int b = 2;
+       |    System.out.println(c);>>
+       |  }
+       |}
+       |""".stripMargin,
+    """|class A {
+       |  private void newMethod(int c) {
+       |    int b = 2;
+       |    System.out.println(c);
+       |  }
+       |
+       |  void foo() {
+       |    int c = 1;
+       |    newMethod(c);
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "with-return",
+    """|class A {
+       |  @@void foo() {
+       |    int c = 1;
+       |    <<int b = 2;
+       |    int x = b + 10;>>
+       |    System.out.println(x);
+       |  }
+       |}
+       |""".stripMargin,
+    """|class A {
+       |  private int newMethod() {
+       |    int b = 2;
+       |    int x = b + 10;
+       |    return x;
+       |  }
+       |
+       |  void foo() {
+       |    int c = 1;
+       |    int x = newMethod();
+       |    System.out.println(x);
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "auto-import",
+    """|class A {
+       |  @@void foo() {
+       |    <<java.util.UUID.randomUUID();>>
+       |  }
+       |}
+       |""".stripMargin,
+    """|import java.util.UUID;
+       |
+       |class A {
+       |  private UUID newMethod() {
+       |    return java.util.UUID.randomUUID();
+       |  }
+       |
+       |  void foo() {
+       |    newMethod();
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "types",
+    """|import java.util.Optional;
+       |
+       |class A {
+       |  @@void foo() {
+       |    <<String[] args = new String[] {"hello"};
+       |      Optional<String> value = Optional.of(args[0]);>>
+       |      System.out.println(value.get());
+       |  }
+       |}
+       |""".stripMargin,
+    """|import java.util.Optional;
+       |
+       |class A {
+       |  private Optional<String> newMethod() {
+       |    String[] args = new String[] {"hello"};
+       |    Optional<String> value = Optional.of(args[0]);
+       |    return value;
+       |  }
+       |
+       |  void foo() {
+       |    Optional<String> value = newMethod();
+       |      System.out.println(value.get());
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkError(
+    "return-selected",
+    """|import java.util.Optional;
+       |
+       |class A {
+       |  @@void foo() {
+       |      <<if (2 == 2) {
+       |        return false;
+       |      }>>
+       |      System.out.println(value.get());
+       |  }
+       |}
+       |""".stripMargin,
+    "Cannot extract selection that contains return statements",
+  )
+
+  checkError(
+    "super-selected",
+    """|class Parent {
+       |  void doSomething() {}
+       |}
+       |
+       |class A extends Parent {
+       |  @@void foo() {
+       |      <<super.doSomething();>>
+       |  }
+       |}
+       |""".stripMargin,
+    "Cannot extract selection that contains super calls",
+  )
+
+  checkError(
+    "multiple-variables-after-selection",
+    """|class A {
+       |  @@void foo() {
+       |      <<int a = 1;
+       |      int b = 2;>>
+       |      System.out.println(a + b);
+       |  }
+       |}
+       |""".stripMargin,
+    "No return type can be inferred, multiple variables are used after the selection.",
+  )
+
+  checkEdit(
+    "multiple-void",
+    """|
+       |
+       |class A {
+       |  void requireNonNull(Object obj, String message) {
+       |    if (obj == null) {
+       |      throw new NullPointerException(message);
+       |    }
+       |  }
+       |
+       |  @@void foo() {
+       |<<    requireNonNull(filter, "filter is null");
+       |      requireNonNull(orderBy, "orderBy is null");
+       |      requireNonNull(nullTreatment, "nullTreatment is null");
+       |      requireNonNull(processingMode, "processingMode is null");
+       |      requireNonNull(arguments, "arguments is null");>>
+       |  }
+       |}
+       |""".stripMargin,
+    """|
+       |class A {
+       |  void requireNonNull(Object obj, String message) {
+       |    if (obj == null) {
+       |      throw new NullPointerException(message);
+       |    }
+       |  }
+       |
+       |  private void newMethod() {
+       |    requireNonNull(filter, "filter is null");
+       |    requireNonNull(orderBy, "orderBy is null");
+       |    requireNonNull(nullTreatment, "nullTreatment is null");
+       |    requireNonNull(processingMode, "processingMode is null");
+       |    requireNonNull(arguments, "arguments is null");
+       |  }
+       |
+       |  void foo() {
+       |    newMethod();
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "static-method",
+    """|class A {
+       |  @@static void foo() {
+       |    <<int a = 1;
+       |    int b = a + 2;>>
+       |    System.out.println(b);
+       |  }
+       |}
+       |""".stripMargin,
+    """|class A {
+       |  private static int newMethod() {
+       |    int a = 1;
+       |    int b = a + 2;
+       |    return b;
+       |  }
+       |
+       |  static void foo() {
+       |    int b = newMethod();
+       |    System.out.println(b);
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "whitespace-in-selection",
+    """|class A {
+       |  @@void foo() {
+       |    <<
+       |    int a = 1;
+       |    int b = a + 2;
+       |    >>
+       |    System.out.println(b);
+       |  }
+       |}
+       |""".stripMargin,
+    """|class A {
+       |  private int newMethod() {
+       |    int a = 1;
+       |    int b = a + 2;
+       |    return b;
+       |  }
+       |
+       |  void foo() {
+       |    
+       |    int b = newMethod();
+       |    
+       |    System.out.println(b);
+       |  }
+       |}
+       |""".stripMargin,
+  )
+  checkEdit(
+    "extract-partial",
+    """|class A {
+       |  @@void foo() {
+       |    boolean a = true;
+       |    boolean b = false;
+       |    boolean c = true;
+       |    boolean d = false;
+       |    boolean e = <<a && b && c &&>> d;
+       |   
+       |    System.out.println(e);
+       |  }
+       |}
+       |""".stripMargin,
+    """|class A {
+       |  private boolean newMethod(boolean a, boolean b, boolean c) {
+       |    return a && b && c;
+       |  }
+       |
+       |  void foo() {
+       |    boolean a = true;
+       |    boolean b = false;
+       |    boolean c = true;
+       |    boolean d = false;
+       |    boolean e = newMethod(a, b, c) && d;
+       |   
+       |    System.out.println(e);
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "method-type-param",
+    """|class A {
+       |  <T> T identity(T value) {
+       |    return value;
+       |  }
+       |
+       |  @@<T> void foo(T input) {
+       |    T result = <<identity(input)>>;
+       |    System.out.println(result);
+       |  }
+       |}
+       |""".stripMargin,
+    """|class A {
+       |  <T> T identity(T value) {
+       |    return value;
+       |  }
+       |
+       |  private <T> T newMethod(T input) {
+       |    return identity(input);
+       |  }
+       |
+       |  <T> void foo(T input) {
+       |    T result = newMethod(input);
+       |    System.out.println(result);
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "method-type-param-bounded",
+    """|import java.util.List;
+       |
+       |class A {
+       |  @@<T extends Number> void foo(List<T> items) {
+       |    T first = <<items.get(0)>>;
+       |    System.out.println(first);
+       |  }
+       |}
+       |""".stripMargin,
+    """|import java.util.List;
+       |
+       |class A {
+       |  private <T extends Number> T newMethod(List<T> items) {
+       |    return items.get(0);
+       |  }
+       |
+       |  <T extends Number> void foo(List<T> items) {
+       |    T first = newMethod(items);
+       |    System.out.println(first);
+       |  }
+       |}
+       |""".stripMargin,
+  )
+}

--- a/tests/javapc/src/test/scala/pc/JavaExtractMethodSuite.scala
+++ b/tests/javapc/src/test/scala/pc/JavaExtractMethodSuite.scala
@@ -424,4 +424,24 @@ class JavaExtractMethodSuite extends BaseJavaExtractMethodSuite {
        |}
        |""".stripMargin,
   )
+
+  checkEdit(
+    "single-void-expr-statement",
+    """|class A {
+       |  @@void foo() {
+       |    <<System.out.println("hello");>>
+       |  }
+       |}
+       |""".stripMargin,
+    """|class A {
+       |  private void newMethod() {
+       |    System.out.println("hello");
+       |  }
+       |
+       |  void foo() {
+       |    newMethod();
+       |  }
+       |}
+       |""".stripMargin,
+  )
 }

--- a/tests/javapc/src/test/scala/pc/JavaExtractMethodSuite.scala
+++ b/tests/javapc/src/test/scala/pc/JavaExtractMethodSuite.scala
@@ -202,6 +202,45 @@ class JavaExtractMethodSuite extends BaseJavaExtractMethodSuite {
     "No return type can be inferred, multiple variables are used after the selection.",
   )
 
+  checkError(
+    "mutated-captured-variable-assignment",
+    """|class A {
+       |  @@void foo() {
+       |    int x = 0;
+       |    <<x = 5;>>
+       |    System.out.println(x);
+       |  }
+       |}
+       |""".stripMargin,
+    "Cannot extract selection that modifies captured variable(s): x",
+  )
+
+  checkError(
+    "mutated-captured-variable-increment",
+    """|class A {
+       |  @@void foo() {
+       |    int x = 0;
+       |    <<x++;>>
+       |    System.out.println(x);
+       |  }
+       |}
+       |""".stripMargin,
+    "Cannot extract selection that modifies captured variable(s): x",
+  )
+
+  checkError(
+    "mutated-captured-variable-compound",
+    """|class A {
+       |  @@void foo() {
+       |    int x = 0;
+       |    <<x += 5;>>
+       |    System.out.println(x);
+       |  }
+       |}
+       |""".stripMargin,
+    "Cannot extract selection that modifies captured variable(s): x",
+  )
+
   checkEdit(
     "multiple-void",
     """|
@@ -274,10 +313,10 @@ class JavaExtractMethodSuite extends BaseJavaExtractMethodSuite {
     "whitespace-in-selection",
     """|class A {
        |  @@void foo() {
-       |    <<
+       |    <</**/
        |    int a = 1;
        |    int b = a + 2;
-       |    >>
+       |    >>/**/
        |    System.out.println(b);
        |  }
        |}
@@ -290,9 +329,9 @@ class JavaExtractMethodSuite extends BaseJavaExtractMethodSuite {
        |  }
        |
        |  void foo() {
-       |    
+       |    /**/
        |    int b = newMethod();
-       |    
+       |    /**/
        |    System.out.println(b);
        |  }
        |}

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolJavaLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolJavaLspSuite.scala
@@ -43,7 +43,6 @@ class ImportMissingSymbolJavaLspSuite
        |
        |import java.time.Instant;
        |
-       |
        |public class Example {
        |  public static Object now = Instant.now();
        |}
@@ -65,7 +64,6 @@ class ImportMissingSymbolJavaLspSuite
     """|package a;
        |
        |import java.util.ArrayList;
-       |
        |
        |public class Example {
        |  private ArrayList<String> items;
@@ -117,7 +115,6 @@ class ImportMissingSymbolJavaLspSuite
     """|package a;
        |
        |import java.util.ArrayList;
-       |
        |
        |public class Example {
        |  public Object create() {
@@ -171,9 +168,7 @@ class ImportMissingSymbolJavaLspSuite
         |""".stripMargin,
     """|package a;
        |import java.time.Instant;
-       |
        |import java.util.ArrayList;
-       |
        |
        |public class Example {
        |  public static Object now = Instant.now();
@@ -199,7 +194,6 @@ class ImportMissingSymbolJavaLspSuite
        |
        |import java.io.IOException;
        |
-       |
        |public class Example {
        |  public void readFile() throws IOException {
        |  }
@@ -222,7 +216,6 @@ class ImportMissingSymbolJavaLspSuite
        |
        |import java.io.Serializable;
        |
-       |
        |public class Example implements Serializable {
        |}
        |""".stripMargin,
@@ -243,7 +236,6 @@ class ImportMissingSymbolJavaLspSuite
     """|package a;
        |
        |import java.lang.annotation.Documented;
-       |
        |
        |@Documented
        |public class Example {
@@ -288,7 +280,6 @@ class ImportMissingSymbolJavaLspSuite
     """|package a;
        |
        |import java.util.ArrayList;
-       |
        |
        |public class Example {
        |  public void run() {

--- a/tests/unit/src/test/scala/tests/codeactions/JavaExtractMethodLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/JavaExtractMethodLspSuite.scala
@@ -1,0 +1,113 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.codeactions.JavaExtractMethodCodeAction
+
+class JavaExtractMethodLspSuite
+    extends BaseCodeActionLspSuite("java-extract-method") {
+
+  override protected def toPath(
+      fileName: String,
+      isSource: Boolean = true,
+  ): String =
+    if (isSource) s"a/src/main/java/a/$fileName"
+    else s"a/$fileName"
+
+  check(
+    "simple-expr",
+    """|package a;
+       |
+       |public class Example {
+       |  int method(int i) {
+       |    return i + 1;
+       |  }
+       |
+       |  void main() {
+       |    int a = <<123 + method(4)>>;
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${JavaExtractMethodCodeAction.title("main")}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  int method(int i) {
+       |    return i + 1;
+       |  }
+       |
+       |  private int newMethod() {
+       |    return 123 + method(4);
+       |  }
+       |
+       |  void main() {
+       |    int a = newMethod();
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+  )
+
+  check(
+    "with-return",
+    """|package a;
+       |
+       |public class Example {
+       |  void foo() {
+       |    int c = 1;
+       |    <<int b = 2;
+       |    int x = b + 10;>>
+       |    System.out.println(x);
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${JavaExtractMethodCodeAction.title("foo")}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  private int newMethod() {
+       |    int b = 2;
+       |    int x = b + 10;
+       |    return x;
+       |  }
+       |
+       |  void foo() {
+       |    int c = 1;
+       |    int x = newMethod();
+       |    System.out.println(x);
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+  )
+
+  check(
+    "auto-import",
+    """|package a;
+       |
+       |public class Example {
+       |  void foo() {
+       |    <<java.util.UUID.randomUUID();>>
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${JavaExtractMethodCodeAction.title("foo")}
+        |""".stripMargin,
+    """|package a;
+       |
+       |import java.util.UUID;
+       |
+       |
+       |public class Example {
+       |  private UUID newMethod() {
+       |    return java.util.UUID.randomUUID();
+       |  }
+       |
+       |  void foo() {
+       |    newMethod();
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+  )
+}

--- a/tests/unit/src/test/scala/tests/codeactions/JavaExtractMethodLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/JavaExtractMethodLspSuite.scala
@@ -97,7 +97,6 @@ class JavaExtractMethodLspSuite
        |
        |import java.util.UUID;
        |
-       |
        |public class Example {
        |  private UUID newMethod() {
        |    return java.util.UUID.randomUUID();

--- a/tests/unit/src/test/scala/tests/j/JavaPCCompletionSuite.scala
+++ b/tests/unit/src/test/scala/tests/j/JavaPCCompletionSuite.scala
@@ -59,7 +59,6 @@ class JavaPCCompletionSuite extends BaseJavaPCSuite("java-pc-completion") {
            |
            |import a.ExampleGreetingBean;
            |
-           |
            |public class FooQux {
            |  public void foo() {
            |    System.out.println(ExampleGreetingBean);


### PR DESCRIPTION
The functionality is parser based and will take into account the AST structure when selecting, which in some cases mightnot reflect 100% what the user selected with some && conditions. I don't want to delve currently into making work for any possible selection, since then you have to play around precedence and that is not simple at all.

Fixes https://github.com/scalameta/metals/issues/8498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Java “Extract Method” code action and compiler support, so selected Java code can now be refactored into a new method.
  * Improved call hierarchy details to better identify enclosing methods in Scala and Java contexts.

* **Bug Fixes**
  * Added safer handling for invalid selections, including cases with `return` statements, `super` calls, or empty ranges.
  * Refined extraction output to better preserve imports, parameters, return values, and call-site rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->