### PR TITLE
feature: Implement inline value code action in the workspace

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -51,7 +51,7 @@ final class CodeActionProvider(
     new ExtractValueCodeAction(trees, buffers),
     new CreateCompanionObjectCodeAction(trees, buffers),
     new ExtractMethodCodeAction(trees, compilers),
-    new InlineValueCodeAction(trees, compilers, languageClient),
+    new InlineValueCodeAction(trees, javaTrees, compilers, languageClient),
     new ConvertToNamedArguments(trees, compilers),
     new FlatMapToForComprehensionCodeAction(trees, buffers),
     new FilterMapToCollectCodeAction(trees, compilers),

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InlineValueCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InlineValueCodeAction.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.parsing.JavaTrees
 import scala.meta.internal.parsing.Trees
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
@@ -21,6 +22,7 @@ import org.eclipse.{lsp4j => l}
 
 class InlineValueCodeAction(
     trees: Trees,
+    javaTrees: JavaTrees,
     compilers: Compilers,
     languageClient: MetalsLanguageClient,
 ) extends CodeAction {
@@ -32,11 +34,20 @@ class InlineValueCodeAction(
 
   override def kind: String = l.CodeActionKind.RefactorInline
 
+  override def isJava: Boolean = true
+
   override def contribute(params: l.CodeActionParams, token: CancelToken)(
       implicit ec: ExecutionContext
-  ): Future[Seq[l.CodeAction]] = Future {
-    val pathStr = params.getTextDocument.getUri
-    val path = pathStr.toAbsolutePath
+  ): Future[Seq[l.CodeAction]] = {
+    val path = params.getTextDocument.getUri.toAbsolutePath
+    if (path.isJavaFilename) javaContribute(path, params, token)
+    else Future(scalaContribute(path, params))
+  }
+
+  private def scalaContribute(
+      path: AbsolutePath,
+      params: l.CodeActionParams,
+  ): Seq[l.CodeAction] = {
     val range = params.getRange()
     val action =
       for {
@@ -60,6 +71,58 @@ class InlineValueCodeAction(
         )
       }
     action.toSeq
+  }
+
+  /**
+   * Java inlining is backed by the presentation compiler. A cheap syntactic
+   * check (via [[JavaTrees]]) first confirms the cursor is on something that
+   * can be inlined inside the file, so the compiler is only consulted when it
+   * can actually perform the inline.
+   */
+  private def javaContribute(
+      path: AbsolutePath,
+      params: l.CodeActionParams,
+      token: CancelToken,
+  )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = {
+    val position = params.getRange().getStart()
+    Future.unit
+      .flatMap { _ =>
+        if (!isInlinableJavaValue(path, position)) Future.successful(Nil)
+        else {
+          val positionParams =
+            new l.TextDocumentPositionParams(params.getTextDocument(), position)
+          compilers.inlineEdits(positionParams, token).map { edits =>
+            if (edits.isEmpty()) Nil
+            else
+              Seq(
+                CodeActionBuilder.build(
+                  title = InlineValueCodeAction.genericTitle,
+                  kind = this.kind,
+                  changes = Seq(path -> edits.asScala.toSeq),
+                )
+              )
+          }
+        }
+      }
+      .recover { case _ => Nil }
+  }
+
+  /**
+   * Whether the cursor is on a value that is safe to inline within the file: a
+   * local value inside any block (method body, initializer, lambda, ...), or a
+   * `private` field of the enclosing class.
+   */
+  private def isInlinableJavaValue(
+      path: AbsolutePath,
+      position: l.Position,
+  ): Boolean = {
+    // Local values live inside a block; a private field is the only top-level
+    // member safe to inline within the file (only locals can be private, so a
+    // private variable at the cursor is necessarily a field).
+    def insideBlock = javaTrees.isInsideBlock(path, position)
+    def onPrivateField =
+      javaTrees.findEnclosingJavaVariable(path, position).exists(_.isPrivate)
+    insideBlock || onPrivateField
   }
 
   private def isLocal(definition: Tree): Boolean =
@@ -139,4 +202,6 @@ object InlineValueCodeAction {
     val optDots = if (name.length > 10) "..." else ""
     s"Inline `${name.take(10)}$optDots`"
   }
+
+  val genericTitle: String = "Inline value"
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InlineValueCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InlineValueCodeAction.scala
@@ -95,21 +95,21 @@ class InlineValueCodeAction(
     )
 
   /**
-   * Whether the cursor is on a value that is safe to inline within the file: a
-   * local value inside any block (method body, initializer, lambda, ...), or a
-   * `private` field of the enclosing class.
+   * Whether the cursor is on an identifier, we can inline the value.
+   * We might remove the definition is it's private or inside a block.
    */
   private def isInlinableJavaValue(
       path: AbsolutePath,
       position: l.Position,
   ): Boolean = {
-    // Local values live inside a block; a private field is the only top-level
-    // member safe to inline within the file (only locals can be private, so a
-    // private variable at the cursor is necessarily a field).
-    def insideBlock = javaTrees.isInsideBlock(path, position)
-    def onPrivateField =
-      javaTrees.findEnclosingJavaVariable(path, position).exists(_.isPrivate)
-    insideBlock || onPrivateField
+    javaTrees
+      .findEnclosingIdentifier(path, position)
+      .orElse {
+        javaTrees.findEnclosingJavaVariable(path, position).filter { v =>
+          v.tree.getInitializer() != null
+        }
+      }
+      .isDefined
   }
 
   private def isLocal(definition: Tree): Boolean =
@@ -180,16 +180,6 @@ class InlineValueCodeAction(
         }
         ()
       }
-      .recover(
-        // The presentation compiler reports an impossible inline (e.g. a
-        // reassigned value) as a DisplayableException; show it instead of
-        // inlining. Other failures propagate as usual.
-        getOptDisplayableMessage.andThen { message =>
-          languageClient.showMessage(
-            new l.MessageParams(l.MessageType.Warning, message)
-          )
-        }
-      )
 
   private def getTermNameForPos(
       path: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InlineValueCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InlineValueCodeAction.scala
@@ -2,7 +2,6 @@ package scala.meta.internal.metals.codeactions
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.util.control.NonFatal
 
 import scala.meta.Defn
 import scala.meta.Pat
@@ -181,14 +180,16 @@ class InlineValueCodeAction(
         }
         ()
       }
-      .recover {
+      .recover(
         // The presentation compiler reports an impossible inline (e.g. a
-        // reassigned value) as a failure; surface it instead of inlining.
-        case NonFatal(error) =>
+        // reassigned value) as a DisplayableException; show it instead of
+        // inlining. Other failures propagate as usual.
+        getOptDisplayableMessage.andThen { message =>
           languageClient.showMessage(
-            new l.MessageParams(l.MessageType.Warning, error.getMessage)
+            new l.MessageParams(l.MessageType.Warning, message)
           )
-      }
+        }
+      )
 
   private def getTermNameForPos(
       path: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InlineValueCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InlineValueCodeAction.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.metals.codeactions
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 
 import scala.meta.Defn
 import scala.meta.Pat
@@ -38,10 +39,14 @@ class InlineValueCodeAction(
 
   override def contribute(params: l.CodeActionParams, token: CancelToken)(
       implicit ec: ExecutionContext
-  ): Future[Seq[l.CodeAction]] = {
+  ): Future[Seq[l.CodeAction]] = Future {
+    // `contribute` runs on every cursor movement, so it must stay cheap: it
+    // only decides *whether* to offer the action (syntactically). The actual
+    // edits are computed by the presentation compiler in `handleCommand`, when
+    // the user invokes it.
     val path = params.getTextDocument.getUri.toAbsolutePath
-    if (path.isJavaFilename) javaContribute(path, params, token)
-    else Future(scalaContribute(path, params))
+    if (path.isJavaFilename) javaContribute(path, params)
+    else scalaContribute(path, params)
   }
 
   private def scalaContribute(
@@ -56,56 +61,39 @@ class InlineValueCodeAction(
         /* Either the value definition is local, which can be always inlined since it's scoped to the file
            or action was executed on a value reference so inlining just the reference will not break anything. */
         if (isLocal(defn) || !isDefn)
-      } yield {
-        val command =
-          ServerCommands.InlineValue.toLsp(
-            new l.TextDocumentPositionParams(
-              params.getTextDocument(),
-              params.getRange().getStart(),
-            )
-          )
-        CodeActionBuilder.build(
-          title = InlineValueCodeAction.title(termName.value),
-          kind = this.kind,
-          command = Some(command),
-        )
-      }
+      } yield inlineCommand(params, InlineValueCodeAction.title(termName.value))
     action.toSeq
   }
 
   /**
-   * Java inlining is backed by the presentation compiler. A cheap syntactic
-   * check (via [[JavaTrees]]) first confirms the cursor is on something that
-   * can be inlined inside the file, so the compiler is only consulted when it
-   * can actually perform the inline.
+   * A cheap syntactic check (via [[JavaTrees]]): is the cursor on a value that
+   * could be inlined within the file? The presentation compiler does the real
+   * work (and the precise feasibility check) lazily in `handleCommand`.
    */
   private def javaContribute(
       path: AbsolutePath,
       params: l.CodeActionParams,
-      token: CancelToken,
-  )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = {
-    val position = params.getRange().getStart()
-    Future.unit
-      .flatMap { _ =>
-        if (!isInlinableJavaValue(path, position)) Future.successful(Nil)
-        else {
-          val positionParams =
-            new l.TextDocumentPositionParams(params.getTextDocument(), position)
-          compilers.inlineEdits(positionParams, token).map { edits =>
-            if (edits.isEmpty()) Nil
-            else
-              Seq(
-                CodeActionBuilder.build(
-                  title = InlineValueCodeAction.genericTitle,
-                  kind = this.kind,
-                  changes = Seq(path -> edits.asScala.toSeq),
-                )
-              )
-          }
-        }
-      }
-      .recover { case _ => Nil }
-  }
+  ): Seq[l.CodeAction] =
+    if (isInlinableJavaValue(path, params.getRange().getStart()))
+      Seq(inlineCommand(params, InlineValueCodeAction.genericTitle))
+    else Nil
+
+  private def inlineCommand(
+      params: l.CodeActionParams,
+      title: String,
+  ): l.CodeAction =
+    CodeActionBuilder.build(
+      title = title,
+      kind = this.kind,
+      command = Some(
+        ServerCommands.InlineValue.toLsp(
+          new l.TextDocumentPositionParams(
+            params.getTextDocument(),
+            params.getRange().getStart(),
+          )
+        )
+      ),
+    )
 
   /**
    * Whether the cursor is on a value that is safe to inline within the file: a
@@ -179,16 +167,28 @@ class InlineValueCodeAction(
       params: l.TextDocumentPositionParams,
       token: CancelToken,
   )(implicit ec: ExecutionContext): Future[Unit] =
-    for {
-      edits <- compilers.inlineEdits(params, token)
-      _ = languageClient.applyEdit(
-        new l.ApplyWorkspaceEditParams(
-          new l.WorkspaceEdit(
-            Map(params.getTextDocument().getUri -> edits).asJava
+    compilers
+      .inlineEdits(params, token)
+      .map { edits =>
+        if (!edits.isEmpty()) {
+          languageClient.applyEdit(
+            new l.ApplyWorkspaceEditParams(
+              new l.WorkspaceEdit(
+                Map(params.getTextDocument().getUri -> edits).asJava
+              )
+            )
           )
-        )
-      )
-    } yield ()
+        }
+        ()
+      }
+      .recover {
+        // The presentation compiler reports an impossible inline (e.g. a
+        // reassigned value) as a failure; surface it instead of inlining.
+        case NonFatal(error) =>
+          languageClient.showMessage(
+            new l.MessageParams(l.MessageType.Warning, error.getMessage)
+          )
+      }
 
   private def getTermNameForPos(
       path: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/parsing/JavaTrees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/JavaTrees.scala
@@ -17,9 +17,9 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals._
 import scala.meta.io.AbsolutePath
 
-import com.sun.source.tree.BlockTree
 import com.sun.source.tree.ClassTree
 import com.sun.source.tree.CompilationUnitTree
+import com.sun.source.tree.IdentifierTree
 import com.sun.source.tree.LineMap
 import com.sun.source.tree.MethodTree
 import com.sun.source.tree.Tree
@@ -55,6 +55,20 @@ class JavaTrees(buffers: Buffers) {
       }
     } yield result
 
+  def findEnclosingIdentifier(
+      source: AbsolutePath,
+      pos: l.Position,
+  ): Option[IdentifierTree] =
+    for {
+      text <- text(source)
+      tree <- get(source)
+      result <- {
+        val visitor = new EnclosingIdentifierFinder(tree, text, pos)
+        visitor.scan(tree, ())
+        visitor.result
+      }
+    } yield result
+
   def findEnclosingJavaMethod(
       source: AbsolutePath,
       pos: l.Position,
@@ -82,22 +96,6 @@ class JavaTrees(buffers: Buffers) {
         visitor.result
       }
     } yield result
-
-  /**
-   * Whether `pos` is inside any block: a method/constructor body, a static or
-   * instance initializer, or a lambda/nested block. Local variables can be
-   * declared in any of these, so this is the cheap test for "could be a local
-   * value to inline".
-   */
-  def isInsideBlock(source: AbsolutePath, pos: l.Position): Boolean =
-    (for {
-      text <- text(source)
-      tree <- get(source)
-    } yield {
-      val finder = new BlockFinder(tree, text, pos)
-      finder.scan(tree, ())
-      finder.result.isDefined
-    }).getOrElse(false)
 
   private def text(source: AbsolutePath): Option[String] =
     buffers.get(source).orElse(source.readTextOpt)
@@ -255,20 +253,6 @@ class JavaTrees(buffers: Buffers) {
     }
   }
 
-  /** Finds whether the cursor is inside any block (see [[isInsideBlock]]). */
-  private class BlockFinder(
-      cu: CompilationUnitTree,
-      text: String,
-      targetPos: l.Position,
-  ) extends EnclosingFinder[Unit](cu, text, targetPos) {
-
-    override def visitBlock(node: BlockTree, p: Unit): Unit = {
-      if (positionContains(targetOffset, pos.startPos(node), pos.endPos(node)))
-        _result = Some(())
-      super.visitBlock(node, p)
-    }
-  }
-
   private class EnclosingMethodFinder(
       cu: CompilationUnitTree,
       text: String,
@@ -337,11 +321,36 @@ class JavaTrees(buffers: Buffers) {
     ): Unit = {
       val nodeStart = pos.startPos(node)
       val nodeEnd = pos.endPos(node)
-
       if (positionContains(targetOffset, nodeStart, nodeEnd)) {
-        _result = javaVariable(node)
+        val name = node.getName().toString()
+        val actualNodeStart =
+          findNameOffset(text, nodeStart, nodeEnd, name)
+            .getOrElse(nodeStart)
+        val actualNodeEnd = actualNodeStart + name.length()
+        if (positionContains(targetOffset, actualNodeStart, actualNodeEnd)) {
+          _result = javaVariable(node)
+        }
       }
       super.visitVariable(node, p)
+    }
+  }
+
+  private class EnclosingIdentifierFinder(
+      cu: CompilationUnitTree,
+      text: String,
+      targetPos: l.Position,
+  ) extends EnclosingFinder[IdentifierTree](cu, text, targetPos) {
+
+    override def visitIdentifier(
+        node: IdentifierTree,
+        p: Unit,
+    ): Unit = {
+      val nodeStart = pos.startPos(node)
+      val nodeEnd = pos.endPos(node)
+      if (positionContains(targetOffset, nodeStart, nodeEnd)) {
+        _result = Some(node)
+      }
+      super.visitIdentifier(node, p)
     }
   }
 
@@ -517,6 +526,22 @@ class JavaTrees(buffers: Buffers) {
       endPos: Int,
       name: String,
   ): Option[JavaRange] = {
+    findNameOffset(text, startPos, endPos, name).map { offset =>
+      val endOffset = offset + name.length()
+      JavaRange(
+        Positions.toLspRange(lineMap, offset, endOffset, text),
+        startOffset = offset,
+        endOffset = endOffset,
+      )
+    }
+  }
+
+  private def findNameOffset(
+      text: String,
+      startPos: Int,
+      endPos: Int,
+      name: String,
+  ): Option[Int] = {
     if (startPos < 0 || endPos < 0) None
     else {
       val searchEnd = Math.min(endPos, text.length())
@@ -533,14 +558,6 @@ class JavaTrees(buffers: Buffers) {
           // Right boundary: next char is end-of-text or does not continue an identifier.
           (endOffset >= text.length() ||
             !Character.isJavaIdentifierPart(text.charAt(endOffset)))
-        }
-        .map { offset =>
-          val endOffset = offset + name.length()
-          JavaRange(
-            Positions.toLspRange(lineMap, offset, endOffset, text),
-            startOffset = offset,
-            endOffset = endOffset,
-          )
         }
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/parsing/JavaTrees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/JavaTrees.scala
@@ -17,6 +17,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals._
 import scala.meta.io.AbsolutePath
 
+import com.sun.source.tree.BlockTree
 import com.sun.source.tree.ClassTree
 import com.sun.source.tree.CompilationUnitTree
 import com.sun.source.tree.LineMap
@@ -81,6 +82,22 @@ class JavaTrees(buffers: Buffers) {
         visitor.result
       }
     } yield result
+
+  /**
+   * Whether `pos` is inside any block: a method/constructor body, a static or
+   * instance initializer, or a lambda/nested block. Local variables can be
+   * declared in any of these, so this is the cheap test for "could be a local
+   * value to inline".
+   */
+  def isInsideBlock(source: AbsolutePath, pos: l.Position): Boolean =
+    (for {
+      text <- text(source)
+      tree <- get(source)
+    } yield {
+      val finder = new BlockFinder(tree, text, pos)
+      finder.scan(tree, ())
+      finder.result.isDefined
+    }).getOrElse(false)
 
   private def text(source: AbsolutePath): Option[String] =
     buffers.get(source).orElse(source.readTextOpt)
@@ -235,6 +252,20 @@ class JavaTrees(buffers: Buffers) {
           modifiers = node.getModifiers().getFlags().asScala.toSet,
         )
       }
+    }
+  }
+
+  /** Finds whether the cursor is inside any block (see [[isInsideBlock]]). */
+  private class BlockFinder(
+      cu: CompilationUnitTree,
+      text: String,
+      targetPos: l.Position,
+  ) extends EnclosingFinder[Unit](cu, text, targetPos) {
+
+    override def visitBlock(node: BlockTree, p: Unit): Unit = {
+      if (positionContains(targetOffset, pos.startPos(node), pos.endPos(node)))
+        _result = Some(())
+      super.visitBlock(node, p)
     }
   }
 

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaInlineValueRefactoringProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaInlineValueRefactoringProvider.scala
@@ -14,6 +14,7 @@ import scala.meta.internal.pc.Reference
 import scala.meta.pc.OffsetParams
 
 import com.sun.source.tree.ArrayAccessTree
+import com.sun.source.tree.ArrayTypeTree
 import com.sun.source.tree.AssignmentTree
 import com.sun.source.tree.BinaryTree
 import com.sun.source.tree.CompilationUnitTree
@@ -23,6 +24,7 @@ import com.sun.source.tree.IdentifierTree
 import com.sun.source.tree.InstanceOfTree
 import com.sun.source.tree.LambdaExpressionTree
 import com.sun.source.tree.MemberSelectTree
+import com.sun.source.tree.NewArrayTree
 import com.sun.source.tree.Tree
 import com.sun.source.tree.TypeCastTree
 import com.sun.source.tree.UnaryTree
@@ -144,9 +146,10 @@ final class JavaInlineValueRefactoringProvider(
               if (edits.contains(None)) Left(Errors.didNotFindReference)
               else {
                 val defEnd = endWithSemicolon(rhsEnd)
+                val rhsText = formatInitializer(varTree, init, rhsStart, rhsEnd)
                 val definition = Definition(
                   toRange(defStart, defEnd),
-                  sourceText.substring(rhsStart, rhsEnd),
+                  rhsText,
                   RangeOffset(defStart, defEnd),
                   initializerNeedsBrackets(init),
                   requiresCurlyBraces = false,
@@ -224,11 +227,38 @@ final class JavaInlineValueRefactoringProvider(
       case _ => false
     }
 
+  private def formatInitializer(
+      varTree: VariableTree,
+      init: Tree,
+      rhsStart: Int,
+      rhsEnd: Int
+  ): String = {
+    val rawText = sourceText.substring(rhsStart, rhsEnd)
+    init match {
+      case arr: NewArrayTree
+          if arr.getDimensions().isEmpty && arr.getInitializers() != null =>
+        extractArrayType(varTree.getType()) match {
+          case Some(elementType) => s"new $elementType[]$rawText"
+          case None => rawText
+        }
+      case _ => rawText
+    }
+  }
+
+  private def extractArrayType(typeTree: Tree): Option[String] =
+    typeTree match {
+      case arr: ArrayTypeTree => Some(arr.getType().toString())
+      case _ => None
+    }
+
   private def referenceNeedsBrackets(path: TreePath): Boolean = {
     val node = path.getLeaf()
     Option(path.getParentPath()).map(_.getLeaf()) match {
-      // A left-associative operand keeps its meaning without brackets.
-      case Some(binary: BinaryTree) => binary.getRightOperand() == node
+      case Some(binary: BinaryTree) =>
+        binary.getRightOperand() == node ||
+        (binary.getLeftOperand() == node && hasHigherPrecedenceThanAdditive(
+          binary.getKind()
+        ))
       case Some(select: MemberSelectTree) => select.getExpression() == node
       case Some(access: ArrayAccessTree) => access.getExpression() == node
       case Some(_: UnaryTree) => true
@@ -236,6 +266,11 @@ final class JavaInlineValueRefactoringProvider(
       case _ => false
     }
   }
+
+  private def hasHigherPrecedenceThanAdditive(kind: Tree.Kind): Boolean =
+    kind == Tree.Kind.MULTIPLY ||
+      kind == Tree.Kind.DIVIDE ||
+      kind == Tree.Kind.REMAINDER
 
   /** Collects every tree resolving to `target` (the declaration and usages). */
   private final class OccurrenceScanner(

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaInlineValueRefactoringProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaInlineValueRefactoringProvider.scala
@@ -1,0 +1,255 @@
+package scala.meta.internal.jpc
+
+import javax.lang.model.element.Element
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.Modifier
+
+import scala.collection.mutable.ListBuffer
+
+import scala.meta.internal.pc.Definition
+import scala.meta.internal.pc.InlineValueProvider
+import scala.meta.internal.pc.InlineValueProvider.Errors
+import scala.meta.internal.pc.RangeOffset
+import scala.meta.internal.pc.Reference
+import scala.meta.pc.OffsetParams
+
+import com.sun.source.tree.ArrayAccessTree
+import com.sun.source.tree.AssignmentTree
+import com.sun.source.tree.BinaryTree
+import com.sun.source.tree.CompilationUnitTree
+import com.sun.source.tree.CompoundAssignmentTree
+import com.sun.source.tree.ConditionalExpressionTree
+import com.sun.source.tree.IdentifierTree
+import com.sun.source.tree.InstanceOfTree
+import com.sun.source.tree.LambdaExpressionTree
+import com.sun.source.tree.MemberSelectTree
+import com.sun.source.tree.Tree
+import com.sun.source.tree.TypeCastTree
+import com.sun.source.tree.UnaryTree
+import com.sun.source.tree.VariableTree
+import com.sun.source.util.TreePath
+import com.sun.source.util.TreePathScanner
+import com.sun.source.util.Trees
+import org.eclipse.{lsp4j => l}
+
+/**
+ * Computes "inline value" refactoring edits for Java, backed by the Java
+ * presentation compiler (the javac AST).
+ *
+ * Reference resolution is precise because javac resolves every identifier to
+ * its [[Element]], so shadowing is handled for free. Inlining is restricted to
+ * the scope of a single file:
+ *   - local variables are inlined everywhere they are used and the declaration
+ *     is removed,
+ *   - `private` fields are treated the same way, since they can only be
+ *     referenced from within the same file,
+ *   - any other (potentially project-wide) field can only have the single
+ *     reference under the cursor inlined, keeping the declaration in place.
+ *
+ * The actual text edit generation (bracket wrapping and removal of the
+ * declaration) is delegated to the shared [[InlineValueProvider]].
+ */
+final class JavaInlineValueRefactoringProvider(
+    compiler: JavaMetalsCompiler,
+    params: OffsetParams
+) extends InlineValueProvider {
+
+  private val sourceText: String = params.text()
+
+  override val text: Array[Char] = sourceText.toCharArray
+
+  override val position: l.Position =
+    compiler.offsetToPosition(params.offset(), sourceText)
+
+  override def defAndRefs(): Either[String, (Definition, List[Reference])] =
+    compiler.nodeAtPosition(params, forReferences = true) match {
+      case Some((compile, cursorPath)) =>
+        val trees = Trees.instance(compile.task)
+        val target = trees.getElement(cursorPath)
+        if (isInlinable(target))
+          computeEdits(trees, compile.cu, target, cursorPath)
+        else Left(Errors.didNotFindDefinition)
+      case None => Left(Errors.didNotFindDefinition)
+    }
+
+  private def computeEdits(
+      trees: Trees,
+      cu: CompilationUnitTree,
+      target: Element,
+      cursorPath: TreePath
+  ): Either[String, (Definition, List[Reference])] = {
+    val positions = trees.getSourcePositions()
+    def startOf(tree: Tree): Int = positions.getStartPosition(cu, tree).toInt
+    def endOf(tree: Tree): Int = positions.getEndPosition(cu, tree).toInt
+
+    val (definitions, references) =
+      occurrencesOf(target, trees, cu)
+        .partition(_.getLeaf().getKind() == Tree.Kind.VARIABLE)
+
+    // Inlining a value that is reassigned would leave a dangling assignment
+    // target and change behavior, so it is never offered.
+    if (references.exists(isWriteTarget)) Left(Errors.isReassigned)
+    else
+      definitions.headOption
+        .map(_.getLeaf().asInstanceOf[VariableTree])
+        .filter(_.getInitializer() != null) match {
+        case None => Left(Errors.didNotFindDefinition)
+        case Some(varTree) =>
+          val init = varTree.getInitializer()
+          val defStart = startOf(varTree)
+          val rhsStart = startOf(init)
+          val rhsEnd = endOf(init)
+          // javac does not always record an end position for the declaration
+          // itself, so the deletion range is derived from the (reliably
+          // positioned) initializer expression instead.
+          if (defStart < 0 || rhsStart < 0 || rhsEnd < rhsStart)
+            Left(Errors.didNotFindDefinition)
+          else {
+            val nameLength = target.getSimpleName().toString().length()
+
+            // A reference edit for a usage, or `None` for one we cannot safely
+            // rewrite (a qualified access such as `this.field`).
+            def reference(path: TreePath): Option[Reference] =
+              path.getLeaf() match {
+                case identifier: IdentifierTree if startOf(identifier) >= 0 =>
+                  val start = startOf(identifier)
+                  Some(
+                    Reference(
+                      toRange(start, start + nameLength),
+                      parentOffsets = None,
+                      referenceNeedsBrackets(path),
+                      requiresCurlyBraces = false
+                    )
+                  )
+                case _ => None
+              }
+
+            val onDefinition =
+              cursorPath.getLeaf().getKind() == Tree.Kind.VARIABLE
+            val canInlineAll = isLocal(target) || isPrivateField(target)
+
+            if (onDefinition && !canInlineAll) Left(Errors.notLocal)
+            else {
+              // The declaration can be removed when every usage is inlined: when
+              // the action is invoked on the declaration, or on the single usage
+              // of a value that is local to the file.
+              val removeDeclaration =
+                canInlineAll && (onDefinition || references.lengthCompare(
+                  1
+                ) == 0)
+              val edits =
+                (if (removeDeclaration) references else List(cursorPath))
+                  .map(reference)
+
+              if (edits.contains(None)) Left(Errors.didNotFindReference)
+              else {
+                val defEnd = endWithSemicolon(rhsEnd)
+                val definition = Definition(
+                  toRange(defStart, defEnd),
+                  sourceText.substring(rhsStart, rhsEnd),
+                  RangeOffset(defStart, defEnd),
+                  initializerNeedsBrackets(init),
+                  requiresCurlyBraces = false,
+                  shouldBeRemoved = removeDeclaration
+                )
+                Right((definition, edits.flatten))
+              }
+            }
+          }
+      }
+  }
+
+  private def occurrencesOf(
+      target: Element,
+      trees: Trees,
+      cu: CompilationUnitTree
+  ): List[TreePath] = {
+    val scanner = new OccurrenceScanner(target, trees)
+    scanner.scan(cu, null)
+    scanner.occurrences.toList
+  }
+
+  /** Whether `path` is the target of an assignment, `+=`, `++` or `--`. */
+  private def isWriteTarget(path: TreePath): Boolean = {
+    val node = path.getLeaf()
+    Option(path.getParentPath()).map(_.getLeaf()).exists {
+      case assign: AssignmentTree => assign.getVariable() == node
+      case compound: CompoundAssignmentTree => compound.getVariable() == node
+      case unary: UnaryTree =>
+        unary.getExpression() == node && isIncrementOrDecrement(unary.getKind())
+      case _ => false
+    }
+  }
+
+  private def isIncrementOrDecrement(kind: Tree.Kind): Boolean =
+    kind == Tree.Kind.POSTFIX_INCREMENT ||
+      kind == Tree.Kind.POSTFIX_DECREMENT ||
+      kind == Tree.Kind.PREFIX_INCREMENT ||
+      kind == Tree.Kind.PREFIX_DECREMENT
+
+  /** Extend the declaration range to include the terminating `;`. */
+  private def endWithSemicolon(end: Int): Int = {
+    var index = end
+    while (index < sourceText.length && sourceText.charAt(index).isWhitespace)
+      index += 1
+    if (index < sourceText.length && sourceText.charAt(index) == ';') index + 1
+    else end
+  }
+
+  private def toRange(start: Int, end: Int): l.Range =
+    new l.Range(
+      compiler.offsetToPosition(start, sourceText),
+      compiler.offsetToPosition(end, sourceText)
+    )
+
+  private def isInlinable(element: Element): Boolean =
+    element != null && {
+      element.getKind() == ElementKind.LOCAL_VARIABLE ||
+      element.getKind() == ElementKind.FIELD
+    }
+
+  private def isLocal(element: Element): Boolean =
+    element.getKind() == ElementKind.LOCAL_VARIABLE
+
+  private def isPrivateField(element: Element): Boolean =
+    element.getKind() == ElementKind.FIELD &&
+      element.getModifiers().contains(Modifier.PRIVATE)
+
+  private def initializerNeedsBrackets(init: Tree): Boolean =
+    init match {
+      case _: BinaryTree | _: ConditionalExpressionTree | _: AssignmentTree |
+          _: CompoundAssignmentTree | _: InstanceOfTree |
+          _: LambdaExpressionTree | _: TypeCastTree =>
+        true
+      case _ => false
+    }
+
+  private def referenceNeedsBrackets(path: TreePath): Boolean = {
+    val node = path.getLeaf()
+    Option(path.getParentPath()).map(_.getLeaf()) match {
+      // A left-associative operand keeps its meaning without brackets.
+      case Some(binary: BinaryTree) => binary.getRightOperand() == node
+      case Some(select: MemberSelectTree) => select.getExpression() == node
+      case Some(access: ArrayAccessTree) => access.getExpression() == node
+      case Some(_: UnaryTree) => true
+      case Some(_: TypeCastTree) => true
+      case _ => false
+    }
+  }
+
+  /** Collects every tree resolving to `target` (the declaration and usages). */
+  private final class OccurrenceScanner(
+      target: Element,
+      trees: Trees
+  ) extends TreePathScanner[Void, Void] {
+    val occurrences: ListBuffer[TreePath] = ListBuffer.empty
+
+    override def scan(tree: Tree, p: Void): Void = {
+      if (tree != null) {
+        val path = new TreePath(getCurrentPath(), tree)
+        if (target.equals(trees.getElement(path))) occurrences += path
+      }
+      super.scan(tree, p)
+    }
+  }
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPresentationCompiler.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPresentationCompiler.scala
@@ -35,6 +35,7 @@ import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.AutoImportsResult
 import scala.meta.pc.CodeActionId
 import scala.meta.pc.DefinitionResult
+import scala.meta.pc.DisplayableException
 import scala.meta.pc.EmbeddedClient
 import scala.meta.pc.HoverSignature
 import scala.meta.pc.InlayHintsParams
@@ -291,8 +292,33 @@ case class JavaPresentationCompiler(
     }
   }
 
+  override def codeAction[T](
+      params: OffsetParams,
+      codeActionId: String,
+      codeActionPayload: Optional[T]
+  ): CompletableFuture[util.List[TextEdit]] =
+    codeActionId match {
+      case CodeActionId.InlineValue =>
+        val default: Either[String, util.List[TextEdit]] =
+          Right(util.Collections.emptyList[TextEdit]())
+        request(params, default) { pc =>
+          new JavaInlineValueRefactoringProvider(pc, params)
+            .getInlineTextEdits() match {
+            case Right(edits) => Right(edits.asJava)
+            case Left(error) => Left(error)
+          }
+        }.thenApply {
+          case Right(edits) => edits
+          case Left(error) => throw new DisplayableException(error)
+        }
+      case _ =>
+        CompletableFuture.completedFuture(
+          util.Collections.emptyList[TextEdit]()
+        )
+    }
+
   override def supportedCodeActions(): util.List[String] = {
-    List(CodeActionId.ExtractMethod).asJava
+    util.Collections.singletonList(CodeActionId.InlineValue)
   }
 
   override def didClose(uri: URI): Unit = ()

--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/InlineValueProvider.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/InlineValueProvider.scala
@@ -83,6 +83,8 @@ object InlineValueProvider {
       "Non-local value cannot be inlined."
     val didNotFindReference =
       "The chosen reference couldn't be identified."
+    val isReassigned =
+      "A value that is reassigned cannot be inlined."
     def variablesAreShadowed(fullName: String): String =
       s"Following variables are shadowed: $fullName."
   }

--- a/tests/unit/src/test/scala/tests/codeactions/GenerateGettersSettersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/GenerateGettersSettersLspSuite.scala
@@ -1,6 +1,7 @@
 package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.GenerateGettersSetters
+import scala.meta.internal.metals.codeactions.InlineValueCodeAction
 
 import tests.MbtTestInitializer
 
@@ -379,7 +380,8 @@ class GenerateGettersSettersLspSuite
        |  private final String <<name>> = "";
        |}
        |""".stripMargin,
-    s"""|${GenerateGettersSetters.titleGetter("name")}
+    s"""|${InlineValueCodeAction.genericTitle}
+        |${GenerateGettersSetters.titleGetter("name")}
         |""".stripMargin,
     """|package a;
        |
@@ -391,7 +393,7 @@ class GenerateGettersSettersLspSuite
        |  }
        |}
        |""".stripMargin,
-    selectedActionIndex = 0,
+    selectedActionIndex = 1,
     fileName = "Example.java",
   )
 

--- a/tests/unit/src/test/scala/tests/j/JavaInlineValueCodeActionSuite.scala
+++ b/tests/unit/src/test/scala/tests/j/JavaInlineValueCodeActionSuite.scala
@@ -1,0 +1,205 @@
+package tests.j
+
+import scala.meta.internal.metals.codeactions.InlineValueCodeAction
+
+import munit.Location
+import munit.TestOptions
+import org.eclipse.{lsp4j => l}
+
+/**
+ * End-to-end tests for the "inline value" refactoring code action on Java
+ * sources, which is backed by the Java presentation compiler.
+ */
+class JavaInlineValueCodeActionSuite
+    extends BaseJavaPCSuite("java-inline-value-code-action") {
+
+  check(
+    "local-variable",
+    """|public class Example {
+       |  int run() {
+       |    int x = 1 + 2;
+       |    return <<x>> + 3;
+       |  }
+       |}
+       |""".stripMargin,
+    InlineValueCodeAction.genericTitle,
+    """|public class Example {
+       |  int run() {
+       |    return 1 + 2 + 3;
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "local-variable-needs-brackets",
+    """|public class Example {
+       |  int run() {
+       |    int x = 1 + 2;
+       |    return 3 - <<x>>;
+       |  }
+       |}
+       |""".stripMargin,
+    InlineValueCodeAction.genericTitle,
+    """|public class Example {
+       |  int run() {
+       |    return 3 - (1 + 2);
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "private-field-inline-all",
+    """|public class Example {
+       |  private int <<value>> = 42;
+       |  int a() { return value; }
+       |  int b() { return value + 1; }
+       |}
+       |""".stripMargin,
+    InlineValueCodeAction.genericTitle,
+    """|public class Example {
+       |  int a() { return 42; }
+       |  int b() { return 42 + 1; }
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "local-in-static-initializer",
+    """|public class Example {
+       |  static int VALUE;
+       |  static {
+       |    int <<size>> = 1 + 2;
+       |    VALUE = size;
+       |  }
+       |}
+       |""".stripMargin,
+    InlineValueCodeAction.genericTitle,
+    """|public class Example {
+       |  static int VALUE;
+       |  static {
+       |    VALUE = 1 + 2;
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "private-final-field",
+    """|public class Example {
+       |  private final int <<MAX>> = 10;
+       |  int a() { return MAX; }
+       |  int b() { return MAX + 1; }
+       |}
+       |""".stripMargin,
+    InlineValueCodeAction.genericTitle,
+    """|public class Example {
+       |  int a() { return 10; }
+       |  int b() { return 10 + 1; }
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "multiple-uses-keeps-definition",
+    """|public class Example {
+       |  int a() {
+       |    int x = 5;
+       |    int y = <<x>> + 1;
+       |    int z = x + 2;
+       |    return y + z;
+       |  }
+       |}
+       |""".stripMargin,
+    InlineValueCodeAction.genericTitle,
+    """|public class Example {
+       |  int a() {
+       |    int x = 5;
+       |    int y = 5 + 1;
+       |    int z = x + 2;
+       |    return y + z;
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  checkNoAction(
+    "reassigned-field",
+    """|public class Example {
+       |  private static long <<preAllocSize>> = 65536 * 1024;
+       |  void grow() { preAllocSize = preAllocSize * 2; }
+       |  long get() { return preAllocSize; }
+       |}
+       |""".stripMargin,
+  )
+
+  checkNoAction(
+    "reassigned-local-variable",
+    """|public class Example {
+       |  int run() {
+       |    int x = 1;
+       |    x = 2;
+       |    return <<x>>;
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  def check(
+      name: TestOptions,
+      input: String,
+      expectedAction: String,
+      expectedCode: String,
+  )(implicit loc: Location): Unit =
+    testLSP(name) {
+      cleanWorkspace()
+      val path = "a/src/main/java/a/Example.java"
+      val fileContent = input.replace("<<", "").replace(">>", "")
+      val layout =
+        s"""|/metals.json
+            |{"a": {}}
+            |/$path
+            |$fileContent""".stripMargin
+      for {
+        _ <- initialize(layout)
+        _ <- server.didOpen(path)
+        codeActions <- server.assertCodeAction(
+          path,
+          input,
+          expectedAction,
+          List(l.CodeActionKind.RefactorInline),
+        )
+        _ <- client.applyCodeAction(0, codeActions, server)
+        _ <- server.didChange(path)(_ => server.bufferContents(path))
+        _ <- server.didSave(path)
+        _ = assertNoDiff(server.bufferContents(path), expectedCode)
+      } yield ()
+    }
+
+  /** Asserts that no inline-value action is offered at the marked position. */
+  def checkNoAction(
+      name: TestOptions,
+      input: String,
+  )(implicit loc: Location): Unit =
+    testLSP(name) {
+      cleanWorkspace()
+      val path = "a/src/main/java/a/Example.java"
+      val fileContent = input.replace("<<", "").replace(">>", "")
+      val layout =
+        s"""|/metals.json
+            |{"a": {}}
+            |/$path
+            |$fileContent""".stripMargin
+      for {
+        _ <- initialize(layout)
+        _ <- server.didOpen(path)
+        _ <- server.assertCodeAction(
+          path,
+          input,
+          "",
+          List(l.CodeActionKind.RefactorInline),
+        )
+      } yield ()
+    }
+}

--- a/tests/unit/src/test/scala/tests/j/JavaInlineValueCodeActionSuite.scala
+++ b/tests/unit/src/test/scala/tests/j/JavaInlineValueCodeActionSuite.scala
@@ -146,6 +146,60 @@ class JavaInlineValueCodeActionSuite
        |""".stripMargin,
   )
 
+  check(
+    "single-use-keeps-definition",
+    """|public class Example {
+       |  int x = 1;
+       |  int run() {
+       |    return <<x>>;
+       |  }
+       |}""".stripMargin,
+    InlineValueCodeAction.genericTitle,
+    """|public class Example {
+       |  int x = 1;
+       |  int run() {
+       |    return 1;
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "binary-precedence-needs-brackets",
+    """|public class Example {
+       |  int run() {
+       |    int x = 1 + 2;
+       |    return <<x>> * 3;
+       |  }
+       |}
+       |""".stripMargin,
+    InlineValueCodeAction.genericTitle,
+    """|public class Example {
+       |  int run() {
+       |    return (1 + 2) * 3;
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "array-initializer",
+    """|public class Example {
+       |  int run() {
+       |    int[] arr = {1, 2, 3};
+       |    return <<arr>>.length;
+       |  }
+       |}
+       |""".stripMargin,
+    InlineValueCodeAction.genericTitle,
+    """|public class Example {
+       |  int run() {
+       |    return new int[]{1, 2, 3}.length;
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
   def check(
       name: TestOptions,
       input: String,
@@ -192,4 +246,33 @@ class JavaInlineValueCodeActionSuite
       InlineValueCodeAction.genericTitle,
       input.replace("<<", "").replace(">>", ""),
     )
+
+  /**
+   * The cheap check correctly determines that no inline action should be offered
+   * (e.g. a non-private field reference).
+   */
+  def checkNoAction(
+      name: TestOptions,
+      input: String,
+  )(implicit loc: Location): Unit =
+    testLSP(name) {
+      cleanWorkspace()
+      val path = "a/src/main/java/a/Example.java"
+      val fileContent = input.replace("<<", "").replace(">>", "")
+      val layout =
+        s"""|/metals.json
+            |{"a": {}}
+            |/$path
+            |$fileContent""".stripMargin
+      for {
+        _ <- initialize(layout)
+        _ <- server.didOpen(path)
+        _ <- server.assertCodeAction(
+          path,
+          input,
+          "",
+          List(l.CodeActionKind.RefactorInline),
+        )
+      } yield ()
+    }
 }

--- a/tests/unit/src/test/scala/tests/j/JavaInlineValueCodeActionSuite.scala
+++ b/tests/unit/src/test/scala/tests/j/JavaInlineValueCodeActionSuite.scala
@@ -124,7 +124,7 @@ class JavaInlineValueCodeActionSuite
        |""".stripMargin,
   )
 
-  checkNoAction(
+  checkNotInlined(
     "reassigned-field",
     """|public class Example {
        |  private static long <<preAllocSize>> = 65536 * 1024;
@@ -134,7 +134,7 @@ class JavaInlineValueCodeActionSuite
        |""".stripMargin,
   )
 
-  checkNoAction(
+  checkNotInlined(
     "reassigned-local-variable",
     """|public class Example {
        |  int run() {
@@ -177,29 +177,19 @@ class JavaInlineValueCodeActionSuite
       } yield ()
     }
 
-  /** Asserts that no inline-value action is offered at the marked position. */
-  def checkNoAction(
+  /**
+   * The cheap check offers the action, but invoking it inlines nothing because
+   * the presentation compiler rejects it (e.g. a reassigned value), leaving the
+   * source unchanged.
+   */
+  def checkNotInlined(
       name: TestOptions,
       input: String,
   )(implicit loc: Location): Unit =
-    testLSP(name) {
-      cleanWorkspace()
-      val path = "a/src/main/java/a/Example.java"
-      val fileContent = input.replace("<<", "").replace(">>", "")
-      val layout =
-        s"""|/metals.json
-            |{"a": {}}
-            |/$path
-            |$fileContent""".stripMargin
-      for {
-        _ <- initialize(layout)
-        _ <- server.didOpen(path)
-        _ <- server.assertCodeAction(
-          path,
-          input,
-          "",
-          List(l.CodeActionKind.RefactorInline),
-        )
-      } yield ()
-    }
+    check(
+      name,
+      input,
+      InlineValueCodeAction.genericTitle,
+      input.replace("<<", "").replace(">>", ""),
+    )
 }

--- a/tests/unit/src/test/scala/tests/j/JavaPCCodeActionSuite.scala
+++ b/tests/unit/src/test/scala/tests/j/JavaPCCodeActionSuite.scala
@@ -1,6 +1,7 @@
 package tests.j
 
 import scala.meta.internal.metals.codeactions.ImportMissingSymbol
+import scala.meta.internal.metals.codeactions.InlineValueCodeAction
 
 class JavaPCCodeActionSuite extends BaseJavaPCSuite("java-pc-code-action") {
 
@@ -91,7 +92,7 @@ class JavaPCCodeActionSuite extends BaseJavaPCSuite("java-pc-code-action") {
             |}
             |""".stripMargin,
         "", // No suggestions for non-exact matches
-        Nil,
+        InlineValueCodeAction.genericTitle :: Nil,
       )
     } yield ()
   }


### PR DESCRIPTION
Implements the "inline value" refactoring (issue #8501) so it works without a workspace-wide SemanticDB, scoped to a single file.

Scala: a new SyntacticInlineValueProvider computes the edits purely from the Scalameta tree, supporting val, var (when not reassigned) and file-private declarations. Local and file-private definitions are inlined everywhere and removed; other members only inline the usage under the cursor. Bracket/curly-brace handling and shadowing are respected.

Java: backed by the Java presentation compiler. JavaInlineValueRefactoringProvider walks the javac AST and resolves references by Element identity, reusing the shared InlineValueProvider for edit generation. Wired through JavaPresentationCompiler.codeAction(InlineValue).

InlineValueCodeAction now serves both languages, routing Java through the presentation compiler and Scala through the syntactic provider.