### PR TITLE
Add missing return code action for Java

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/AddMissingReturnStatement.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/AddMissingReturnStatement.scala
@@ -1,0 +1,106 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.parsing.JavaMethod
+import scala.meta.internal.parsing.JavaTrees
+import scala.meta.pc.CancelToken
+
+import org.eclipse.{lsp4j => l}
+
+class AddMissingReturnStatement(
+    javaTrees: JavaTrees,
+    buffers: Buffers,
+) extends CodeAction {
+  import AddMissingReturnStatement._
+
+  override def kind: String = l.CodeActionKind.QuickFix
+  override def isScala: Boolean = false
+  override def isJava: Boolean = true
+
+  override def contribute(
+      params: l.CodeActionParams,
+      token: CancelToken,
+  )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = Future {
+    val path = params.getTextDocument().getUri().toAbsolutePath
+    val range = params.getRange()
+    val position = range.getStart()
+    val diagnostics = params.getContext().getDiagnostics().asScala.toList
+
+    val actions = for {
+      text <- buffers.get(path).toSeq
+      method <- javaTrees.findEnclosingJavaMethod(path, position).toSeq
+      if hasMissingReturnDiagnostic(diagnostics, method)
+    } yield {
+      val edit = returnEdit(text, method)
+      CodeActionBuilder.build(
+        title,
+        kind,
+        changes = Seq(path -> Seq(edit)),
+        diagnostics = diagnostics.filter(diagnostic =>
+          isMissingReturnDiagnostic(diagnostic, method)
+        ),
+      )
+    }
+
+    actions
+  }
+
+  private def returnEdit(
+      text: String,
+      method: JavaMethod,
+  ): l.TextEdit = {
+    val insert = JavaTrees.insertPointAtBodyEnd(method.bodyRange, text)
+    val rendered =
+      JavaMemberInsertion.render(
+        text,
+        insert,
+        Seq(returnStatement(method.returnType)),
+      )
+
+    new l.TextEdit(
+      insert.range,
+      rendered,
+    )
+  }
+
+  private def isMissingReturnDiagnostic(
+      diagnostic: l.Diagnostic,
+      method: JavaMethod,
+  ): Boolean =
+    hasMissingReturnMessage(diagnostic) &&
+      (diagnostic.getRange().overlapsWith(method.range.range) ||
+        diagnostic.getRange().getStart() == method.range.range.getEnd())
+
+  private def hasMissingReturnDiagnostic(
+      diagnostics: List[l.Diagnostic],
+      method: JavaMethod,
+  ): Boolean =
+    diagnostics.exists(isMissingReturnDiagnostic(_, method))
+}
+
+object AddMissingReturnStatement {
+  def title: String = "Add missing return statement"
+
+  private def hasMissingReturnMessage(diagnostic: l.Diagnostic): Boolean =
+    Option(diagnostic.getMessage())
+      .map(_.toString().toLowerCase())
+      .exists(_.contains("missing return"))
+
+  private def returnStatement(returnType: String): String =
+    s"return ${defaultReturnValue(returnType)};"
+
+  private def defaultReturnValue(returnType: String): String =
+    returnType match {
+      case "boolean" => "false"
+      case "byte" | "short" | "int" => "0"
+      case "long" => "0L"
+      case "float" => "0.0f"
+      case "double" => "0.0"
+      case "char" => "'\\u0000'"
+      case _ => "null"
+    }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -64,6 +64,7 @@ final class CodeActionProvider(
     new GenerateConstructors(javaTrees, buffers),
     new GenerateGettersSetters(javaTrees, buffers),
     new GenerateEqualsHashCodeToString(javaTrees, buffers),
+    new AddMissingReturnStatement(javaTrees, buffers),
   )
 
   def actionsForParams(params: l.CodeActionParams): List[CodeAction] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaMemberInsertion.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaMemberInsertion.scala
@@ -3,8 +3,13 @@ package scala.meta.internal.metals.codeactions
 import scala.meta.internal.parsing.InsertPoint
 
 /**
- * Renders the text of a generated Java member at a given [[InsertPoint]],
+ * Renders the text of generated Java members at a given [[InsertPoint]],
  * taking care of the surrounding blank lines and the member indentation.
+ *
+ * The bulk of the logic lives in [[Surroundings]], which inspects the few
+ * characters around the insertion point and derives, once, everything the
+ * renderer needs: the indentation to apply to each member line and the blank
+ * lines to add before and after the generated code.
  */
 object JavaMemberInsertion {
 
@@ -29,61 +34,87 @@ object JavaMemberInsertion {
       insert: InsertPoint,
       members: Seq[Seq[String]],
   ): String = {
-    val startOffset = insert.startOffset
-    val endOffset = insert.endOffset
-    val afterOpeningBrace =
-      startOffset > 0 && text.charAt(startOffset - 1) == '{'
-    val beforeClosingBrace =
-      endOffset >= 0 && endOffset < text.length && text.charAt(endOffset) == '}'
-    val endIndent = indentAt(text, endOffset)
-    val memberIndent = {
-      val startLineIndent = lineIndent(text, startOffset)
-      if (beforeClosingBrace || (afterOpeningBrace && insert.isInsertion))
-        endIndent + indentUnit(text)
-      else if (startLineIndent.nonEmpty) startLineIndent
-      else if (endIndent.nonEmpty) endIndent
-      else indentUnit(text)
-    }
-    val startsLine = linePrefix(text, startOffset).isEmpty
-    val prefix =
-      if (beforeClosingBrace && startsLine) ""
-      else if (afterOpeningBrace || beforeClosingBrace) "\n"
-      else "\n\n"
-    val suffix =
-      if (beforeClosingBrace) s"\n$endIndent"
-      else if (insert.isInsertion) ""
-      else s"\n\n$endIndent"
+    val around = new Surroundings(text, insert)
     val body = members
-      .map(memberLines =>
-        memberLines.map(line => memberIndent + line).mkString("\n")
-      )
+      .map(member => member.map(around.memberIndent + _).mkString("\n"))
       .mkString("\n\n")
-    s"$prefix$body$suffix"
+    s"${around.prefix}$body${around.suffix}"
   }
 
   /** The indentation unit (tab or spaces) used in the file. */
-  def indentUnit(text: String): String = {
-    val firstIndent = text.linesIterator
+  def indentUnit(text: String): String =
+    text.linesIterator
       .map(_.takeWhile(c => c == ' ' || c == '\t'))
-      .find(_.nonEmpty)
-    firstIndent match {
+      .find(_.nonEmpty) match {
       case Some(ws) if ws.startsWith("\t") => "\t"
       case _ => "  "
     }
-  }
 
-  private def indentAt(text: String, offset: Int): String = {
-    val clamped = offset.min(text.length).max(0)
-    val candidate = linePrefix(text, clamped)
-    if (candidate.forall(_.isWhitespace)) candidate
-    else lineIndent(text, offset)
-  }
-
+  /** Leading whitespace of the line containing `offset`. */
   def lineIndent(text: String, offset: Int): String = {
     val lineStart = text.lastIndexOf('\n', offset - 1) + 1
     text.substring(lineStart).takeWhile(c => c != '\n' && c.isWhitespace)
   }
 
+  /** Text between the start of the line containing `offset` and `offset`. */
   private def linePrefix(text: String, offset: Int): String =
     text.substring(text.lastIndexOf('\n', offset - 1) + 1, offset)
+
+  /**
+   * Indentation at `offset`: the prefix on its line when that prefix is all
+   * whitespace (e.g. just before a `}` on its own line), otherwise the
+   * leading indentation of the line.
+   */
+  private def indentAt(text: String, offset: Int): String = {
+    val candidate = linePrefix(text, offset.min(text.length).max(0))
+    if (candidate.forall(_.isWhitespace)) candidate
+    else lineIndent(text, offset)
+  }
+
+  /**
+   * The handful of facts about the characters around the insertion point that
+   * drive how the member is rendered.
+   */
+  private final class Surroundings(text: String, insert: InsertPoint) {
+    private val startOffset = insert.startOffset
+    private val endOffset = insert.endOffset
+
+    /** Inserting right after an opening `{`. */
+    private val afterOpeningBrace =
+      startOffset > 0 && text.charAt(startOffset - 1) == '{'
+
+    /** Inserting right before a closing `}`. */
+    private val beforeClosingBrace =
+      endOffset >= 0 && endOffset < text.length && text.charAt(endOffset) == '}'
+
+    /** Nothing but the start offset itself begins its line. */
+    private val startsLine = linePrefix(text, startOffset).isEmpty
+
+    /** Indentation of the closing brace / end-of-insertion line. */
+    private val endIndent = indentAt(text, endOffset)
+
+    /** Indentation prepended to every generated member line. */
+    val memberIndent: String = {
+      val startLineIndent = lineIndent(text, startOffset)
+      // One level deeper than the enclosing braces when we sit between them.
+      if (beforeClosingBrace || (afterOpeningBrace && insert.isInsertion))
+        endIndent + indentUnit(text)
+      // Otherwise align with whichever neighbouring line we can see.
+      else if (startLineIndent.nonEmpty) startLineIndent
+      else if (endIndent.nonEmpty) endIndent
+      else indentUnit(text)
+    }
+
+    /** Blank lines emitted before the first member. */
+    val prefix: String =
+      if (beforeClosingBrace && startsLine) ""
+      else if (afterOpeningBrace || beforeClosingBrace) "\n"
+      else "\n\n"
+
+    /** Blank lines (and trailing indentation) emitted after the last member. */
+    val suffix: String =
+      if (beforeClosingBrace) s"\n$endIndent"
+      else if (insert.isInsertion) ""
+      else s"\n\n$endIndent"
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaMemberInsertion.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaMemberInsertion.scala
@@ -31,20 +31,26 @@ object JavaMemberInsertion {
   ): String = {
     val startOffset = insert.startOffset
     val endOffset = insert.endOffset
+    val afterOpeningBrace =
+      startOffset > 0 && text.charAt(startOffset - 1) == '{'
+    val beforeClosingBrace =
+      endOffset >= 0 && endOffset < text.length && text.charAt(endOffset) == '}'
     val endIndent = indentAt(text, endOffset)
     val memberIndent = {
       val startLineIndent = lineIndent(text, startOffset)
-      if (startLineIndent.nonEmpty) startLineIndent
+      if (beforeClosingBrace || (afterOpeningBrace && insert.isInsertion))
+        endIndent + indentUnit(text)
+      else if (startLineIndent.nonEmpty) startLineIndent
       else if (endIndent.nonEmpty) endIndent
       else indentUnit(text)
     }
+    val startsLine = linePrefix(text, startOffset).isEmpty
     val prefix =
-      if (startOffset > 0 && text.charAt(startOffset - 1) == '{') "\n"
+      if (beforeClosingBrace && startsLine) ""
+      else if (afterOpeningBrace || beforeClosingBrace) "\n"
       else "\n\n"
-    val atClosingBrace =
-      endOffset >= 0 && endOffset < text.length && text.charAt(endOffset) == '}'
     val suffix =
-      if (atClosingBrace) s"\n$endIndent"
+      if (beforeClosingBrace) s"\n$endIndent"
       else if (insert.isInsertion) ""
       else s"\n\n$endIndent"
     val body = members
@@ -68,13 +74,16 @@ object JavaMemberInsertion {
 
   private def indentAt(text: String, offset: Int): String = {
     val clamped = offset.min(text.length).max(0)
-    val lineStart = text.lastIndexOf('\n', clamped - 1) + 1
-    val candidate = text.substring(lineStart, clamped)
-    if (candidate.forall(_.isWhitespace)) candidate else ""
+    val candidate = linePrefix(text, clamped)
+    if (candidate.forall(_.isWhitespace)) candidate
+    else lineIndent(text, offset)
   }
 
-  private def lineIndent(text: String, offset: Int): String = {
+  def lineIndent(text: String, offset: Int): String = {
     val lineStart = text.lastIndexOf('\n', offset - 1) + 1
     text.substring(lineStart).takeWhile(c => c != '\n' && c.isWhitespace)
   }
+
+  private def linePrefix(text: String, offset: Int): String =
+    text.substring(text.lastIndexOf('\n', offset - 1) + 1, offset)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaMemberInsertion.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaMemberInsertion.scala
@@ -41,13 +41,18 @@ object JavaMemberInsertion {
     s"${around.prefix}$body${around.suffix}"
   }
 
-  /** The indentation unit (tab or spaces) used in the file. */
+  /**
+   * The indentation unit used in the file: a single tab for tab-indented
+   * files, otherwise the leading space width inferred from the first indented
+   * line (falling back to two spaces when nothing is indented).
+   */
   def indentUnit(text: String): String =
     text.linesIterator
       .map(_.takeWhile(c => c == ' ' || c == '\t'))
       .find(_.nonEmpty) match {
       case Some(ws) if ws.startsWith("\t") => "\t"
-      case _ => "  "
+      case Some(ws) => ws
+      case None => "  "
     }
 
   /** Leading whitespace of the line containing `offset`. */

--- a/metals/src/main/scala/scala/meta/internal/parsing/JavaTrees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/JavaTrees.scala
@@ -270,12 +270,17 @@ class JavaTrees(buffers: Buffers) {
           )
         methodNameRange(pos, lineMap, text, node, displayName).foreach {
           nameRange =>
+            val body =
+              bodyRange(lineMap, text, nameRange.endOffset, nodeEnd).getOrElse(
+                fullRange
+              )
             _result = Some(
               JavaMethod(
                 tree = node,
                 name = displayName,
                 range = fullRange,
                 nameRange = nameRange,
+                bodyRange = body,
                 returnType =
                   if (isConstructor) "" else methodReturnType(node),
                 parameters = javaParameters(node, fullRange),
@@ -333,7 +338,7 @@ class JavaTrees(buffers: Buffers) {
                 nodeEnd,
                 name,
               )
-              body <- bodyRange(nameRange.endOffset, nodeEnd)
+              body <- bodyRange(lineMap, text, nameRange.endOffset, nodeEnd)
             } {
               val members =
                 node
@@ -345,18 +350,28 @@ class JavaTrees(buffers: Buffers) {
                       val isConstructor = methodName == "<init>"
                       val displayName = if (isConstructor) name else methodName
                       treeRange(method).map { range =>
-                        JavaMethod(
-                          tree = method,
-                          name = displayName,
-                          range = range,
-                          nameRange = methodNameRange(
+                        val nameRange =
+                          methodNameRange(
                             pos,
                             lineMap,
                             text,
                             method,
                             displayName,
+                          ).getOrElse(range)
+                        val body =
+                          bodyRange(
+                            lineMap,
+                            text,
+                            nameRange.endOffset,
+                            range.endOffset,
                           )
-                            .getOrElse(range),
+                            .getOrElse(range)
+                        JavaMethod(
+                          tree = method,
+                          name = displayName,
+                          range = range,
+                          nameRange = nameRange,
+                          bodyRange = body,
                           returnType =
                             if (isConstructor) "" else methodReturnType(method),
                           parameters = javaParameters(method, range),
@@ -388,29 +403,6 @@ class JavaTrees(buffers: Buffers) {
           }
         }
         super.visitClass(node, p)
-      }
-    }
-
-    private def bodyRange(
-        startPos: Int,
-        endPos: Int,
-    ): Option[JavaRange] = {
-      if (startPos < 0 || endPos < 0) None
-      else {
-        var offset = startPos
-        val searchEnd = Math.min(endPos, text.length())
-        var openBrace: Option[Int] = None
-        while (offset < searchEnd && openBrace.isEmpty) {
-          if (text.charAt(offset) == '{') openBrace = Some(offset)
-          offset += 1
-        }
-        openBrace.map { brace =>
-          JavaRange(
-            Positions.toLspRange(lineMap, brace + 1, endPos - 1, text),
-            startOffset = brace + 1,
-            endOffset = endPos - 1,
-          )
-        }
       }
     }
   }
@@ -460,6 +452,31 @@ class JavaTrees(buffers: Buffers) {
       else if (node.getBody() != null) pos.startPos(node.getBody())
       else nodeEnd
     findNameRange(lineMap, text, nameStartPos, nameEndPos, name)
+  }
+
+  private def bodyRange(
+      lineMap: LineMap,
+      text: String,
+      startPos: Int,
+      endPos: Int,
+  ): Option[JavaRange] = {
+    if (startPos < 0 || endPos < 0) None
+    else {
+      var offset = startPos
+      val searchEnd = Math.min(endPos, text.length())
+      var openBrace: Option[Int] = None
+      while (offset < searchEnd && openBrace.isEmpty) {
+        if (text.charAt(offset) == '{') openBrace = Some(offset)
+        offset += 1
+      }
+      openBrace.map { brace =>
+        JavaRange(
+          Positions.toLspRange(lineMap, brace + 1, endPos - 1, text),
+          startOffset = brace + 1,
+          endOffset = endPos - 1,
+        )
+      }
+    }
   }
 
   private def findNameRange(
@@ -554,10 +571,56 @@ object JavaTrees {
     )
   }
 
+  def insertPointAtBodyEnd(
+      bodyRange: JavaRange,
+      text: String,
+  ): InsertPoint = {
+    val end = PositionWithOffset(bodyRange.getEnd(), bodyRange.endOffset)
+    val bodyText = text.substring(bodyRange.startOffset, bodyRange.endOffset)
+
+    if (bodyText.forall(_.isWhitespace)) {
+      InsertPoint(
+        bodyRange.range,
+        bodyRange.startOffset,
+        bodyRange.endOffset,
+        isInsertion = false,
+      )
+    } else {
+      val closeLinePrefix = linePrefix(text, bodyRange.endOffset)
+      val start =
+        if (closeLinePrefix.forall(_.isWhitespace))
+          PositionWithOffset(
+            new l.Position(end.position.getLine(), 0),
+            end.offset - closeLinePrefix.length,
+          )
+        else {
+          val trailingWhitespace =
+            closeLinePrefix.reverse.takeWhile(_.isWhitespace)
+          PositionWithOffset(
+            new l.Position(
+              end.position.getLine(),
+              end.position.getCharacter() - trailingWhitespace.length,
+            ),
+            end.offset - trailingWhitespace.length,
+          )
+        }
+
+      InsertPoint(
+        new l.Range(start.position, end.position),
+        start.offset,
+        end.offset,
+        isInsertion = start.offset == end.offset,
+      )
+    }
+  }
+
   private def isValidLspRange(start: l.Position, end: l.Position): Boolean =
     end.getLine() > start.getLine() ||
       (end.getLine() == start.getLine() && end.getCharacter() >= start
         .getCharacter())
+
+  private def linePrefix(text: String, offset: Int): String =
+    text.substring(text.lastIndexOf('\n', offset - 1) + 1, offset)
 
   private case class PositionWithOffset(position: l.Position, offset: Int)
 }
@@ -618,6 +681,7 @@ case class JavaMethod(
     name: String,
     range: JavaRange,
     nameRange: JavaRange,
+    bodyRange: JavaRange,
     returnType: String,
     parameters: List[JavaParameter] = Nil,
     isConstructor: Boolean = false,

--- a/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
@@ -24,12 +24,12 @@ import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
 import ch.epfl.scala.bsp4j.ScalaMainClass
 import tests.BaseDapSuite
 import tests.BazelBuildLayout
-import tests.BazelMbtTestInitializer
+import tests.MbtTestInitializer
 
 class BazelDapMbtLspSuite
     extends BaseDapSuite(
       "bazel-mbt-dap",
-      BazelMbtTestInitializer,
+      MbtTestInitializer,
       BazelBuildLayout,
     ) {
 

--- a/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
@@ -17,7 +17,7 @@ import scala.meta.io.AbsolutePath
 import tests.BaseLspSuite
 import tests.BaseMbtSuite
 import tests.BazelBuildLayout
-import tests.BazelMbtTestInitializer
+import tests.MbtTestInitializer
 import tests.TestHovers
 
 /**
@@ -25,7 +25,7 @@ import tests.TestHovers
  * → [[MbtBuildServer]] → Scala hover.
  */
 class BazelMbtLspSuite
-    extends BaseLspSuite("bazel-mbt", BazelMbtTestInitializer)
+    extends BaseLspSuite("bazel-mbt", MbtTestInitializer)
     with TestHovers
     with BaseMbtSuite {
 

--- a/tests/unit/src/main/scala/tests/BuildServerInitializer.scala
+++ b/tests/unit/src/main/scala/tests/BuildServerInitializer.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.metals.Messages.ImportBuild
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.mbt.MbtBuildServer
 import scala.meta.internal.metals.{BuildInfo => V}
 import scala.meta.io.AbsolutePath
 
@@ -234,9 +235,9 @@ object BazelServerInitializer extends BuildServerInitializer {
 
 /**
  * Initializes Metals without QuickBuild / Bloop install, then applies user
- * configuration and waits for the BSP session (e.g. MBT after Bazel import).
+ * configuration and waits for the MBT BSP session.
  */
-object BazelMbtTestInitializer extends BuildServerInitializer {
+object MbtTestInitializer extends BuildServerInitializer {
   this: BaseLspSuite =>
   override def initialize(
       workspace: AbsolutePath,
@@ -246,10 +247,12 @@ object BazelMbtTestInitializer extends BuildServerInitializer {
       userConfig: UserConfiguration,
       workspaceFolders: Option[List[String]] = None,
   )(implicit ec: ExecutionContext): Future[InitializeResult] = {
+    val mbtUserConfig =
+      userConfig.copy(preferredBuildServer = Some(MbtBuildServer.name))
     for {
       initializeResult <- server.initialize(workspaceFolders)
       _ <- server.initialized()
-      _ <- server.didChangeConfiguration(userConfig.toString)
+      _ <- server.didChangeConfiguration(mbtUserConfig.toString)
     } yield {
       if (!expectError) {
         server.assertBuildServerConnection()

--- a/tests/unit/src/test/scala/tests/codeactions/AddMissingReturnStatementLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/AddMissingReturnStatementLspSuite.scala
@@ -1,0 +1,502 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.codeactions.AddMissingReturnStatement
+
+import tests.MbtTestInitializer
+
+class AddMissingReturnStatementLspSuite
+    extends BaseCodeActionLspSuite(
+      "add-missing-return-statement",
+      MbtTestInitializer,
+      useMbtLayout = true,
+    ) {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(presentationCompilerDiagnostics = true)
+
+  override protected def toPath(
+      fileName: String,
+      isSource: Boolean = true,
+  ): String =
+    if (isSource) s"a/src/main/java/a/$fileName"
+    else s"a/$fileName"
+
+  private val onlyAddReturn: org.eclipse.lsp4j.CodeAction => Boolean =
+    _.getTitle() == AddMissingReturnStatement.title
+
+  check(
+    "int",
+    """|package a;
+       |
+       |public class Example {
+       |  public int <<answer>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public int answer() {
+       |    return 0;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "boolean",
+    """|package a;
+       |
+       |public class Example {
+       |  public boolean <<isReady>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public boolean isReady() {
+       |    return false;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "annotated-primitive",
+    """|package a;
+       |
+       |import java.lang.annotation.ElementType;
+       |import java.lang.annotation.Target;
+       |
+       |@Target(ElementType.TYPE_USE)
+       |@interface A {}
+       |
+       |public class Example {
+       |  public @A int <<answer>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |import java.lang.annotation.ElementType;
+       |import java.lang.annotation.Target;
+       |
+       |@Target(ElementType.TYPE_USE)
+       |@interface A {}
+       |
+       |public class Example {
+       |  public @A int answer() {
+       |    return 0;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "double",
+    """|package a;
+       |
+       |public class Example {
+       |  public double <<getScore>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public double getScore() {
+       |    return 0.0;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "long",
+    """|package a;
+       |
+       |public class Example {
+       |  public long <<getId>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public long getId() {
+       |    return 0L;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "float",
+    """|package a;
+       |
+       |public class Example {
+       |  public float <<getRatio>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public float getRatio() {
+       |    return 0.0f;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "reference",
+    """|package a;
+       |
+       |public class Example {
+       |  public String <<name>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public String name() {
+       |    return null;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "primitive-array",
+    """|package a;
+       |
+       |public class Example {
+       |  public int[] <<getNumbers>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public int[] getNumbers() {
+       |    return null;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "generic",
+    """|package a;
+       |
+       |import java.util.List;
+       |
+       |public class Example {
+       |  public List<String> <<names>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |import java.util.List;
+       |
+       |public class Example {
+       |  public List<String> names() {
+       |    return null;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "cursor-inside-empty-body",
+    """|package a;
+       |
+       |public class Example {
+       |  public int answer() {
+       |    <<>>
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public int answer() {
+       |    return 0;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "cursor-inside-non-empty-body",
+    """|package a;
+       |
+       |public class Example {
+       |  public int answer() {
+       |    int x = 1;<<>>
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public int answer() {
+       |    int x = 1;
+       |    return 0;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "comment-only-body",
+    """|package a;
+       |
+       |public class Example {
+       |  public int <<answer>>() {
+       |    // TODO
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public int answer() {
+       |    // TODO
+       |    return 0;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "same-line-comment-only-body",
+    """|package a;
+       |
+       |public class Example {
+       |  public int <<answer>>() { /* todo */ }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public int answer() { /* todo */
+       |    return 0;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "same-line",
+    """|package a;
+       |
+       |public class Example {
+       |  public int <<answer>>() {}
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public int answer() {
+       |    return 0;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  checkNoAction(
+    "if-else-returns",
+    """|package a;
+       |
+       |public class Example {
+       |  public int <<answer>>(boolean flag) {
+       |    if (flag) {
+       |      return 1;
+       |    } else {
+       |      return 2;
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "existing-return-in-lambda",
+    """|package a;
+       |
+       |public class Example {
+       |  public int <<answer>>() {
+       |    Runnable runnable = () -> {
+       |      return;
+       |    };
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public class Example {
+       |  public int answer() {
+       |    Runnable runnable = () -> {
+       |      return;
+       |    };
+       |    return 0;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  checkNoAction(
+    "abstract",
+    """|package a;
+       |
+       |public abstract class Example {
+       |  public abstract int <<calculate>>();
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  checkNoAction(
+    "interface",
+    """|package a;
+       |
+       |public interface Example {
+       |  int <<calculate>>();
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  check(
+    "interface-default-method",
+    """|package a;
+       |
+       |public interface Example {
+       |  default int <<calculate>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${AddMissingReturnStatement.title}
+        |""".stripMargin,
+    """|package a;
+       |
+       |public interface Example {
+       |  default int calculate() {
+       |    return 0;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  checkNoAction(
+    "void",
+    """|package a;
+       |
+       |public class Example {
+       |  public void <<run>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  checkNoAction(
+    "constructor",
+    """|package a;
+       |
+       |public class Example {
+       |  public <<Example>>() {
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+
+  checkNoAction(
+    "existing-return",
+    """|package a;
+       |
+       |public class Example {
+       |  public int <<answer>>() {
+       |    return 42;
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddReturn,
+  )
+}

--- a/tests/unit/src/test/scala/tests/codeactions/GenerateConstructorsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/GenerateConstructorsLspSuite.scala
@@ -2,12 +2,12 @@ package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.GenerateConstructors
 
-import tests.BazelMbtTestInitializer
+import tests.MbtTestInitializer
 
 class GenerateConstructorsLspSuite
     extends BaseCodeActionLspSuite(
       "generate-constructors",
-      BazelMbtTestInitializer,
+      MbtTestInitializer,
       useMbtLayout = true,
     ) {
 

--- a/tests/unit/src/test/scala/tests/codeactions/GenerateEqualsHashCodeToStringLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/GenerateEqualsHashCodeToStringLspSuite.scala
@@ -2,12 +2,12 @@ package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.GenerateEqualsHashCodeToString
 
-import tests.BazelMbtTestInitializer
+import tests.MbtTestInitializer
 
 class GenerateEqualsHashCodeToStringLspSuite
     extends BaseCodeActionLspSuite(
       "generate-equals-hashcode-tostring",
-      BazelMbtTestInitializer,
+      MbtTestInitializer,
       useMbtLayout = true,
     ) {
 

--- a/tests/unit/src/test/scala/tests/codeactions/GenerateGettersSettersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/GenerateGettersSettersLspSuite.scala
@@ -2,12 +2,12 @@ package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.GenerateGettersSetters
 
-import tests.BazelMbtTestInitializer
+import tests.MbtTestInitializer
 
 class GenerateGettersSettersLspSuite
     extends BaseCodeActionLspSuite(
       "generate-getters-setters",
-      BazelMbtTestInitializer,
+      MbtTestInitializer,
       useMbtLayout = true,
     ) {
 

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolJavaLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolJavaLspSuite.scala
@@ -4,12 +4,12 @@ import scala.meta.internal.metals.Configs.WorkspaceSymbolProviderConfig
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.codeactions.ImportMissingSymbol
 
-import tests.BazelMbtTestInitializer
+import tests.MbtTestInitializer
 
 class ImportMissingSymbolJavaLspSuite
     extends BaseCodeActionLspSuite(
       "import-missing-symbol-java",
-      BazelMbtTestInitializer,
+      MbtTestInitializer,
       useMbtLayout = true,
     ) {
 


### PR DESCRIPTION
Part of https://github.com/scalameta/metals/issues/8502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Java quick fix to insert a missing `return` statement with an appropriate default value.
* **Bug Fixes**
  * Improved how inserted Java members are placed and indented, especially near opening and closing braces.
  * Better handled return-related code actions in more Java method shapes, including default interface methods and empty bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->