### PR TITLE
Add missing override annotation diagnostic & quick-fix code action

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/AddMissingOverrideAnnotation.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/AddMissingOverrideAnnotation.scala
@@ -1,0 +1,81 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.jpc.MissingOverrideDiagnosticProvider
+import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.parsing.JavaMethod
+import scala.meta.internal.parsing.JavaTrees
+import scala.meta.io.AbsolutePath
+import scala.meta.pc.CancelToken
+
+import org.eclipse.{lsp4j => l}
+
+class AddMissingOverrideAnnotation(
+    javaTrees: JavaTrees,
+    buffers: Buffers,
+) extends CodeAction {
+  import AddMissingOverrideAnnotation._
+
+  override def kind: String = l.CodeActionKind.QuickFix
+  override def isScala: Boolean = false
+  override def isJava: Boolean = true
+
+  override def contribute(
+      params: l.CodeActionParams,
+      token: CancelToken,
+  )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = Future {
+    val path = params.getTextDocument().getUri().toAbsolutePath
+    val range = params.getRange()
+
+    for {
+      text <- buffers.get(path).orElse(path.readTextOpt).toSeq
+      diagnostic <- params.getContext().getDiagnostics().asScala.toSeq
+      if isMissingOverride(diagnostic)
+      if range.overlapsWith(diagnostic.getRange())
+      method <- javaTrees
+        .findEnclosingJavaMethod(path, diagnostic.getRange().getStart())
+        .toSeq
+      if !method.isConstructor
+    } yield build(path, diagnostic, method, text)
+  }
+
+  private def build(
+      path: AbsolutePath,
+      diagnostic: l.Diagnostic,
+      method: JavaMethod,
+      text: String,
+  ): l.CodeAction = {
+    val methodStart = method.range.getStart()
+    val position = new l.Position(methodStart.getLine(), 0)
+    val edit = new l.TextEdit(
+      new l.Range(position, position),
+      s"${indentAt(text, method.range.startOffset)}@Override\n",
+    )
+    CodeActionBuilder.build(
+      title,
+      kind,
+      diagnostics = List(diagnostic),
+      changes = Seq(path -> Seq(edit)),
+    )
+  }
+
+  private def indentAt(text: String, offset: Int): String = {
+    val lineStart = text.lastIndexOf('\n', Math.max(0, offset - 1)) + 1
+    text
+      .slice(lineStart, Math.min(offset, text.length))
+      .takeWhile(ch => ch == ' ' || ch == '\t')
+  }
+}
+
+object AddMissingOverrideAnnotation {
+  val title = "Add missing @Override annotation"
+
+  private def isMissingOverride(diagnostic: l.Diagnostic): Boolean =
+    Option(diagnostic.getCode()).exists(code =>
+      code.isLeft() &&
+        code.getLeft() == MissingOverrideDiagnosticProvider.MissingOverrideCode
+    )
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/AddMissingOverrideAnnotation.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/AddMissingOverrideAnnotation.scala
@@ -49,24 +49,21 @@ class AddMissingOverrideAnnotation(
       text: String,
   ): l.CodeAction = {
     val methodStart = method.range.getStart()
-    val position = new l.Position(methodStart.getLine(), 0)
-    val edit = new l.TextEdit(
-      new l.Range(position, position),
-      s"${indentAt(text, method.range.startOffset)}@Override\n",
-    )
+    val linePrefix =
+      JavaMemberInsertion.linePrefix(text, method.range.startOffset)
+    // Insert on its own indented line when the declaration already starts a
+    // line, otherwise inline before the declaration.
+    val (position, newText) =
+      if (linePrefix.forall(_.isWhitespace))
+        (new l.Position(methodStart.getLine(), 0), s"$linePrefix@Override\n")
+      else (methodStart, "@Override ")
+    val edit = new l.TextEdit(new l.Range(position, position), newText)
     CodeActionBuilder.build(
       title,
       kind,
       diagnostics = List(diagnostic),
       changes = Seq(path -> Seq(edit)),
     )
-  }
-
-  private def indentAt(text: String, offset: Int): String = {
-    val lineStart = text.lastIndexOf('\n', Math.max(0, offset - 1)) + 1
-    text
-      .slice(lineStart, Math.min(offset, text.length))
-      .takeWhile(ch => ch == ' ' || ch == '\t')
   }
 }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -61,6 +61,7 @@ final class CodeActionProvider(
     new RemoveInvalidImportQuickFix(trees, buildTargets),
     new SourceRemoveInvalidImports(trees, buildTargets, diagnostics),
     new ConvertToNamedLambdaParameters(trees, compilers),
+    new AddMissingOverrideAnnotation(javaTrees, buffers),
     new GenerateConstructors(javaTrees, buffers),
     new GenerateGettersSetters(javaTrees, buffers),
     new GenerateEqualsHashCodeToString(javaTrees, buffers),

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaMemberInsertion.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/JavaMemberInsertion.scala
@@ -62,7 +62,7 @@ object JavaMemberInsertion {
   }
 
   /** Text between the start of the line containing `offset` and `offset`. */
-  private def linePrefix(text: String, offset: Int): String =
+  def linePrefix(text: String, offset: Int): String =
     text.substring(text.lastIndexOf('\n', offset - 1) + 1, offset)
 
   /**

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDiagnosticProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDiagnosticProvider.scala
@@ -25,12 +25,18 @@ class JavaDiagnosticProvider(
     compile.task.analyze()
     params.checkCanceled()
 
-    for {
+    val javacDiagnostics = for {
       d <- compile.listener.diagnostics.iterator
       // The compiler may report noisy diagnostics from transitive dependencies
       // TODO: we can't rely on the URI here, getName() with originaluri- is better.
       if d.getSource() != null && d.getSource().toUri() == params.uri()
     } yield JavaDiagnostics.toLspDiagnostic(lineMap, params.text(), d)
-  }.toList
+
+    javacDiagnostics.toList ++
+      new MissingOverrideDiagnosticProvider(
+        compile,
+        params.text()
+      ).diagnostics()
+  }
 
 }

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDiagnosticProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDiagnosticProvider.scala
@@ -34,6 +34,7 @@ class JavaDiagnosticProvider(
 
     javacDiagnostics.toList ++
       new MissingOverrideDiagnosticProvider(
+        compiler,
         compile,
         params.text()
       ).diagnostics()

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/MissingOverrideDiagnosticProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/MissingOverrideDiagnosticProvider.scala
@@ -14,6 +14,7 @@ import com.sun.source.util.Trees
 import org.eclipse.{lsp4j => l}
 
 private class MissingOverrideDiagnosticProvider(
+    compiler: JavaMetalsCompiler,
     compile: JavaSourceCompile,
     text: String
 ) {
@@ -112,36 +113,22 @@ private class MissingOverrideDiagnosticProvider(
   }
 
   private def methodNameRange(method: MethodTree): Option[l.Range] = {
-    val name = method.getName().toString()
-    val start =
-      Option(method.getReturnType())
-        .map(sourcePositions.getEndPosition(compile.cu, _))
-        .getOrElse(sourcePositions.getStartPosition(compile.cu, method))
-    val end =
-      method
-        .getParameters()
-        .asScala
-        .headOption
-        .orElse(Option(method.getBody()))
-        .map(sourcePositions.getStartPosition(compile.cu, _))
-        .getOrElse(sourcePositions.getEndPosition(compile.cu, method))
-
+    val start = sourcePositions.getStartPosition(compile.cu, method)
+    val end = sourcePositions.getEndPosition(compile.cu, method)
     if (start < 0 || end < 0) None
-    else
-      (start.toInt until Math.min(end.toInt, text.length()))
-        .find(nameStartsAt(name, _))
-        .map(offset =>
-          Positions.toLspRange(lineMap, offset, offset + name.length(), text)
-        )
+    else {
+      val (nameStart, nameEnd) = compiler.findIndentifierStartAndEnd(
+        text,
+        method.getName().toString(),
+        start.toInt,
+        end.toInt,
+        method,
+        compile.cu,
+        sourcePositions
+      )
+      Some(Positions.toLspRange(lineMap, nameStart, nameEnd, text))
+    }
   }
-
-  /** Whether `name` occurs at `offset` as a whole identifier, not a substring. */
-  private def nameStartsAt(name: String, offset: Int): Boolean =
-    text.startsWith(name, offset) &&
-      (offset == 0 ||
-        !Character.isJavaIdentifierPart(text.charAt(offset - 1))) &&
-      (offset + name.length() >= text.length() ||
-        !Character.isJavaIdentifierPart(text.charAt(offset + name.length())))
 }
 
 object MissingOverrideDiagnosticProvider {

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/MissingOverrideDiagnosticProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/MissingOverrideDiagnosticProvider.scala
@@ -1,0 +1,149 @@
+package scala.meta.internal.jpc
+
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.TypeElement
+
+import scala.jdk.CollectionConverters._
+
+import com.sun.source.tree.ClassTree
+import com.sun.source.tree.MethodTree
+import com.sun.source.util.TreePath
+import com.sun.source.util.TreePathScanner
+import com.sun.source.util.Trees
+import org.eclipse.{lsp4j => l}
+
+private class MissingOverrideDiagnosticProvider(
+    compile: JavaSourceCompile,
+    text: String
+) {
+
+  private val task = compile.task
+  private val trees = Trees.instance(task)
+  private val sourcePositions = trees.getSourcePositions()
+  private val elements = task.getElements()
+  private val types = task.getTypes()
+  private val lineMap = compile.cu.getLineMap()
+
+  def diagnostics(): List[l.Diagnostic] = {
+    val diagnostics = List.newBuilder[l.Diagnostic]
+    val scanner = new TreePathScanner[Unit, Option[TypeElement]] {
+      override def visitClass(
+          node: ClassTree,
+          owner: Option[TypeElement]
+      ): Unit =
+        super.visitClass(node, typeElement(getCurrentPath()).orElse(owner))
+
+      override def visitMethod(
+          node: MethodTree,
+          owner: Option[TypeElement]
+      ): Unit = {
+        for {
+          classElement <- owner
+          method <- executableElement(getCurrentPath())
+          if method.getKind() == ElementKind.METHOD
+          if !hasOverrideAnnotation(node)
+          if overridesSuperMethod(method, classElement)
+          range <- methodNameRange(node)
+        } {
+          val diagnostic = new l.Diagnostic(
+            range,
+            s"missing @Override annotation on '${node.getName()}'",
+            l.DiagnosticSeverity.Warning,
+            "javac"
+          )
+          diagnostic.setCode(
+            MissingOverrideDiagnosticProvider.MissingOverrideCode
+          )
+          diagnostics += diagnostic
+        }
+        super.visitMethod(node, owner)
+      }
+    }
+
+    scanner.scan(compile.cu, None)
+    diagnostics.result()
+  }
+
+  private def typeElement(path: TreePath): Option[TypeElement] =
+    trees.getElement(path) match {
+      case element: TypeElement => Some(element)
+      case _ => None
+    }
+
+  private def executableElement(path: TreePath): Option[ExecutableElement] =
+    trees.getElement(path) match {
+      case executable: ExecutableElement => Some(executable)
+      case _ => None
+    }
+
+  private def hasOverrideAnnotation(method: MethodTree): Boolean =
+    method.getModifiers().getAnnotations().asScala.exists { annotation =>
+      val name = annotation.getAnnotationType().toString()
+      name == "Override" || name == "java.lang.Override"
+    }
+
+  private def overridesSuperMethod(
+      method: ExecutableElement,
+      owner: TypeElement
+  ): Boolean =
+    superTypes(owner).exists { superType =>
+      superType.getEnclosedElements().asScala.exists {
+        case candidate: ExecutableElement
+            if candidate.getKind() == ElementKind.METHOD =>
+          elements.overrides(method, candidate, owner)
+        case _ => false
+      }
+    }
+
+  private def superTypes(owner: TypeElement): List[TypeElement] = {
+    val seen = scala.collection.mutable.LinkedHashSet.empty[TypeElement]
+    def loop(element: TypeElement): Unit =
+      for {
+        superType <- types.directSupertypes(element.asType()).asScala
+        superElement <- types.asElement(superType) match {
+          case element: TypeElement => Some(element)
+          case _ => None
+        }
+        if seen.add(superElement)
+      } loop(superElement)
+    loop(owner)
+    seen.toList
+  }
+
+  private def methodNameRange(method: MethodTree): Option[l.Range] = {
+    val name = method.getName().toString()
+    val start =
+      Option(method.getReturnType())
+        .map(sourcePositions.getEndPosition(compile.cu, _))
+        .getOrElse(sourcePositions.getStartPosition(compile.cu, method))
+    val end =
+      method
+        .getParameters()
+        .asScala
+        .headOption
+        .orElse(Option(method.getBody()))
+        .map(sourcePositions.getStartPosition(compile.cu, _))
+        .getOrElse(sourcePositions.getEndPosition(compile.cu, method))
+
+    if (start < 0 || end < 0) None
+    else
+      (start.toInt until Math.min(end.toInt, text.length()))
+        .find(nameStartsAt(name, _))
+        .map(offset =>
+          Positions.toLspRange(lineMap, offset, offset + name.length(), text)
+        )
+  }
+
+  /** Whether `name` occurs at `offset` as a whole identifier, not a substring. */
+  private def nameStartsAt(name: String, offset: Int): Boolean =
+    text.startsWith(name, offset) &&
+      (offset == 0 ||
+        !Character.isJavaIdentifierPart(text.charAt(offset - 1))) &&
+      (offset + name.length() >= text.length() ||
+        !Character.isJavaIdentifierPart(text.charAt(offset + name.length())))
+}
+
+object MissingOverrideDiagnosticProvider {
+  val MissingOverrideCode = "missing-override-annotation"
+}

--- a/tests/unit/src/test/scala/tests/codeactions/AddMissingOverrideAnnotationLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/AddMissingOverrideAnnotationLspSuite.scala
@@ -3,12 +3,12 @@ package tests.codeactions
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.codeactions.AddMissingOverrideAnnotation
 
-import tests.BazelMbtTestInitializer
+import tests.MbtTestInitializer
 
 class AddMissingOverrideAnnotationLspSuite
     extends BaseCodeActionLspSuite(
       "add-missing-override-annotation",
-      BazelMbtTestInitializer,
+      MbtTestInitializer,
       useMbtLayout = true,
     ) {
 
@@ -183,6 +183,21 @@ class AddMissingOverrideAnnotationLspSuite
        |  @Override
        |  public void put(String item) {}
        |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddOverride,
+  )
+
+  check(
+    "compact-class",
+    """|package a;
+       |
+       |public class Example { public String <<toString>>() { return ""; } }
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example { @Override public String toString() { return ""; } }
        |""".stripMargin,
     fileName = "Example.java",
     filterAction = onlyAddOverride,

--- a/tests/unit/src/test/scala/tests/codeactions/AddMissingOverrideAnnotationLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/AddMissingOverrideAnnotationLspSuite.scala
@@ -1,0 +1,220 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.codeactions.AddMissingOverrideAnnotation
+
+import tests.BazelMbtTestInitializer
+
+class AddMissingOverrideAnnotationLspSuite
+    extends BaseCodeActionLspSuite(
+      "add-missing-override-annotation",
+      BazelMbtTestInitializer,
+      useMbtLayout = true,
+    ) {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(presentationCompilerDiagnostics = true)
+
+  override protected def toPath(
+      fileName: String,
+      isSource: Boolean = true,
+  ): String =
+    if (isSource) s"a/src/main/java/a/$fileName"
+    else s"a/$fileName"
+
+  private def title: String =
+    s"""|${AddMissingOverrideAnnotation.title}
+        |""".stripMargin
+
+  private val onlyAddOverride: org.eclipse.lsp4j.CodeAction => Boolean =
+    _.getTitle() == AddMissingOverrideAnnotation.title
+
+  check(
+    "object-method",
+    """|package a;
+       |
+       |public class Example {
+       |  public String <<toString>>() {
+       |    return "";
+       |  }
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |  @Override
+       |  public String toString() {
+       |    return "";
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddOverride,
+  )
+
+  check(
+    "existing-annotation",
+    """|package a;
+       |
+       |public class Example {
+       |  @Deprecated
+       |  public String <<toString>>() {
+       |    return "";
+       |  }
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |  @Override
+       |  @Deprecated
+       |  public String toString() {
+       |    return "";
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddOverride,
+  )
+
+  check(
+    "interface-method",
+    """|package a;
+       |
+       |interface Named {
+       |  String name();
+       |}
+       |
+       |public class Example implements Named {
+       |  public String <<name>>() {
+       |    return "";
+       |  }
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |interface Named {
+       |  String name();
+       |}
+       |
+       |public class Example implements Named {
+       |  @Override
+       |  public String name() {
+       |    return "";
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddOverride,
+  )
+
+  checkNoAction(
+    "already-has-override",
+    """|package a;
+       |
+       |public class Example {
+       |  @Override
+       |  public String <<toString>>() {
+       |    return "";
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddOverride,
+  )
+
+  checkNoAction(
+    "custom-method",
+    """|package a;
+       |
+       |public class Example {
+       |  public String <<myCustomMethod>>() {
+       |    return "";
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddOverride,
+  )
+
+  checkNoAction(
+    "static-method",
+    """|package a;
+       |
+       |public class Example {
+       |  public static void <<main>>(String[] args) {}
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddOverride,
+  )
+
+  checkNoAction(
+    "constructor",
+    """|package a;
+       |
+       |public class Example {
+       |  public <<Example>>() {}
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddOverride,
+  )
+
+  check(
+    "generic-type",
+    """|package a;
+       |
+       |interface Box<T> { void put(T item); }
+       |
+       |public class Example implements Box<String> {
+       |  public void <<put>>(String item) {}
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |interface Box<T> { void put(T item); }
+       |
+       |public class Example implements Box<String> {
+       |  @Override
+       |  public void put(String item) {}
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddOverride,
+  )
+
+  check(
+    "javadoc",
+    """|package a;
+       |
+       |public class Example {
+       |  /**
+       |   * My custom toString.
+       |   */
+       |  public String <<toString>>() {
+       |    return "";
+       |  }
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |  /**
+       |   * My custom toString.
+       |   */
+       |  @Override
+       |  public String toString() {
+       |    return "";
+       |  }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyAddOverride,
+  )
+}

--- a/tests/unit/src/test/scala/tests/j/JavaPCDiagnosticsSuite.scala
+++ b/tests/unit/src/test/scala/tests/j/JavaPCDiagnosticsSuite.scala
@@ -275,6 +275,113 @@ class JavaPCDiagnosticsSuite extends BaseJavaPCSuite("java-pc-diagnostics") {
     } yield ()
   }
 
+  test("missing-override-class") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |/a/src/main/java/a/Example.java
+           |package a;
+           |
+           |public class Example {
+           |  public String toString() {
+           |    return "";
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/java/a/Example.java")
+      _ <- server.didFocus("a/src/main/java/a/Example.java")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/java/a/Example.java:4:17: warning: missing @Override annotation on 'toString'
+           |  public String toString() {
+           |                ^^^^^^^^
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("missing-override-interface") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |/a/src/main/java/a/Example.java
+           |package a;
+           |
+           |interface Named {
+           |  String name();
+           |}
+           |
+           |public class Example implements Named {
+           |  public String name() {
+           |    return "";
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/java/a/Example.java")
+      _ <- server.didFocus("a/src/main/java/a/Example.java")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/java/a/Example.java:8:17: warning: missing @Override annotation on 'name'
+           |  public String name() {
+           |                ^^^^
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("missing-override-diamond") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |/a/src/main/java/a/Example.java
+           |package a;
+           |
+           |interface Base {
+           |  String id();
+           |}
+           |
+           |interface Left extends Base {}
+           |
+           |interface Right extends Base {}
+           |
+           |public class Example implements Left, Right {
+           |  public String id() {
+           |    return "";
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/java/a/Example.java")
+      _ <- server.didFocus("a/src/main/java/a/Example.java")
+      // `id` is declared in `Base`, reachable via both `Left` and `Right`.
+      // The transitive supertype walk must find it, and report it only once.
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/java/a/Example.java:12:17: warning: missing @Override annotation on 'id'
+           |  public String id() {
+           |                ^^
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
   test("mbt-java-deps".tag(JavacSourcepath)) {
     cleanWorkspace()
     val mainFile = "Main.java"


### PR DESCRIPTION
Part of https://github.com/scalameta/metals/issues/8502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Java quick-fix to insert `@Override` when a method overrides a parent method but is missing the annotation.
  * Java diagnostics now include warnings for missing `@Override` annotations.
  * Added test coverage for common override scenarios, including interfaces, generics, Javadocs, and diamond inheritance.

* **Bug Fixes**
  * The new quick-fix avoids constructors, static methods, and methods that already have `@Override`.
  * Existing annotations are preserved when the new annotation is added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->