### PR TITLE
Github CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-reports
-          path: "**/.reports/**/*"
+          path: "**/target/test-reports/*.xml"
           if-no-files-found: ignore
           retention-days: 7
           compression-level: 9

--- a/.github/workflows/test-failures-report.yml
+++ b/.github/workflows/test-failures-report.yml
@@ -7,15 +7,17 @@ on:
 permissions:
   statuses: write
   checks: write
-  contents: write
+  contents: read
   pull-requests: write
-  actions: write
+  actions: read
 jobs:
   aggregate-test-reports:
     if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download reports for each test job
         uses: dawidd6/action-download-artifact@v21
         with:


### PR DESCRIPTION
* Correct path to test reports (as in #8432)
* Tightened permissions, as suggested by Coderabbit (from #8606 comments)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI test-report collection for integration runs to target the correct XML test results.
  * Tightened workflow permissions for the test-failure reporting workflow.
  * Prevented checkout from persisting repository credentials during aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->