### PR TITLE
Select test reports by workflow run ID

### DIFF
--- a/.github/workflows/test-failures-report.yml
+++ b/.github/workflows/test-failures-report.yml
@@ -15,12 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
       - name: Download reports for each test job
         uses: dawidd6/action-download-artifact@v21
         with:
-          workflow: ci.yml
-          workflow_conclusion: completed
+          run_id: ${{ github.event.workflow_run.id }}
+          name: test-reports
           merge_multiple: true
       - name: Test Report
         uses: dorny/test-reporter@29672c52a8220c09bd9f79b5b6cf6315f1763996


### PR DESCRIPTION
This should eliminate the false failures in the aggregated test reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of test-failure reporting by ensuring the report uses the exact commit that triggered the run.
  * Updated artifact retrieval so test reports are fetched from the correct workflow run, reducing missed or mismatched results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->