### PR TITLE
Reset the connection state if there was an error during Scala CLI startup

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -19,7 +19,6 @@ import scala.util.Properties
 import scala.util.Success
 import scala.util.control.NonFatal
 
-import scala.meta.internal.bsp.BuildChange
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.BuildServerConnection
@@ -207,21 +206,22 @@ class ScalaCli(
       val f = futureConn.flatMap { conn =>
         state.set(ConnectionState.Connected(path, conn, ImportedBuild.empty))
         scribe.info(s"Connected to Scala CLI server v${conn.version}")
-        importBuild().map { _ =>
-          BuildChange.Reconnected
-        }
+        importBuild()
       }
 
       f.transform {
         case Failure(ex) =>
           scribe.error("Error starting Scala CLI", ex)
+          disconnectOldBuildServer()
           Success(())
         case Success(_) =>
           scribe.info(s"Scala CLI started for $path")
           Success(())
       }
     } else {
-      scribe.error(s"Multiply Scala CLI start calls. Failed for: $path")
+      scribe.error(
+        s"Aborting the Scala CLI startup because another startup call is in progress. Workspace folder: $path"
+      )
       Future.unit
     }
   }


### PR DESCRIPTION
Suggested by Coderabbit: https://github.com/scalameta/metals/pull/8587#pullrequestreview-4570037899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability when connecting to Scala CLI.
  * Fixed a case where a failed startup could leave the connection in an unusable state.
  * Made concurrent startup attempts report a clearer message when one is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->