### PR TITLE
Fix an OutOfMemory error caused by an infinite loop in the folding logic 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/parsing/JavaFoldingRangeExtractor.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/JavaFoldingRangeExtractor.scala
@@ -2,8 +2,7 @@ package scala.meta.internal.parsing
 
 import javax.tools.Diagnostic.NOPOS
 
-import scala.annotation.tailrec
-
+import scala.meta.internal.jpc.JavaComment
 import scala.meta.internal.jpc.JavaMetalsCompiler
 import scala.meta.internal.jpc.SourceJavaFileObject
 import scala.meta.io.AbsolutePath
@@ -17,7 +16,6 @@ import com.sun.source.tree.LiteralTree
 import com.sun.source.tree.Tree
 import com.sun.source.util.SourcePositions
 import com.sun.source.util.TreePathScanner
-import com.sun.source.util.Trees
 import org.eclipse.lsp4j.FoldingRange
 import org.eclipse.lsp4j.FoldingRangeKind
 import org.slf4j.Logger
@@ -33,8 +31,6 @@ object JavaFoldingRangeExtractor {
       endPos: Long,
       kind: String,
   ) {
-    def contains(idx: Long): Boolean = startPos <= idx && endPos >= idx
-
     def toFoldingRange(lineMap: LineMap): FoldingRange = {
       val startLine = lineMap.getLineNumber(startPos) - 1
       val startCharacter = lineMap.getColumnNumber(startPos) - 1
@@ -47,6 +43,7 @@ object JavaFoldingRangeExtractor {
       foldingRange
     }
   }
+
   private class FoldScanner(
       compUnit: CompilationUnitTree,
       sourcePositions: SourcePositions,
@@ -133,42 +130,63 @@ object JavaFoldingRangeExtractor {
     }
   }
 
-  private def getTrees(
+  private def blockCommentRanges(
+      comments: List[JavaComment],
       text: String,
-      path: AbsolutePath,
-  ): Option[(Trees, CompilationUnitTree)] = {
-    val source = SourceJavaFileObject.make(text, path.toURI)
-    JavaMetalsCompiler.parse(source)
-  }
-
-  // search for any comments in file that aren't defined within a String
-  private def findComments(
-      text: String,
-      exclusions: List[Range],
-  ): List[Range] = {
-    @tailrec
-    def findComments(comments: List[Range], idx: Int): List[Range] = {
-      val startIdx = text.indexOf("/*", idx)
-      if (startIdx == -1)
-        comments
-      else {
-        val (newComments, newIdx) =
-          if (exclusions.exists(range => range.contains(startIdx.longValue)))
-            (comments, startIdx + 2)
-          else {
-            val endIdx = text.indexOf("*/", startIdx + 2)
-            val range = Range(
-              startIdx.longValue,
-              endIdx.longValue + 2,
-              FoldingRangeKind.Comment,
-            )
-            (range :: comments, endIdx + 2)
-          }
-        findComments(newComments, newIdx)
-      }
+  ): List[Range] =
+    comments.collect {
+      case comment
+          if !comment.isLineComment &&
+            text.regionMatches(comment.end - 2, "*/", 0, 2) =>
+        Range(
+          comment.start.toLong,
+          comment.end.toLong,
+          FoldingRangeKind.Comment,
+        )
     }
 
-    findComments(Nil, 0)
+  // Standalone (line-leading) `//` comments fold as a single region. Comments
+  // separated only by whitespace (adjacent lines or blank lines in between) join
+  // into one group spanning from the first comment to the last, like imports; a
+  // lone one folds on its own (the span threshold decides if it's kept).
+  private def lineCommentRanges(
+      comments: List[JavaComment],
+      text: String,
+      lineMap: LineMap,
+  ): List[Range] = {
+    def isLineLeading(
+        comment: JavaComment
+    ): Boolean = {
+      val lineStart =
+        lineMap.getStartPosition(lineMap.getLineNumber(comment.start.toLong))
+      text.substring(lineStart.toInt, comment.start).forall(_.isWhitespace)
+    }
+    val leading = comments
+      .filter(comment => comment.isLineComment && isLineLeading(comment))
+      .sortBy(_.start)
+    val groups = leading
+      .foldRight(List.empty[List[JavaComment]]) { (comment, groups) =>
+        groups match {
+          case (group @ (head :: _)) :: rest
+              if text
+                .substring(comment.end, head.start)
+                .forall(_.isWhitespace) =>
+            (comment :: group) :: rest
+          case _ =>
+            List(comment) :: groups
+        }
+      }
+    for {
+      group <- groups
+      first <- group.headOption
+      last <- group.lastOption
+    } yield {
+      Range(
+        first.start.toLong,
+        last.end.toLong,
+        FoldingRangeKind.Comment,
+      )
+    }
   }
 
   def extract(
@@ -177,9 +195,11 @@ object JavaFoldingRangeExtractor {
       foldOnlyLines: Boolean,
       spanThreshold: Int,
   ): List[FoldingRange] = {
-    getTrees(text, path) match {
-      case Some((trees, root)) =>
-        val sourcePositions = trees.getSourcePositions
+    val source = SourceJavaFileObject.make(text, path.toURI)
+    JavaMetalsCompiler.parseWithComments(source) match {
+      case Some(parsed) =>
+        val root = parsed.unit
+        val sourcePositions = parsed.trees.getSourcePositions
         val scanner = new FoldScanner(root, sourcePositions, text)
         scanner.scan(root, {})
         val lineMap = root.getLineMap
@@ -187,8 +207,11 @@ object JavaFoldingRangeExtractor {
         val mergedImports = mergeRanges(
           scanner.imports.map(range => range.toFoldingRange(lineMap))
         ).toList
-        // comments are not returned by the scanner so search separately
-        val comments = findComments(text, scanner.strings)
+        val allComments = parsed.comments
+        val comments = blockCommentRanges(
+          allComments,
+          text,
+        ) ::: lineCommentRanges(allComments, text, lineMap)
         val allRanges = mergedImports :::
           scanner.regions.map(range => range.toFoldingRange(lineMap)) :::
           scanner.strings.map(range => range.toFoldingRange(lineMap)) :::

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/CommentCollectingScanner.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/CommentCollectingScanner.scala
@@ -1,0 +1,11 @@
+package scala.meta.internal.jpc
+
+import com.sun.tools.javac.parser.JavaTokenizer
+import com.sun.tools.javac.parser.Scanner
+import com.sun.tools.javac.parser.ScannerFactory
+
+// `Scanner`'s constructor is protected; subclass to make it callable.
+private[jpc] final class CommentCollectingScanner(
+    factory: ScannerFactory,
+    tokenizer: JavaTokenizer
+) extends Scanner(factory, tokenizer)

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/CommentCollectingScannerFactory.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/CommentCollectingScannerFactory.scala
@@ -1,0 +1,30 @@
+package scala.meta.internal.jpc
+
+import com.sun.tools.javac.parser.Scanner
+import com.sun.tools.javac.parser.ScannerFactory
+import com.sun.tools.javac.util.Context
+
+// Produces scanners whose tokenizer reports every comment to `onComment`.
+// Registering an instance in a javac `Context` (its constructor puts itself
+// there) makes the parser collect comments during a normal parse.
+private[jpc] final class CommentCollectingScannerFactory(
+    context: Context,
+    onComment: JavaComment => Unit
+) extends ScannerFactory(context) {
+  override def newScanner(
+      input: CharSequence,
+      keepDocComments: Boolean
+  ): Scanner = {
+    val array = input.toString.toCharArray
+    newScanner(array, array.length, keepDocComments)
+  }
+  override def newScanner(
+      input: Array[Char],
+      inputLength: Int,
+      keepDocComments: Boolean
+  ): Scanner =
+    new CommentCollectingScanner(
+      this,
+      new CommentCollectingTokenizer(this, input, inputLength, onComment)
+    )
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/CommentCollectingTokenizer.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/CommentCollectingTokenizer.scala
@@ -1,0 +1,23 @@
+package scala.meta.internal.jpc
+
+import com.sun.tools.javac.parser.JavaTokenizer
+import com.sun.tools.javac.parser.ScannerFactory
+import com.sun.tools.javac.parser.Tokens.Comment
+import com.sun.tools.javac.parser.Tokens.Comment.CommentStyle
+
+// javac reports comments through the `processComment` callback
+private[jpc] final class CommentCollectingTokenizer(
+    factory: ScannerFactory,
+    input: Array[Char],
+    inputLength: Int,
+    onComment: JavaComment => Unit
+) extends JavaTokenizer(factory, input, inputLength) {
+  override protected def processComment(
+      pos: Int,
+      endPos: Int,
+      style: CommentStyle
+  ): Comment = {
+    onComment(JavaComment(pos, endPos, style))
+    super.processComment(pos, endPos, style)
+  }
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaComment.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaComment.scala
@@ -1,0 +1,17 @@
+package scala.meta.internal.jpc
+
+import com.sun.tools.javac.parser.Tokens.Comment.CommentStyle
+
+// A comment's start and (exclusive) end offset in the source.
+private[internal] final case class JavaComment(
+    start: Int,
+    end: Int,
+    style: CommentStyle
+) {
+  // NOTE: only plain `//` comments count as line comments. On JDK 23+ a `///`
+  // markdown doc comment (JEP 467) is reported as its own `JAVADOC_LINE` style,
+  // so it is not treated as a line comment here and does not fold (it has no
+  // `*/`, so the block-comment path skips it too). On JDK < 23 `///` is a plain
+  // `LINE` comment and does fold.
+  def isLineComment: Boolean = style == CommentStyle.LINE
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaMetalsCompiler.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaMetalsCompiler.scala
@@ -15,6 +15,7 @@ import javax.tools.JavaFileObject
 import javax.tools.StandardJavaFileManager
 import javax.tools.ToolProvider
 
+import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 
 import scala.meta.internal.metals.ReportLevel
@@ -36,6 +37,7 @@ import com.sun.source.util.JavacTask
 import com.sun.source.util.SourcePositions
 import com.sun.source.util.TreePath
 import com.sun.source.util.Trees
+import com.sun.tools.javac.api.JavacTaskImpl
 import org.eclipse.lsp4j.Position
 import org.slf4j.Logger
 
@@ -315,19 +317,13 @@ object JavaMetalsCompiler {
   val COMPILER: JavaCompiler = ToolProvider.getSystemJavaCompiler()
   val STANDARD_FILE_MANAGER: StandardJavaFileManager =
     COMPILER.getStandardFileManager(null, null, StandardCharsets.UTF_8)
+
   def parse(params: VirtualFileParams): Option[(Trees, CompilationUnitTree)] = {
     parse(SourceJavaFileObject.fromParams(params))
   }
+
   def parse(source: JavaFileObject): Option[(Trees, CompilationUnitTree)] = {
-    val printer = new StringWriter()
-    val task = COMPILER.getTask(
-      printer,
-      STANDARD_FILE_MANAGER,
-      null,
-      List.empty[String].asJava,
-      null,
-      List(source).asJava
-    )
+    val task = createParseTask(source)
     val elems = task.asInstanceOf[JavacTask].parse()
     val trees = Trees.instance(task)
     val iter = elems.iterator
@@ -336,10 +332,56 @@ object JavaMetalsCompiler {
     else None
   }
 
+  private[internal] def parseWithComments(
+      source: JavaFileObject
+  ): Option[JavaParseResult] = {
+    val task = createParseTask(source)
+    val comments = ListBuffer.empty[JavaComment]
+    registerCommentCollectingScannerFactory(
+      task,
+      onComment = comment => comments += comment
+    )
+
+    val elems = task.asInstanceOf[JavacTask].parse()
+    val trees = Trees.instance(task)
+    val iter = elems.iterator
+    // only one CompilationUnitTree for a single file
+    if (iter.hasNext())
+      Some(JavaParseResult(trees, iter.next(), comments.toList))
+    else None
+  }
+
+  private def createParseTask(
+      source: JavaFileObject
+  ): JavaCompiler.CompilationTask = {
+    val printer = new StringWriter()
+    COMPILER.getTask(
+      printer,
+      STANDARD_FILE_MANAGER,
+      null,
+      List.empty[String].asJava,
+      null,
+      List(source).asJava
+    )
+  }
+
   def makeFileObject(file: File): JavaFileObject = {
     val files =
       STANDARD_FILE_MANAGER.getJavaFileObjectsFromFiles(List(file).asJava)
     files.iterator().next()
+  }
+
+  // `onComment` is invoked by CommentCollectingTokenizer for every comment found
+  private def registerCommentCollectingScannerFactory(
+      task: JavaCompiler.CompilationTask,
+      onComment: JavaComment => Unit
+  ): Unit = {
+    val context = task.asInstanceOf[JavacTaskImpl].getContext
+
+    // Register the comment-saving scanner before parsing.
+    // `ScannerFactory`'s constructor puts itself into the context,
+    // so the parser picks it up when it later calls `ScannerFactory.instance`.
+    new CommentCollectingScannerFactory(context, onComment)
   }
 
 }

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaParseResult.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaParseResult.scala
@@ -1,0 +1,11 @@
+package scala.meta.internal.jpc
+
+import com.sun.source.tree.CompilationUnitTree
+import com.sun.source.util.Trees
+
+// The result of parsing a Java source: its tree and all of its comments.
+private[internal] final case class JavaParseResult(
+    trees: Trees,
+    unit: CompilationUnitTree,
+    comments: List[JavaComment]
+)

--- a/tests/unit/src/test/scala/tests/JavaFoldingRangeSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaFoldingRangeSuite.scala
@@ -1,0 +1,496 @@
+package tests
+
+import java.nio.file.Paths
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.TextEdits
+import scala.meta.internal.parsing.JavaFoldingRangeExtractor
+import scala.meta.io.AbsolutePath
+
+final class JavaFoldingRangeSuite extends BaseSuite {
+
+  // Expected folding ranges are written inline with `>>kind>>` / `<<kind<<`
+  // markers (the same convention as the Scala folding suites): `>>region>>`
+  // marks a region start, `<<region<<` its end, and likewise for `comment`.
+
+  // ---------------------------------------------------------------------------
+  // Line comments
+  // ---------------------------------------------------------------------------
+
+  // Consecutive standalone `//` comments fold as one region.
+  test("consecutive-line-comments") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>// line one
+         |  // line two
+         |  // line three<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // Line comments separated only by blank lines fold together into one region
+  // (like imports), spanning from the first comment to the last.
+  test("line-comments-separated-by-blank-line") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>// group a1
+         |  // group a2
+         |
+         |  // group b1
+         |  // group b2<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // Code between two runs of line comments keeps them in separate regions: only
+  // whitespace-separated comments merge.
+  test("line-comments-separated-by-code-stay-separate") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>// block a1
+         |  // block a2<<comment<<
+         |  int x = 1;
+         |  >>comment>>// block b1
+         |  // block b2<<comment<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A trailing `//` comment after code is not line-leading, so it does not join
+  // the standalone comment block that follows.
+  test("trailing-line-comment-not-grouped") {
+    check(
+      """|class Foo >>region>>{
+         |  int x = 1; // trailing
+         |  >>comment>>// standalone1
+         |  // standalone2<<comment<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A `/* ... */` that appears inside a line (`//`) comment is not treated as a
+  // block comment; the whole line folds as a single line-comment range instead.
+  test("block-comment-inside-inline-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>// an inline /* not a block */ comment<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // Regression test: an unterminated `/*` (e.g. inside a line comment)
+  // used to send `findComments` into an endless loop.
+  test("unterminated-block-comment-in-line-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>// glob/*.json<<comment<<
+         |  void bar() >>region>>{
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Block comments
+  // ---------------------------------------------------------------------------
+
+  // A block comment with a matching `/*` and `*/` is folded, and the
+  // surrounding class and method ranges are detected as usual.
+  test("complete-block-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>/* a block
+         |     comment */<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A block comment that fits on a single line still folds.
+  test("single-line-block-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>/* one line */<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A `//` inside a block comment is part of the block, not a line comment:
+  // the block continues until the real `*/`, yielding a single comment range.
+  test("inline-comment-inside-block-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>/* outer block
+         |     // an inline comment here
+         |     still block */<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // Two block comments back-to-back with no separator must both be folded.
+  test("adjacent-block-comments") {
+    check(
+      """|class Foo >>region>>{
+         |  int x = 1; >>comment>>/* a */<<comment<<>>comment>>/* b */<<comment<<
+         |  void bar() >>region>>{
+         |    int y = 2;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // Lone `/` division operators must not be read as comment starts, and a real
+  // block comment after them must still fold.
+  test("division-then-block-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  int x = 10 / 2 / 5;
+         |  >>comment>>/* c */<<comment<<
+         |  void bar() >>region>>{
+         |    int y = 2;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // Regression test: a `/*` (or `*/`) that appears inside a line (`//`)
+  // comment must not be treated as the start/end of a block comment, so the
+  // real block comment that follows is still detected correctly.
+  test("block-comment-markers-in-line-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>// glob/*<<comment<<
+         |  >>comment>>/* block
+         |     comment */<<comment<<
+         |  void bar() >>region>>{
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A `//` line that contains a block-comment opener `/*` must not start a
+  // block comment: the `/*` is ignored and the complete block comment on the
+  // following lines is folded as its own comment range.
+  test("block-comment-opener-in-inline-comment-then-block-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>// see pattern /* here<<comment<<
+         |  >>comment>>/* a real
+         |     block comment */<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A `/*` that is never closed produces no comment range. Because javac treats
+  // everything from the `/*` to EOF as a comment, the method that follows is
+  // swallowed and only the enclosing class range remains.
+  test("unclosed-block-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  /* a block
+         |     comment that never closes
+         |  void bar() {
+         |    int x = 1;
+         |  }
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A stray `*/` with no matching `/*` is not treated as a comment: while
+  // OutsideComment the closing marker is just ordinary text, so no comment
+  // range is produced and the class/method ranges are unaffected.
+  test("closed-not-opened-block-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |  end of comment */
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A stray `*/` before a method is just ordinary text (no `/*` opened a
+  // comment), so it produces no comment range and the following method still
+  // folds.
+  test("closed-not-opened-block-comment-before-method") {
+    check(
+      """|class Foo >>region>>{
+         |  */
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A block comment directly above a run of line comments folds as its own
+  // region, separate from the line-comment region.
+  test("block-and-line-comments-stay-separate") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>/* a block
+         |     comment */<<comment<<
+         |  >>comment>>// line one
+         |  // line two<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Comments and string literals
+  // ---------------------------------------------------------------------------
+
+  // A `//` inside a String literal (e.g. a URL) must not start a line comment.
+  test("line-comment-marker-in-string") {
+    check(
+      """|class Foo >>region>>{
+         |  String url = >>region>>"http://example.com"<<region<<;
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A `/*` or `*/` inside a String literal must be ignored (the literal is an
+  // exclusion), so the real block comment that follows is still folded.
+  test("block-comment-markers-in-string-literal") {
+    check(
+      """|class Foo >>region>>{
+         |  String s = >>region>>"not a /* comment */ here"<<region<<;
+         |  >>comment>>/* real
+         |     block */<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A String literal that itself contains both `//` and `/*` markers is
+  // excluded, so those markers are ignored and the real block comment that
+  // follows is still folded.
+  test("string-with-comment-markers-then-block-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  String s = >>region>>"a // b /* c"<<region<<;
+         |  >>comment>>/* real
+         |     block */<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A `"..."` that appears inside a block comment is comment text, not a String
+  // literal (javac does not tokenize it), so the whole block comment folds as
+  // one range.
+  test("string-literal-inside-block-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>/* comment with "a string" inside */<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A `"..."` inside a line comment is comment text too (not a String literal),
+  // so the line folds as a single line-comment range with no string region.
+  test("string-literal-inside-line-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>// comment with "a string" inside<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A block comment that contains a `"..."` which in turn contains a `//`: it
+  // is all comment text, so the whole block comment folds as a single range.
+  test("comment-with-string-with-comment") {
+    check(
+      """|class Foo >>region>>{
+         |  >>comment>>/* outer "inner // still comment" end */<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // A block comment immediately following a String literal (no separator) must
+  // still be folded - the literal's exclusive end must not swallow the `/`.
+  test("block-comment-right-after-string") {
+    check(
+      """|class Foo >>region>>{
+         |  String s = >>region>>"x"<<region<<>>comment>>/* c */<<comment<<;
+         |  void bar() >>region>>{
+         |    int y = 2;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Imports
+  // ---------------------------------------------------------------------------
+
+  // A single import statement folds as its own imports range.
+  test("single-import") {
+    check(
+      """|>>imports>>import java.util.List;<<imports<<
+         |class Foo >>region>>{
+         |  void bar() >>region>>{}<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // Multiple consecutive imports merge into a single imports range spanning from
+  // the first import to the last.
+  test("consecutive-imports") {
+    check(
+      """|>>imports>>import java.util.List;
+         |import java.util.Map;
+         |import java.util.Set;<<imports<<
+         |class Foo >>region>>{
+         |  void bar() >>region>>{}<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // Imports separated by blank lines still merge into one imports range covering
+  // everything from the first import to the last, blank lines included.
+  test("imports-separated-by-blank-lines") {
+    check(
+      """|>>imports>>import java.util.List;
+         |
+         |import java.util.Map;
+         |
+         |import java.util.Set;<<imports<<
+         |class Foo >>region>>{
+         |  void bar() >>region>>{}<<region<<
+         |}<<region<<
+         |""".stripMargin
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Methods and span thresholds
+  // ---------------------------------------------------------------------------
+
+  // A single-line method body spans 0 lines, so at threshold 0 it still folds.
+  test("single-line-method-span-threshold-0") {
+    check(
+      """|class Foo >>region>>{
+         |  void bar() >>region>>{}<<region<<
+         |}<<region<<
+         |""".stripMargin,
+      spanThreshold = 0,
+    )
+  }
+
+  // The same single-line method body is filtered at threshold 1 (span 0 < 1),
+  // leaving only the multi-line class region.
+  test("single-line-method-span-threshold-1") {
+    check(
+      """|class Foo >>region>>{
+         |  void bar() {}
+         |}<<region<<
+         |""".stripMargin,
+      spanThreshold = 1,
+    )
+  }
+
+  // With a span threshold above 0, single-line comments (line and block) span 0
+  // lines and are filtered out, while the multi-line block comment and the
+  // class/method regions still fold.
+  test("span-threshold-filters-single-line-comments") {
+    check(
+      """|class Foo >>region>>{
+         |  // single line comment
+         |  /* single line block */
+         |  >>comment>>/* multi
+         |     line block */<<comment<<
+         |  void bar() >>region>>{
+         |    int x = 1;
+         |  }<<region<<
+         |}<<region<<
+         |""".stripMargin,
+      spanThreshold = 1,
+    )
+  }
+
+  private def check(expected: String, spanThreshold: Int = 0): Unit = {
+    val text = expected
+      .replace(">>region>>", "")
+      .replace("<<region<<", "")
+      .replace(">>comment>>", "")
+      .replace("<<comment<<", "")
+      .replace(">>imports>>", "")
+      .replace("<<imports<<", "")
+    val actual = JavaFoldingRangeExtractor.extract(
+      text,
+      path = AbsolutePath(Paths.get("Foo.java")),
+      foldOnlyLines = false,
+      spanThreshold = spanThreshold,
+    )
+    val edits = RangesTextEdits.fromFoldingRanges(actual.asJava)
+    val obtained = TextEdits.applyEdits(text, edits)
+    assertNoDiff(obtained, expected)
+  }
+}


### PR DESCRIPTION
## Description
If we add a comment like this
```java
// some-glob/*.json
```
to a Java file and open it in an editor running Metals, we get into an infinite loop in JavaFoldingRangeEtractor#findComments

It's because of this line:
```java
val endIdx = text.indexOf("*/", startIdx + 2)
```

In the provided example the `/*` part is treated as the beginning of a block comment, however the comment is never closed (because it's not actually a comment block)

We end up calling findComments recursively with the same `idx` parameter but the `comments` list keeps growing.
It goes like this:

```
input: "// some-glob/*.json"
findComments(idx = 0)

---

idx = 0
startidx = 12
endIdx = -1
findComments(idx = endIdx + 2 = -1 + 2 = 1) 

---

idx = 1
startidx = 12
endIdx = -1
findComments(idx = -1 + 2 = 1)
idx is 1 again -> loop
```

This leads to an OutOfMemory error

## DEMO
### Before

<img width="1910" height="985" alt="image" src="https://github.com/user-attachments/assets/4e92fde3-547f-4e79-bd98-c312095e6131" />

---

### After

<img width="1910" height="985" alt="image" src="https://github.com/user-attachments/assets/4b4bfe45-4bbc-445d-9619-a3ef0c6fd700" />
