### PR TITLE
Add unused import diagnostic & quick-fix code action

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -62,6 +62,7 @@ final class CodeActionProvider(
     new SourceRemoveInvalidImports(trees, buildTargets, diagnostics),
     new ConvertToNamedLambdaParameters(trees, compilers),
     new AddMissingOverrideAnnotation(javaTrees, buffers),
+    new RemoveUnusedJavaImport(buffers),
     new GenerateConstructors(javaTrees, buffers),
     new GenerateGettersSetters(javaTrees, buffers),
     new GenerateEqualsHashCodeToString(javaTrees, buffers),

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/RemoveUnusedJavaImport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/RemoveUnusedJavaImport.scala
@@ -54,18 +54,24 @@ object RemoveUnusedJavaImport {
   ): Option[l.TextEdit] = {
     val lines = text.split("\n", -1)
     val startLine = range.getStart().getLine()
-    if (startLine < 0 || startLine >= lines.length) None
+    val importEndLine = range.getEnd().getLine()
+    if (
+      startLine < 0 ||
+      startLine >= lines.length ||
+      importEndLine < startLine ||
+      importEndLine >= lines.length
+    ) None
     else {
       val endLine =
         if (
-          startLine + 2 < lines.length &&
-          lines(startLine + 1).isEmpty &&
+          importEndLine + 2 < lines.length &&
+          lines(importEndLine + 1).isEmpty &&
           (startLine == 0 || lines(startLine - 1).isEmpty)
-        ) startLine + 2
-        else if (startLine + 1 < lines.length) startLine + 1
-        else startLine
+        ) importEndLine + 2
+        else if (importEndLine + 1 < lines.length) importEndLine + 1
+        else importEndLine
       val endCharacter =
-        if (endLine == startLine) lines(startLine).length()
+        if (endLine == importEndLine) lines(importEndLine).length()
         else 0
       Some(
         new l.TextEdit(

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/RemoveUnusedJavaImport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/RemoveUnusedJavaImport.scala
@@ -1,0 +1,81 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.jpc.UnusedImportDiagnosticProvider
+import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.pc.CancelToken
+
+import org.eclipse.{lsp4j => l}
+
+class RemoveUnusedJavaImport(buffers: Buffers) extends CodeAction {
+  import RemoveUnusedJavaImport._
+
+  override def kind: String = l.CodeActionKind.QuickFix
+  override def isScala: Boolean = false
+  override def isJava: Boolean = true
+
+  override def contribute(
+      params: l.CodeActionParams,
+      token: CancelToken,
+  )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = Future {
+    val path = params.getTextDocument().getUri().toAbsolutePath
+    val range = params.getRange()
+
+    for {
+      text <- buffers.get(path).orElse(path.readTextOpt).toSeq
+      diagnostic <- params.getContext().getDiagnostics().asScala.toSeq
+      if isUnusedImport(diagnostic)
+      if range.overlapsWith(diagnostic.getRange())
+      edit <- removeImportEdit(text, diagnostic.getRange()).toSeq
+    } yield CodeActionBuilder.build(
+      title,
+      kind,
+      diagnostics = List(diagnostic),
+      changes = Seq(path -> Seq(edit)),
+    )
+  }
+}
+
+object RemoveUnusedJavaImport {
+  val title = "Remove unused import"
+
+  private def isUnusedImport(diagnostic: l.Diagnostic): Boolean =
+    Option(diagnostic.getCode()).exists(code =>
+      code.isLeft() &&
+        code.getLeft() == UnusedImportDiagnosticProvider.UnusedImportCode
+    )
+
+  private def removeImportEdit(
+      text: String,
+      range: l.Range,
+  ): Option[l.TextEdit] = {
+    val lines = text.split("\n", -1)
+    val startLine = range.getStart().getLine()
+    if (startLine < 0 || startLine >= lines.length) None
+    else {
+      val endLine =
+        if (
+          startLine + 2 < lines.length &&
+          lines(startLine + 1).isEmpty &&
+          (startLine == 0 || lines(startLine - 1).isEmpty)
+        ) startLine + 2
+        else if (startLine + 1 < lines.length) startLine + 1
+        else startLine
+      val endCharacter =
+        if (endLine == startLine) lines(startLine).length()
+        else 0
+      Some(
+        new l.TextEdit(
+          new l.Range(
+            new l.Position(startLine, 0),
+            new l.Position(endLine, endCharacter),
+          ),
+          "",
+        )
+      )
+    }
+  }
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDiagnosticProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDiagnosticProvider.scala
@@ -37,6 +37,10 @@ class JavaDiagnosticProvider(
         compiler,
         compile,
         params.text()
+      ).diagnostics() ++
+      new UnusedImportDiagnosticProvider(
+        compile,
+        params.text()
       ).diagnostics()
   }
 

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDiagnosticProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDiagnosticProvider.scala
@@ -61,10 +61,7 @@ class JavaDiagnosticProvider(
       compile: JavaSourceCompile
   ): List[l.Diagnostic] =
     try {
-      new UnusedImportDiagnosticProvider(
-        compile,
-        params.text()
-      ).diagnostics()
+      new UnusedImportDiagnosticProvider(compile).diagnostics()
     } catch {
       case NonFatal(e) =>
         compiler.logger.warn("Failed to compute unused import diagnostics", e)

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDiagnosticProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDiagnosticProvider.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.jpc
 
+import scala.util.control.NonFatal
+
 import scala.meta.pc.VirtualFileParams
 
 import org.eclipse.{lsp4j => l}
@@ -33,15 +35,39 @@ class JavaDiagnosticProvider(
     } yield JavaDiagnostics.toLspDiagnostic(lineMap, params.text(), d)
 
     javacDiagnostics.toList ++
+      missingOverrideDiagnostics(compile) ++
+      unusedImportDiagnostics(compile)
+  }
+
+  private def missingOverrideDiagnostics(
+      compile: JavaSourceCompile
+  ): List[l.Diagnostic] =
+    try {
       new MissingOverrideDiagnosticProvider(
         compiler,
         compile,
         params.text()
-      ).diagnostics() ++
+      ).diagnostics()
+    } catch {
+      case NonFatal(e) =>
+        compiler.logger.warn(
+          "Failed to compute missing override diagnostics",
+          e
+        )
+        Nil
+    }
+
+  private def unusedImportDiagnostics(
+      compile: JavaSourceCompile
+  ): List[l.Diagnostic] =
+    try {
       new UnusedImportDiagnosticProvider(
         compile,
         params.text()
       ).diagnostics()
-  }
-
+    } catch {
+      case NonFatal(e) =>
+        compiler.logger.warn("Failed to compute unused import diagnostics", e)
+        Nil
+    }
 }

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/UnusedImportDiagnosticProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/UnusedImportDiagnosticProvider.scala
@@ -2,44 +2,61 @@ package scala.meta.internal.jpc
 
 import javax.lang.model.element.Element
 import javax.lang.model.element.QualifiedNameable
+import javax.tools.Diagnostic.Kind.ERROR
 
 import scala.jdk.CollectionConverters._
 
+import com.sun.source.tree.ClassTree
 import com.sun.source.tree.IdentifierTree
 import com.sun.source.tree.ImportTree
+import com.sun.source.tree.MethodTree
 import com.sun.source.tree.Tree
+import com.sun.source.tree.VariableTree
+import com.sun.source.util.DocTrees
 import com.sun.source.util.TreePath
 import com.sun.source.util.TreePathScanner
 import com.sun.source.util.Trees
 import org.eclipse.{lsp4j => l}
 
 private class UnusedImportDiagnosticProvider(
-    compile: JavaSourceCompile,
-    text: String
+    compile: JavaSourceCompile
 ) {
 
   private val task = compile.task
   private val trees = Trees.instance(task)
+  private val docTrees = DocTrees.instance(task)
+  private val sourcePositions = trees.getSourcePositions()
+  private val sourceUri = compile.cu.getSourceFile().toUri()
 
   def diagnostics(): List[l.Diagnostic] = {
     val seen = scala.collection.mutable.Set.empty[String]
 
-    val imports = compile.cu.getImports().asScala.toList.map { importTree =>
-      val info = UnusedImportDiagnosticProvider.ImportInfo(
-        importTree,
-        element(importTree.getQualifiedIdentifier())
-      )
-      info.copy(isDuplicate = !seen.add(info.normalized))
-    }
+    val imports = compile.cu
+      .getImports()
+      .asScala
+      .toList
+      .filterNot(hasError)
+      .map { importTree =>
+        val info = UnusedImportDiagnosticProvider.ImportInfo(
+          importTree,
+          element(importTree.getQualifiedIdentifier())
+        )
+        info.copy(isDuplicate = !seen.add(info.normalized))
+      }
 
     if (imports.isEmpty) Nil
     else {
       val usedElements = scala.collection.mutable.Set.empty[Element]
       val usedNames = scala.collection.mutable.Set.empty[String]
+      val javadocNames = scala.collection.mutable.Set.empty[String]
 
-      val javadocNames = namesUsedInJavadocs(text)
       val scanner = new TreePathScanner[Unit, Unit] {
         override def visitImport(node: ImportTree, p: Unit): Unit = ()
+
+        override def visitClass(node: ClassTree, p: Unit): Unit = {
+          addJavadocReferences(getCurrentPath(), javadocNames)
+          super.visitClass(node, p)
+        }
 
         override def visitIdentifier(
             node: IdentifierTree,
@@ -48,6 +65,16 @@ private class UnusedImportDiagnosticProvider(
           usedNames += node.getName().toString()
           addElement(getCurrentPath(), usedElements)
           super.visitIdentifier(node, p)
+        }
+
+        override def visitMethod(node: MethodTree, p: Unit): Unit = {
+          addJavadocReferences(getCurrentPath(), javadocNames)
+          super.visitMethod(node, p)
+        }
+
+        override def visitVariable(node: VariableTree, p: Unit): Unit = {
+          addJavadocReferences(getCurrentPath(), javadocNames)
+          super.visitVariable(node, p)
         }
       }
       scanner.scan(compile.cu, ())
@@ -59,7 +86,7 @@ private class UnusedImportDiagnosticProvider(
               !info.isUsed(
                 usedElements.toSet,
                 usedNames.toSet,
-                javadocNames
+                javadocNames.toSet
               ) =>
           val importTree = info.tree
           diagnostic(importTree)
@@ -70,30 +97,38 @@ private class UnusedImportDiagnosticProvider(
   private def packageName: Option[String] =
     Option(compile.cu.getPackageName()).map(_.toString())
 
-  private def namesUsedInJavadocs(text: String): Set[String] = {
-    val names = Set.newBuilder[String]
-    for {
-      commentMatch <- UnusedImportDiagnosticProvider.JavadocCommentRegex
-        .findAllMatchIn(text)
-      comment = commentMatch.matched
-      reference <- UnusedImportDiagnosticProvider.InlineJavadocReferenceRegex
-        .findAllMatchIn(comment)
-    } addJavadocReference(reference.group(1), names)
+  private def hasError(importTree: ImportTree): Boolean = {
+    val start = sourcePositions.getStartPosition(compile.cu, importTree)
+    val end = sourcePositions.getEndPosition(compile.cu, importTree)
+    if (start < 0 || end < 0) false
+    else {
+      compile.listener.diagnostics.exists { d =>
+        val diagnosticStart = d.getPosition()
+        val diagnosticEnd = math.max(diagnosticStart, d.getEndPosition())
+        val sameSource =
+          d.getSource() != null && d.getSource().toUri() == sourceUri
+        val overlapsImport =
+          diagnosticStart <= end && diagnosticEnd >= start
 
-    for {
-      commentMatch <- UnusedImportDiagnosticProvider.JavadocCommentRegex
-        .findAllMatchIn(text)
-      comment = commentMatch.matched
-      reference <- UnusedImportDiagnosticProvider.SeeJavadocReferenceRegex
-        .findAllMatchIn(comment)
-    } addJavadocReference(reference.group(1), names)
-
-    names.result()
+        d.getKind() == ERROR && sameSource && overlapsImport
+      }
+    }
   }
+
+  private def addJavadocReferences(
+      path: TreePath,
+      names: scala.collection.mutable.Set[String]
+  ): Unit =
+    for {
+      docComment <- Option(docTrees.getDocCommentTree(path))
+      comment = docComment.toString()
+      regex <- UnusedImportDiagnosticProvider.JavadocReferenceRegexes
+      reference <- regex.findAllMatchIn(comment)
+    } addJavadocReference(reference.group(1), names)
 
   private def addJavadocReference(
       signature: String,
-      names: scala.collection.mutable.Builder[String, Set[String]]
+      names: scala.collection.mutable.Set[String]
   ): Unit = {
     val withoutMember = signature.takeWhile(_ != '#')
     val withoutParams = withoutMember.takeWhile(_ != '(')
@@ -111,8 +146,8 @@ private class UnusedImportDiagnosticProvider(
     Option(trees.getElement(path)).foreach(usedElements += _)
 
   private def element(tree: Tree): Option[Element] = {
-    val path = new TreePath(new TreePath(compile.cu), tree)
-    Option(trees.getElement(path))
+    Option(trees.getPath(compile.cu, tree))
+      .flatMap(path => Option(trees.getElement(path)))
   }
 
   private def diagnostic(importTree: ImportTree): l.Diagnostic = {
@@ -130,10 +165,11 @@ private class UnusedImportDiagnosticProvider(
 
 object UnusedImportDiagnosticProvider {
   val UnusedImportCode = "unused-import"
-  private val JavadocCommentRegex = """(?s)/\*\*.*?\*/""".r
   private val InlineJavadocReferenceRegex =
     """\{@(?:link|linkplain|value)\s+([^\s#(}]+)""".r
   private val SeeJavadocReferenceRegex = """@see\s+([^\s#(]+)""".r
+  private val JavadocReferenceRegexes =
+    List(InlineJavadocReferenceRegex, SeeJavadocReferenceRegex)
 
   private case class ImportInfo(
       tree: ImportTree,

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/UnusedImportDiagnosticProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/UnusedImportDiagnosticProvider.scala
@@ -1,0 +1,214 @@
+package scala.meta.internal.jpc
+
+import javax.lang.model.element.Element
+import javax.lang.model.element.QualifiedNameable
+
+import scala.jdk.CollectionConverters._
+
+import com.sun.source.tree.IdentifierTree
+import com.sun.source.tree.ImportTree
+import com.sun.source.tree.Tree
+import com.sun.source.util.TreePath
+import com.sun.source.util.TreePathScanner
+import com.sun.source.util.Trees
+import org.eclipse.{lsp4j => l}
+
+private class UnusedImportDiagnosticProvider(
+    compile: JavaSourceCompile,
+    text: String
+) {
+
+  private val task = compile.task
+  private val trees = Trees.instance(task)
+
+  def diagnostics(): List[l.Diagnostic] = {
+    val seen = scala.collection.mutable.Set.empty[String]
+
+    val imports = compile.cu.getImports().asScala.toList.map { importTree =>
+      val info = UnusedImportDiagnosticProvider.ImportInfo(
+        importTree,
+        element(importTree.getQualifiedIdentifier())
+      )
+      info.copy(isDuplicate = !seen.add(info.normalized))
+    }
+
+    if (imports.isEmpty) Nil
+    else {
+      val usedElements = scala.collection.mutable.Set.empty[Element]
+      val usedNames = scala.collection.mutable.Set.empty[String]
+
+      val javadocNames = namesUsedInJavadocs(text)
+      val scanner = new TreePathScanner[Unit, Unit] {
+        override def visitImport(node: ImportTree, p: Unit): Unit = ()
+
+        override def visitIdentifier(
+            node: IdentifierTree,
+            p: Unit
+        ): Unit = {
+          usedNames += node.getName().toString()
+          addElement(getCurrentPath(), usedElements)
+          super.visitIdentifier(node, p)
+        }
+      }
+      scanner.scan(compile.cu, ())
+
+      imports.collect {
+        case info
+            if info.isRedundant(packageName) ||
+              info.isDuplicate ||
+              !info.isUsed(
+                usedElements.toSet,
+                usedNames.toSet,
+                javadocNames
+              ) =>
+          val importTree = info.tree
+          diagnostic(importTree)
+      }
+    }
+  }
+
+  private def packageName: Option[String] =
+    Option(compile.cu.getPackageName()).map(_.toString())
+
+  private def namesUsedInJavadocs(text: String): Set[String] = {
+    val names = Set.newBuilder[String]
+    for {
+      commentMatch <- UnusedImportDiagnosticProvider.JavadocCommentRegex
+        .findAllMatchIn(text)
+      comment = commentMatch.matched
+      reference <- UnusedImportDiagnosticProvider.InlineJavadocReferenceRegex
+        .findAllMatchIn(comment)
+    } addJavadocReference(reference.group(1), names)
+
+    for {
+      commentMatch <- UnusedImportDiagnosticProvider.JavadocCommentRegex
+        .findAllMatchIn(text)
+      comment = commentMatch.matched
+      reference <- UnusedImportDiagnosticProvider.SeeJavadocReferenceRegex
+        .findAllMatchIn(comment)
+    } addJavadocReference(reference.group(1), names)
+
+    names.result()
+  }
+
+  private def addJavadocReference(
+      signature: String,
+      names: scala.collection.mutable.Builder[String, Set[String]]
+  ): Unit = {
+    val withoutMember = signature.takeWhile(_ != '#')
+    val withoutParams = withoutMember.takeWhile(_ != '(')
+    val name = withoutParams.stripSuffix("[]").trim()
+    if (name.nonEmpty) {
+      names += name
+      names += name.split('.').last
+    }
+  }
+
+  private def addElement(
+      path: TreePath,
+      usedElements: scala.collection.mutable.Set[Element]
+  ): Unit =
+    Option(trees.getElement(path)).foreach(usedElements += _)
+
+  private def element(tree: Tree): Option[Element] = {
+    val path = new TreePath(new TreePath(compile.cu), tree)
+    Option(trees.getElement(path))
+  }
+
+  private def diagnostic(importTree: ImportTree): l.Diagnostic = {
+    val range = Positions.toLspRange(trees, compile.cu, importTree)
+    val diagnostic = new l.Diagnostic(
+      range,
+      "unused import",
+      l.DiagnosticSeverity.Warning,
+      "javac"
+    )
+    diagnostic.setCode(UnusedImportDiagnosticProvider.UnusedImportCode)
+    diagnostic
+  }
+}
+
+object UnusedImportDiagnosticProvider {
+  val UnusedImportCode = "unused-import"
+  private val JavadocCommentRegex = """(?s)/\*\*.*?\*/""".r
+  private val InlineJavadocReferenceRegex =
+    """\{@(?:link|linkplain|value)\s+([^\s#(}]+)""".r
+  private val SeeJavadocReferenceRegex = """@see\s+([^\s#(]+)""".r
+
+  private case class ImportInfo(
+      tree: ImportTree,
+      isStatic: Boolean,
+      isWildcard: Boolean,
+      owner: String,
+      name: String,
+      fullName: String,
+      normalized: String,
+      element: Option[Element],
+      isDuplicate: Boolean
+  ) {
+    def isRedundant(packageName: Option[String]): Boolean =
+      !isStatic &&
+        (owner == "java.lang" || packageName.contains(owner))
+
+    def isUsed(
+        usedElements: Set[Element],
+        usedNames: Set[String],
+        javadocNames: Set[String]
+    ): Boolean =
+      if (isWildcard) {
+        usedElements.exists { element =>
+          val usedOwner =
+            if (isStatic)
+              UnusedImportDiagnosticProvider.enclosingName(element)
+            else UnusedImportDiagnosticProvider.name(element)
+          usedOwner.exists(name =>
+            name == owner || name.startsWith(owner + ".")
+          )
+        }
+      } else {
+        element.exists(usedElements.contains) ||
+        (isStatic && usedNames.contains(name)) ||
+        javadocNames.exists(name => name == this.name || name == fullName)
+      }
+  }
+
+  private object ImportInfo {
+    def apply(tree: ImportTree, element: Option[Element]): ImportInfo = {
+      val importText = tree.getQualifiedIdentifier().toString()
+      val isWildcard = importText.endsWith(".*")
+      val withoutWildcard =
+        if (isWildcard) importText.stripSuffix(".*") else importText
+      val (owner, name) =
+        if (isWildcard) withoutWildcard -> "*"
+        else {
+          val lastDot = withoutWildcard.lastIndexOf(".")
+          if (lastDot >= 0)
+            withoutWildcard.substring(0, lastDot) ->
+              withoutWildcard.substring(lastDot + 1)
+          else "" -> withoutWildcard
+        }
+      val normalized = s"${tree.isStatic()}:$importText"
+      ImportInfo(
+        tree,
+        tree.isStatic(),
+        isWildcard,
+        owner,
+        name,
+        withoutWildcard,
+        normalized,
+        element,
+        isDuplicate = false
+      )
+    }
+  }
+
+  private def name(element: Element): Option[String] =
+    element match {
+      case qualified: QualifiedNameable =>
+        Some(qualified.getQualifiedName().toString())
+      case _ => None
+    }
+
+  private def enclosingName(element: Element): Option[String] =
+    Option(element.getEnclosingElement()).flatMap(name)
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/UnusedImportDiagnosticProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/UnusedImportDiagnosticProvider.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.jpc
 
 import javax.lang.model.element.Element
 import javax.lang.model.element.QualifiedNameable
+import javax.lang.model.element.TypeElement
 import javax.tools.Diagnostic.Kind.ERROR
 
 import scala.jdk.CollectionConverters._
@@ -9,6 +10,7 @@ import scala.jdk.CollectionConverters._
 import com.sun.source.tree.ClassTree
 import com.sun.source.tree.IdentifierTree
 import com.sun.source.tree.ImportTree
+import com.sun.source.tree.MemberSelectTree
 import com.sun.source.tree.MethodTree
 import com.sun.source.tree.Tree
 import com.sun.source.tree.VariableTree
@@ -24,6 +26,7 @@ private class UnusedImportDiagnosticProvider(
 
   private val task = compile.task
   private val trees = Trees.instance(task)
+  private val elements = task.getElements()
   private val docTrees = DocTrees.instance(task)
   private val sourcePositions = trees.getSourcePositions()
   private val sourceUri = compile.cu.getSourceFile().toUri()
@@ -39,15 +42,14 @@ private class UnusedImportDiagnosticProvider(
       .map { importTree =>
         val info = UnusedImportDiagnosticProvider.ImportInfo(
           importTree,
-          element(importTree.getQualifiedIdentifier())
+          matchElements(importTree)
         )
-        info.copy(isDuplicate = !seen.add(info.normalized))
+        info.copy(isDuplicate = !seen.add(info.fullName))
       }
 
     if (imports.isEmpty) Nil
     else {
       val usedElements = scala.collection.mutable.Set.empty[Element]
-      val usedNames = scala.collection.mutable.Set.empty[String]
       val javadocNames = scala.collection.mutable.Set.empty[String]
 
       val scanner = new TreePathScanner[Unit, Unit] {
@@ -62,7 +64,6 @@ private class UnusedImportDiagnosticProvider(
             node: IdentifierTree,
             p: Unit
         ): Unit = {
-          usedNames += node.getName().toString()
           addElement(getCurrentPath(), usedElements)
           super.visitIdentifier(node, p)
         }
@@ -85,7 +86,6 @@ private class UnusedImportDiagnosticProvider(
               info.isDuplicate ||
               !info.isUsed(
                 usedElements.toSet,
-                usedNames.toSet,
                 javadocNames.toSet
               ) =>
           val importTree = info.tree
@@ -150,6 +150,29 @@ private class UnusedImportDiagnosticProvider(
       .flatMap(path => Option(trees.getElement(path)))
   }
 
+  /**
+   * The elements whose presence in `usedElements` means an import is used.
+   */
+  private def matchElements(importTree: ImportTree): Set[Element] = {
+    val qualifiedIdentifier = importTree.getQualifiedIdentifier()
+    if (!importTree.isStatic()) element(qualifiedIdentifier).toSet
+    else
+      qualifiedIdentifier match {
+        case select: MemberSelectTree =>
+          val name = select.getIdentifier().toString()
+          element(select.getExpression()) match {
+            case Some(owner: TypeElement) =>
+              elements
+                .getAllMembers(owner)
+                .asScala
+                .filter(_.getSimpleName().toString() == name)
+                .toSet
+            case _ => Set.empty
+          }
+        case _ => Set.empty
+      }
+  }
+
   private def diagnostic(importTree: ImportTree): l.Diagnostic = {
     val range = Positions.toLspRange(trees, compile.cu, importTree)
     val diagnostic = new l.Diagnostic(
@@ -178,8 +201,7 @@ object UnusedImportDiagnosticProvider {
       owner: String,
       name: String,
       fullName: String,
-      normalized: String,
-      element: Option[Element],
+      matchElements: Set[Element],
       isDuplicate: Boolean
   ) {
     def isRedundant(packageName: Option[String]): Boolean =
@@ -188,28 +210,20 @@ object UnusedImportDiagnosticProvider {
 
     def isUsed(
         usedElements: Set[Element],
-        usedNames: Set[String],
         javadocNames: Set[String]
     ): Boolean =
       if (isWildcard) {
         usedElements.exists { element =>
-          val usedOwner =
-            if (isStatic)
-              UnusedImportDiagnosticProvider.enclosingName(element)
-            else UnusedImportDiagnosticProvider.name(element)
-          usedOwner.exists(name =>
-            name == owner || name.startsWith(owner + ".")
-          )
+          UnusedImportDiagnosticProvider.enclosingName(element).contains(owner)
         }
       } else {
-        element.exists(usedElements.contains) ||
-        (isStatic && usedNames.contains(name)) ||
+        matchElements.exists(usedElements.contains) ||
         javadocNames.exists(name => name == this.name || name == fullName)
       }
   }
 
   private object ImportInfo {
-    def apply(tree: ImportTree, element: Option[Element]): ImportInfo = {
+    def apply(tree: ImportTree, matchElements: Set[Element]): ImportInfo = {
       val importText = tree.getQualifiedIdentifier().toString()
       val isWildcard = importText.endsWith(".*")
       val withoutWildcard =
@@ -223,7 +237,6 @@ object UnusedImportDiagnosticProvider {
               withoutWildcard.substring(lastDot + 1)
           else "" -> withoutWildcard
         }
-      val normalized = s"${tree.isStatic()}:$importText"
       ImportInfo(
         tree,
         tree.isStatic(),
@@ -231,8 +244,7 @@ object UnusedImportDiagnosticProvider {
         owner,
         name,
         withoutWildcard,
-        normalized,
-        element,
+        matchElements,
         isDuplicate = false
       )
     }

--- a/tests/unit/src/test/scala/tests/codeactions/RemoveUnusedJavaImportLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/RemoveUnusedJavaImportLspSuite.scala
@@ -173,6 +173,26 @@ class RemoveUnusedJavaImportLspSuite
   )
 
   check(
+    "multiline-import",
+    """|package a;
+       |
+       |<<import java.util.
+       |  Map;>>
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
     "wildcard-import",
     """|package a;
        |

--- a/tests/unit/src/test/scala/tests/codeactions/RemoveUnusedJavaImportLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/RemoveUnusedJavaImportLspSuite.scala
@@ -357,6 +357,33 @@ class RemoveUnusedJavaImportLspSuite
     filterAction = onlyRemoveUnusedImport,
   )
 
+  check(
+    "member-type-shadows-import",
+    """|package a;
+       |
+       |<<import java.util.List;>>
+       |
+       |public class Example {
+       |  static class List {
+       |  }
+       |
+       |  public List names;
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |  static class List {
+       |  }
+       |
+       |  public List names;
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
   checkNoAction(
     "javadoc-only",
     """|package a;

--- a/tests/unit/src/test/scala/tests/codeactions/RemoveUnusedJavaImportLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/RemoveUnusedJavaImportLspSuite.scala
@@ -358,6 +358,30 @@ class RemoveUnusedJavaImportLspSuite
   )
 
   check(
+    "duplicate-static-nested-type-import",
+    """|package a;
+       |
+       |import java.util.Map.Entry;
+       |<<import static java.util.Map.Entry;>>
+       |
+       |public class Example {
+       |  public Entry entry;
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |import java.util.Map.Entry;
+       |
+       |public class Example {
+       |  public Entry entry;
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
     "member-type-shadows-import",
     """|package a;
        |

--- a/tests/unit/src/test/scala/tests/codeactions/RemoveUnusedJavaImportLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/RemoveUnusedJavaImportLspSuite.scala
@@ -1,0 +1,360 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.codeactions.RemoveUnusedJavaImport
+
+import tests.MbtJsonBuilder
+import tests.MbtTestInitializer
+
+class RemoveUnusedJavaImportLspSuite
+    extends BaseCodeActionLspSuite(
+      "remove-unused-java-import",
+      MbtTestInitializer,
+      useMbtLayout = true,
+    ) {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(presentationCompilerDiagnostics = true)
+
+  override protected def toPath(
+      fileName: String,
+      isSource: Boolean = true,
+  ): String =
+    if (isSource) s"a/src/main/java/a/$fileName"
+    else s"a/$fileName"
+
+  private val onlyRemoveUnusedImport: org.eclipse.lsp4j.CodeAction => Boolean =
+    _.getTitle() == RemoveUnusedJavaImport.title
+
+  private def title: String =
+    s"""|${RemoveUnusedJavaImport.title}
+        |""".stripMargin
+
+  check(
+    "basic",
+    """|package a;
+       |
+       |import java.util.List;
+       |<<import java.util.Map;>>
+       |
+       |public class Example {
+       |  public List<String> names;
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |import java.util.List;
+       |
+       |public class Example {
+       |  public List<String> names;
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  checkNoAction(
+    "used",
+    """|package a;
+       |
+       |<<import java.util.List;>>
+       |
+       |public class Example {
+       |  public List<String> names;
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
+    "static-import",
+    """|package a;
+       |
+       |import static java.lang.Math.PI;
+       |<<import static java.lang.Math.max;>>
+       |
+       |public class Example {
+       |  public double getPi() { return PI; }
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |import static java.lang.Math.PI;
+       |
+       |public class Example {
+       |  public double getPi() { return PI; }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
+    "multiple-unused",
+    """|package a;
+       |
+       |<<import java.util.Map;>>
+       |import java.util.Set;
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |import java.util.Set;
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    expectNoDiagnostics = false,
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
+    "inner-class",
+    """|package a;
+       |
+       |<<import java.util.Map.Entry;>>
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
+    "with-inline-comment",
+    """|package a;
+       |
+       |<<import java.util.List; // this is unused>>
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
+    "block-comment",
+    """|package a;
+       |
+       |<<import java.util. /* unused */ Map;>>
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
+    "wildcard-import",
+    """|package a;
+       |
+       |<<import java.util.*;>>
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  checkNoAction(
+    "wildcard-import-used",
+    """|package a;
+       |
+       |<<import java.util.*;>>
+       |
+       |public class Example {
+       |  public List<String> names;
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
+    "static-wildcard-import",
+    """|package a;
+       |
+       |<<import static java.lang.Math.*;>>
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  checkNoAction(
+    "static-wildcard-import-used",
+    """|package a;
+       |
+       |<<import static java.lang.Math.*;>>
+       |
+       |public class Example {
+       |  public int maxValue() { return max(1, 2); }
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
+    "no-package",
+    """|<<import java.util.List;>>
+       |
+       |public class Example {
+       |}
+       |""".stripMargin,
+    title,
+    """|public class Example {
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
+    "java-lang-redundant",
+    """|package a;
+       |
+       |<<import java.lang.String;>>
+       |
+       |public class Example {
+       |  public String name;
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |  public String name;
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  check(
+    "same-package-redundant",
+    """|package a;
+       |
+       |<<import a.Helper;>>
+       |
+       |public class Example {
+       |  public Helper helper;
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |public class Example {
+       |  public Helper helper;
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+    overrideLayout = Some(
+      s"""|/.metals/mbt.json
+          |$mbtJson
+          |/a/src/main/java/a/Helper.java
+          |package a;
+          |
+          |public class Helper {
+          |}
+          |/a/src/main/java/a/Example.java
+          |package a;
+          |
+          |<<import a.Helper;>>
+          |
+          |public class Example {
+          |  public Helper helper;
+          |}
+          |""".stripMargin
+    ),
+  )
+
+  check(
+    "duplicate-import",
+    """|package a;
+       |
+       |import java.util.List;
+       |<<import java.util.List;>>
+       |
+       |public class Example {
+       |  public List<String> names;
+       |}
+       |""".stripMargin,
+    title,
+    """|package a;
+       |
+       |import java.util.List;
+       |
+       |public class Example {
+       |  public List<String> names;
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  checkNoAction(
+    "javadoc-only",
+    """|package a;
+       |
+       |<<import java.util.Map;>>
+       |
+       |/**
+       | * Returns data as a {@link Map}.
+       | */
+       |public class Example {
+       |}
+       |""".stripMargin,
+    fileName = "Example.java",
+    filterAction = onlyRemoveUnusedImport,
+  )
+
+  private def mbtJson: String =
+    new MbtJsonBuilder(scalaVersion)
+      .addNamespace("a", List("a/src/main/java/**", "a/src/main/scala/**"))
+      .build()
+}

--- a/tests/unit/src/test/scala/tests/j/JavaPCDiagnosticsSuite.scala
+++ b/tests/unit/src/test/scala/tests/j/JavaPCDiagnosticsSuite.scala
@@ -66,6 +66,38 @@ class JavaPCDiagnosticsSuite extends BaseJavaPCSuite("java-pc-diagnostics") {
     } yield ()
   }
 
+  test("unused-import") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |/a/src/main/java/a/UnusedImport.java
+           |package a;
+           |
+           |import java.util.List;
+           |import java.util.Map;
+           |
+           |public class UnusedImport {
+           |  public List<String> names;
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/java/a/UnusedImport.java")
+      _ <- server.didFocus("a/src/main/java/a/UnusedImport.java")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/java/a/UnusedImport.java:4:1: warning: unused import
+           |import java.util.Map;
+           |^^^^^^^^^^^^^^^^^^^^^
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
   test("introduce-type-error") {
     cleanWorkspace()
     for {

--- a/tests/unit/src/test/scala/tests/p/ProtoPCJavaSuite.scala
+++ b/tests/unit/src/test/scala/tests/p/ProtoPCJavaSuite.scala
@@ -1166,8 +1166,6 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |/a/src/main/java/com/example/GreeterService.java
            |package com.example;
            |import com.example.api.jproto.GreeterGrpc;
-           |import com.example.api.jproto.HelloRequest;
-           |import com.example.api.jproto.HelloReply;
            |public class GreeterService {
            |  public static Class<?> grpcClass() { return GreeterGrpc.class; }
            |}


### PR DESCRIPTION
Part of https://github.com/scalameta/metals/issues/8502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unused Java import detection, surfaced as `warning: unused import` diagnostics.
  * Introduced a Java quick fix, **Remove unused import**, to delete the unused import with appropriate surrounding blank-line cleanup.

* **Bug Fixes**
  * Improved unused-import diagnostics and quick-fix eligibility, including redundant and duplicate imports, wildcard/static imports, shadowing cases, and Javadoc-referenced usage.
  * Made diagnostics generation more resilient when optional diagnostic computations fail.

* **Tests**
  * Added unit and LSP suite coverage for `unused-import` and the remove-unused-java-import quick fix.
  * Updated a Java fixture to remove now-unused imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->