### PR TITLE
Exclude module-info.java from indexing in workspace symbol provider

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -53,6 +53,7 @@ import scala.meta.internal.metals.formatting.OnTypeFormattingProvider
 import scala.meta.internal.metals.formatting.RangeFormattingProvider
 import scala.meta.internal.metals.mbt.MbtBuild
 import scala.meta.internal.metals.mbt.MbtBuildServer
+import scala.meta.internal.metals.mbt.MbtIndexFilter
 import scala.meta.internal.metals.mbt.MbtReferenceProvider
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
 import scala.meta.internal.metals.newScalaFile.NewFileProvider
@@ -361,10 +362,7 @@ abstract class MetalsLspService(
     fallbackClasspaths = () => compilers.fallbackClasspaths,
     sleeper = sleeper,
     turbineRecompileDelay = () => userConfig.javaTurbineRecompileDelay,
-    indexFilters = List(
-      mbt.ProtobufVersionHistoryIndexFilter,
-      mbt.ProtobufTemplateAndTestIndexFilter,
-    ),
+    indexFilters = MbtIndexFilter.allFilters,
     protobufLspConfig = () => userConfig.protobufLspConfig,
     metalsOutDir = Some(embedded.targetDir),
     mbtBuild = () => mbtBuild,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/JavaModuleInfoIndexFilter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/JavaModuleInfoIndexFilter.scala
@@ -1,0 +1,15 @@
+package scala.meta.internal.metals.mbt
+
+import java.nio.file.FileSystems
+
+object JavaModuleInfoIndexFilter extends MbtIndexFilter {
+  private val matcher = FileSystems.getDefault.getPathMatcher(
+    "glob:**/module-info.java"
+  )
+
+  override def decide(candidate: MbtFileCandidate): MbtIndexDecision =
+    if (matcher.matches(candidate.path.toNIO))
+      MbtIndexDecision.Skip
+    else
+      MbtIndexDecision.Continue
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtIndexFilter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtIndexFilter.scala
@@ -6,12 +6,8 @@ import scala.meta.io.AbsolutePath
  * Represents a candidate file being considered for indexing.
  *
  * @param path The absolute path to the file
- * @param relativePath The path relative to the workspace root
  */
-case class MbtFileCandidate(
-    path: AbsolutePath,
-    relativePath: String,
-)
+case class MbtFileCandidate(path: AbsolutePath)
 
 /**
  * Decision returned by an index filter.
@@ -39,4 +35,16 @@ object MbtIndexFilter {
 
   /** Default filter that includes all files. */
   val IncludeAll: MbtIndexFilter = _ => MbtIndexDecision.Continue
+
+  val allFilters: List[MbtIndexFilter] = List(
+    ProtobufVersionHistoryIndexFilter,
+    ProtobufTemplateAndTestIndexFilter,
+    JavaModuleInfoIndexFilter,
+  )
+
+  def included(
+      filters: List[MbtIndexFilter],
+      candidate: MbtFileCandidate,
+  ): Boolean =
+    filters.forall(_.decide(candidate) == MbtIndexDecision.Continue)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -105,10 +105,7 @@ class MbtWorkspaceSymbolProvider(
     sleeper: Sleeper = Sleeper.TestingSleeper,
     turbineRecompileDelay: () => TurbineRecompileDelayConfig = () =>
       TurbineRecompileDelayConfig.fromConfig(None),
-    indexFilters: List[MbtIndexFilter] = List(
-      ProtobufVersionHistoryIndexFilter,
-      ProtobufTemplateAndTestIndexFilter,
-    ),
+    indexFilters: List[MbtIndexFilter] = MbtIndexFilter.allFilters,
     protobufLspConfig: () => ProtobufLspConfig = () =>
       ProtobufLspConfig.default,
     metalsOutDir: Option[Path] = None,
@@ -256,8 +253,8 @@ class MbtWorkspaceSymbolProvider(
     val toIndex = ParArray.fromSpecific(for {
       file <- files
       path = workspace.resolve(file.path)
-      candidate = MbtFileCandidate(path, file.path)
-      if indexFilters.forall(_.decide(candidate) == MbtIndexDecision.Continue)
+      candidate = MbtFileCandidate(path)
+      if MbtIndexFilter.included(indexFilters, candidate)
       isCached = documents.get(path).exists(_.oid == file.oid)
       if !isCached
     } yield path)
@@ -423,17 +420,19 @@ class MbtWorkspaceSymbolProvider(
       file: AbsolutePath,
       updateDocumentKeys: Boolean,
   ): Future[Unit] = try {
-    val enableProtoJavaPackage =
-      file.isProtoFilename && protobufWorkspace.isJavaPackageIndexingEnabled
-    val mdoc =
-      IndexedDocument.fromFile(
-        file,
-        mtags(),
-        buffers,
-        dialects.Scala3,
-        enableProtoJavaPackage = enableProtoJavaPackage,
-      )
-    putDocument(file, mdoc, updateDocumentKeys = updateDocumentKeys)
+    if (MbtIndexFilter.included(indexFilters, MbtFileCandidate(file))) {
+      val enableProtoJavaPackage =
+        file.isProtoFilename && protobufWorkspace.isJavaPackageIndexingEnabled
+      val mdoc =
+        IndexedDocument.fromFile(
+          file,
+          mtags(),
+          buffers,
+          dialects.Scala3,
+          enableProtoJavaPackage = enableProtoJavaPackage,
+        )
+      putDocument(file, mdoc, updateDocumentKeys = updateDocumentKeys)
+    } else Future.unit
   } catch {
     case _: NoSuchFileException =>
       onDidDelete(file)
@@ -894,7 +893,7 @@ class MbtWorkspaceSymbolProvider(
     // .metals/out contains JDK sources materialized for --patch-module; they are not workspace sources
     if (metalsOutDir.exists(outDir => file.toNIO.startsWith(outDir))) {
       Future.unit
-    } else {
+    } else if (MbtIndexFilter.included(indexFilters, MbtFileCandidate(file))) {
       val old = documents.put(file, doc)
       if (old == None && updateDocumentKeys) {
         updateDocumentsKeys(documents)
@@ -920,7 +919,7 @@ class MbtWorkspaceSymbolProvider(
       } else {
         Future.unit
       }
-    }
+    } else Future.unit
   }
 
   private def addDocumentToPackages(

--- a/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
@@ -2,7 +2,9 @@ package tests.mbt
 
 import java.nio.file.Files
 
+import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 import scala.meta.internal.metals.Configs
 import scala.meta.internal.metals.mbt.IndexingStats
@@ -149,6 +151,49 @@ object Hello2 {
         |Method main2 com.Hello2.
         |""".stripMargin,
     )
+  }
+
+  test("exclude-module-info-java") {
+    FileLayout.fromString(
+      """
+/com/Hello.java
+package com;
+public class Hello {}
+/module-info.java
+module com.example {
+  requires java.base;
+  exports com;
+}
+""",
+      root = workspace(),
+    )
+    val provider = newProvider()
+    workspace.executeCommand("git init -b main")
+    workspace.gitCommitAllChanges()
+    val stats = provider.onReindex().awaitBackgroundJobs()
+    assertEquals(stats, IndexingStats(totalFiles = 2, updatedFiles = 1))
+    assertEquals(
+      provider.allFiles().map(_.toRelative(workspace()).toString()),
+      List("com/Hello.java"),
+    )
+  }
+
+  test("exclude-module-info-java-on-did-change") {
+    FileLayout.fromString(
+      """
+/module-info.java
+module com.example {
+  requires java.base;
+}
+""",
+      root = workspace(),
+    )
+    val provider = newProvider()
+    Await.result(
+      provider.onDidChange(workspace().resolve("module-info.java")),
+      5.seconds,
+    )
+    assertEquals(provider.allFiles(), Nil)
   }
 
   def manuallyTestWorkspace(


### PR DESCRIPTION
module-info.java could overflow the bloom filter, e.g.:

    bloom filter is full for
    [...]/elasticsearch/server/src/main/java/module-info.java

Filtering only applies when writing new indexes - indexes already saved by previous Metals versions are not deleted or re-filtered on read. Deleting .metals directory should fix the corrupted IDE state. Introducing additional filtering mechanisms during the loading process may be excessive. 

Remove the unused `relativePath` field from `MbtFileCandidate`.
Going
Fixes #8615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace symbol indexing now includes the full set of supported MBT filters by default.
  * Java `module-info.java` files are now excluded from MBT workspace indexing.

* **Bug Fixes**
  * Changed file updates are now ignored when they don’t match the active indexing filters, reducing unnecessary reindexing.
  * Incremental indexing now behaves more consistently for excluded files during file changes and saves.

* **Tests**
  * Added coverage for excluding `module-info.java` during indexing and change handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->