### PR TITLE
Simplified interface for CompilerWrapper

### DIFF
--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaMetalsCompilerWrapper.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaMetalsCompilerWrapper.scala
@@ -12,10 +12,6 @@ class JavaMetalsCompilerWrapper(factory: () => JavaMetalsCompiler)
     override def reporter: Unit = ()
   }
 
-  override def askShutdown(): Unit = {
-    stop()
-  }
-
   override def isAlive(): Boolean = _compiler != null
 
   override def stop(): Unit = {

--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
@@ -61,7 +61,7 @@ abstract class CompilerAccess[Reporter, Compiler](
   def shutdownCurrentCompiler(): Unit = {
     val compiler = _compiler
     if (compiler != null) {
-      compiler.askShutdown()
+      compiler.stop()
       _compiler = null
       sh.foreach { scheduler =>
         scheduler.schedule[Unit](

--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/CompilerWrapper.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/CompilerWrapper.scala
@@ -8,8 +8,6 @@ trait CompilerWrapper[Reporter, Compiler] {
 
   def reporterAccess: ReporterAccess[Reporter]
 
-  def askShutdown(): Unit
-
   def isAlive(): Boolean
 
   def stop(): Unit

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaCompilerAccess.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaCompilerAccess.scala
@@ -28,16 +28,12 @@ class ScalaCompilerWrapper(global: MetalsGlobal)
       def reporter = global.reporter.asInstanceOf[MetalsReporter]
     }
 
-  override def askShutdown(): Unit = {
+  override def stop(): Unit = {
     global.askShutdown()
   }
 
   override def isAlive(): Boolean = {
     global.presentationCompilerThread.isAlive()
-  }
-
-  override def stop(): Unit = {
-    global.presentationCompilerThread.stop()
   }
 
   override def presentationCompilerThread: Option[Thread] = {


### PR DESCRIPTION
Currently scala.meta.internal.pc.CompilerWrapper has just two implementations. 

In JavaMetalsCompilerWrapper, the method askShutdown() just deferred to stop(), so the two methods did exactly the same thing. In ScalaCompilerWrapper, the method stop() called the deprecated method java.lang.Thread.stop(), which [always fails](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/lang/Thread.html#stop()) in Java 20 and later. 

I decided to merge these two methods into one, and chose the shorter one of the two names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler shutdown behavior to be more consistent and reliable.
  * Reduced the risk of abrupt termination by using the standard shutdown flow.
* **Refactor**
  * Simplified internal shutdown handling across compiler wrappers.
  * Removed redundant wrapper-specific shutdown logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->