### PR TITLE
Avoid infix and postfix syntax in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -228,9 +228,9 @@ val sharedSettings = sharedJavacOptions ++ sharedScalacOptions ++ List(
     scalaVersion.value,
     if2 = List(
       compilerPlugin(
-        "org.scalameta" % "semanticdb-scalac" % V.semanticdb(
+        ("org.scalameta" % "semanticdb-scalac" % V.semanticdb(
           scalaVersion.value
-        ) cross CrossVersion.full
+        )).cross(CrossVersion.full)
       )
     ),
   ),
@@ -359,9 +359,9 @@ val mtagsSettings = List(
       if2 = List(
         // for token edit-distance used by goto definition
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
-        "org.scalameta" % "semanticdb-scalac-core" % V.semanticdb(
+        ("org.scalameta" % "semanticdb-scalac-core" % V.semanticdb(
           scalaVersion.value
-        ) cross CrossVersion.full,
+        )).cross(CrossVersion.full),
       ),
       if3 = List(
         "org.scala-lang" %% "scala3-compiler" % scalaVersion.value,
@@ -464,9 +464,9 @@ lazy val metals = project
       "com.lihaoyi" %% "requests" % "0.9.3",
       // for producing SemanticDB from Scala source files, to be sure we want the same version of scalameta
       "org.scalameta" %% "scalameta" % V.semanticdb(scalaVersion.value),
-      "org.scalameta" %% "semanticdb-metap" % V.semanticdb(
+      ("org.scalameta" %% "semanticdb-metap" % V.semanticdb(
         scalaVersion.value
-      ) cross CrossVersion.full,
+      )).cross(CrossVersion.full),
       "org.scalameta" %% "semanticdb-shared" % V.semanticdb(scalaVersion.value),
       "org.scala-lang.modules" %% "scala-xml" % "2.4.0",
       ("org.virtuslab.scala-cli" % "scala-cli-bsp" % V.scalaCli)
@@ -762,13 +762,13 @@ lazy val metalsDependencies = project
       "com.olegpy" %% "better-monadic-for" % V.betterMonadicFor,
       ("com.lihaoyi" % "mill-contrib-testng" % V.mill)
         .exclude("com.lihaoyi", "unroll-annotation_3"),
-      "org.virtuslab.scala-cli" % "cli_3" % V.scalaCli intransitive (),
+      ("org.virtuslab.scala-cli" % "cli_3" % V.scalaCli).intransitive(),
       ("ch.epfl.scala" % "bloop-maven-plugin" % V.mavenBloop)
         .exclude("com.lihaoyi", "unroll-annotation_2.13"),
       ("ch.epfl.scala" %% "gradle-bloop" % V.gradleBloop)
         .exclude("com.lihaoyi", "unroll-annotation_2.13"),
       "com.sourcegraph" % "semanticdb-java" % V.javaSemanticdb,
-      "org.foundweekends.giter8" %% "giter8" % V.gitter8Version intransitive (),
+      ("org.foundweekends.giter8" %% "giter8" % V.gitter8Version).intransitive(),
     ),
   )
   .disablePlugins(ScalafixPlugin)
@@ -844,9 +844,9 @@ lazy val bench = project
     moduleName := "metals-bench",
     buildInfoKeys := Seq[BuildInfoKey](scalaVersion),
     libraryDependencies ++= List(
-      "org.scalameta" % "semanticdb-scalac" % V.semanticdb(
+      ("org.scalameta" % "semanticdb-scalac" % V.semanticdb(
         scalaVersion.value
-      ) cross CrossVersion.full
+      )).cross(CrossVersion.full)
     ),
     buildInfoPackage := "bench",
     Jmh / bspEnabled := false,

--- a/project/V.scala
+++ b/project/V.scala
@@ -88,69 +88,76 @@ object V {
   val dap4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j.debug" % lsp4jV
 
   val eclipseJdt = Seq(
-    "org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.25.0" exclude ("*", "*"),
-    "org.eclipse.platform" % "org.eclipse.ant.core" % "3.5.500" exclude (
+    ("org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.25.0").exclude("*", "*"),
+    ("org.eclipse.platform" % "org.eclipse.ant.core" % "3.5.500").exclude(
       "*",
       "*",
     ),
-    "org.eclipse.platform" % "org.eclipse.compare.core" % "3.6.600" exclude (
+    ("org.eclipse.platform" % "org.eclipse.compare.core" % "3.6.600").exclude(
       "*",
       "*",
     ),
-    "org.eclipse.platform" % "org.eclipse.core.commands" % "3.9.500" exclude (
+    ("org.eclipse.platform" % "org.eclipse.core.commands" % "3.9.500").exclude(
       "*",
       "*",
     ),
-    "org.eclipse.platform" % "org.eclipse.core.contenttype" % "3.7.500" exclude (
+    ("org.eclipse.platform" % "org.eclipse.core.contenttype" % "3.7.500")
+      .exclude(
+        "*",
+        "*",
+      ),
+    ("org.eclipse.platform" % "org.eclipse.core.expressions" % "3.6.500")
+      .exclude(
+        "*",
+        "*",
+      ),
+    ("org.eclipse.platform" % "org.eclipse.core.filesystem" % "1.7.500")
+      .exclude(
+        "*",
+        "*",
+      ),
+    ("org.eclipse.platform" % "org.eclipse.core.jobs" % "3.10.500").exclude(
       "*",
       "*",
     ),
-    "org.eclipse.platform" % "org.eclipse.core.expressions" % "3.6.500" exclude (
+    ("org.eclipse.platform" % "org.eclipse.core.resources" % "3.13.500")
+      .exclude(
+        "*",
+        "*",
+      ),
+    ("org.eclipse.platform" % "org.eclipse.core.runtime" % "3.16.0").exclude(
       "*",
       "*",
     ),
-    "org.eclipse.platform" % "org.eclipse.core.filesystem" % "1.7.500" exclude (
+    ("org.eclipse.platform" % "org.eclipse.core.variables" % "3.4.600").exclude(
       "*",
       "*",
     ),
-    "org.eclipse.platform" % "org.eclipse.core.jobs" % "3.10.500" exclude (
+    ("org.eclipse.platform" % "org.eclipse.equinox.app" % "1.4.300").exclude(
       "*",
       "*",
     ),
-    "org.eclipse.platform" % "org.eclipse.core.resources" % "3.13.500" exclude (
+    ("org.eclipse.platform" % "org.eclipse.equinox.common" % "3.10.600")
+      .exclude(
+        "*",
+        "*",
+      ),
+    ("org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.7.600")
+      .exclude(
+        "*",
+        "*",
+      ),
+    ("org.eclipse.platform" % "org.eclipse.equinox.registry" % "3.8.600")
+      .exclude(
+        "*",
+        "*",
+      ),
+    ("org.eclipse.platform" % "org.eclipse.osgi" % "3.15.0").exclude("*", "*"),
+    ("org.eclipse.platform" % "org.eclipse.team.core" % "3.8.700").exclude(
       "*",
       "*",
     ),
-    "org.eclipse.platform" % "org.eclipse.core.runtime" % "3.16.0" exclude (
-      "*",
-      "*",
-    ),
-    "org.eclipse.platform" % "org.eclipse.core.variables" % "3.4.600" exclude (
-      "*",
-      "*",
-    ),
-    "org.eclipse.platform" % "org.eclipse.equinox.app" % "1.4.300" exclude (
-      "*",
-      "*",
-    ),
-    "org.eclipse.platform" % "org.eclipse.equinox.common" % "3.10.600" exclude (
-      "*",
-      "*",
-    ),
-    "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.7.600" exclude (
-      "*",
-      "*",
-    ),
-    "org.eclipse.platform" % "org.eclipse.equinox.registry" % "3.8.600" exclude (
-      "*",
-      "*",
-    ),
-    "org.eclipse.platform" % "org.eclipse.osgi" % "3.15.0" exclude ("*", "*"),
-    "org.eclipse.platform" % "org.eclipse.team.core" % "3.8.700" exclude (
-      "*",
-      "*",
-    ),
-    "org.eclipse.platform" % "org.eclipse.text" % "3.9.0" exclude ("*", "*"),
+    ("org.eclipse.platform" % "org.eclipse.text" % "3.9.0").exclude("*", "*"),
   )
 
   def semanticdb(scalaVersion: String) =


### PR DESCRIPTION
Prepare for sbt 2.x

https://www.scala-sbt.org/2.x/docs/en/changes/migrating-from-sbt-1.x.html#avoid-postfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build and dependency declarations for consistency and readability.
  * Standardized dependency syntax, including SemanticDB cross-version usage and transitive/exclusion formatting, without changing versions or included artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->