### PR TITLE
Inject sbt-debug-dapter plugin for sbt 2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -843,6 +843,11 @@ lazy val bench = project
     publish / skip := true,
     moduleName := "metals-bench",
     buildInfoKeys := Seq[BuildInfoKey](scalaVersion),
+    libraryDependencies ++= List(
+      ("org.scalameta" % "semanticdb-scalac" % V.semanticdb(
+        scalaVersion.value
+      )).cross(CrossVersion.full)
+    ),
     buildInfoPackage := "bench",
     Jmh / bspEnabled := false,
     Jmh / fork := true,

--- a/build.sbt
+++ b/build.sbt
@@ -843,11 +843,6 @@ lazy val bench = project
     publish / skip := true,
     moduleName := "metals-bench",
     buildInfoKeys := Seq[BuildInfoKey](scalaVersion),
-    libraryDependencies ++= List(
-      ("org.scalameta" % "semanticdb-scalac" % V.semanticdb(
-        scalaVersion.value
-      )).cross(CrossVersion.full)
-    ),
     buildInfoPackage := "bench",
     Jmh / bspEnabled := false,
     Jmh / fork := true,

--- a/metals-bench/src/main/scala/bench/MetalsBench.scala
+++ b/metals-bench/src/main/scala/bench/MetalsBench.scala
@@ -5,6 +5,7 @@ import scala.reflect.io.VirtualFile
 import scala.tools.nsc.interactive.Global
 
 import scala.meta.dialects
+import scala.meta.interactive.InteractiveSemanticdb
 import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.metals.IdentifierIndex
 import scala.meta.internal.metals.JdkSources
@@ -153,12 +154,7 @@ class MetalsBench {
     }
   }
 
-  lazy val global: Global = {
-    val settings = new scala.tools.nsc.Settings
-    settings.usejavacp.value = true
-    val reporter = new scala.tools.nsc.reporters.StoreReporter(settings)
-    new Global(settings, reporter)
-  }
+  lazy val global: Global = InteractiveSemanticdb.newCompiler()
 
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))

--- a/metals-bench/src/main/scala/bench/MetalsBench.scala
+++ b/metals-bench/src/main/scala/bench/MetalsBench.scala
@@ -5,7 +5,6 @@ import scala.reflect.io.VirtualFile
 import scala.tools.nsc.interactive.Global
 
 import scala.meta.dialects
-import scala.meta.interactive.InteractiveSemanticdb
 import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.metals.IdentifierIndex
 import scala.meta.internal.metals.JdkSources
@@ -154,7 +153,12 @@ class MetalsBench {
     }
   }
 
-  lazy val global: Global = InteractiveSemanticdb.newCompiler()
+  lazy val global: Global = {
+    val settings = new scala.tools.nsc.Settings
+    settings.usejavacp.value = true
+    val reporter = new scala.tools.nsc.reporters.StoreReporter(settings)
+    new Global(settings, reporter)
+  }
 
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))

--- a/metals-bench/src/main/scala/scala/meta/bench/ClasspathFuzzBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/ClasspathFuzzBench.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit

--- a/metals-bench/src/main/scala/scala/meta/bench/ClasspathIndexingBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/ClasspathIndexingBench.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit

--- a/metals-bench/src/main/scala/scala/meta/bench/ClasspathOnlySymbolSearch.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/ClasspathOnlySymbolSearch.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import java.net.URI
 import java.util.Optional

--- a/metals-bench/src/main/scala/scala/meta/bench/ClasspathSymbolsBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/ClasspathSymbolsBench.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import java.util.concurrent.TimeUnit
 

--- a/metals-bench/src/main/scala/scala/meta/bench/CompletionBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/CompletionBench.scala
@@ -1,6 +1,9 @@
-package bench
+package scala.meta.bench
 
 import java.util.concurrent.TimeUnit
+
+import scala.meta.bench.PcBenchmark
+import scala.meta.bench.SourceRequest
 
 import org.eclipse.lsp4j.CompletionList
 import org.openjdk.jmh.annotations.Benchmark

--- a/metals-bench/src/main/scala/scala/meta/bench/DefinitionBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/DefinitionBench.scala
@@ -1,8 +1,11 @@
-package bench
+package scala.meta.bench
 
 import java.util.concurrent.TimeUnit
 
-import org.eclipse.lsp4j.SignatureHelp
+import scala.meta.bench.PcBenchmark
+import scala.meta.bench.SourceRequest
+import scala.meta.pc.DefinitionResult
+
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Mode
@@ -12,7 +15,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 
 @State(Scope.Benchmark)
-class SignatureHelpBench extends PcBenchmark {
+class DefinitionBench extends PcBenchmark {
 
   var requests: Map[String, SourceRequest] = Map.empty
 
@@ -24,10 +27,10 @@ class SignatureHelpBench extends PcBenchmark {
            |
            |object Main{
            |  def foo(a: Int, bab: String, dbl: Double = 1.0)
-           |  foo(a = 12,)
+           |  foo(1, "")
            |}
            |""".stripMargin,
-        "  foo(a = 12,@@)",
+        "  f@@oo(1, \"\")",
       )
     )
   }
@@ -41,12 +44,12 @@ class SignatureHelpBench extends PcBenchmark {
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  def signatureHelp(): SignatureHelp = {
+  def definition(): DefinitionResult = {
     val pc = presentationCompiler(scalaVersion)
-    currentSignatureHelp.signatureHelp(pc)
+    currentDefinition.definition(pc)
   }
 
-  def currentSignatureHelp: SourceRequest = requests(
+  def currentDefinition: SourceRequest = requests(
     currentRequest
   )
 

--- a/metals-bench/src/main/scala/scala/meta/bench/DocumentHighlightBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/DocumentHighlightBench.scala
@@ -1,9 +1,12 @@
-package bench
+package scala.meta.bench
 
 import java.util.concurrent.TimeUnit
+import java.{util => ju}
 
-import scala.meta.pc.DefinitionResult
+import scala.meta.bench.PcBenchmark
+import scala.meta.bench.SourceRequest
 
+import org.eclipse.lsp4j.DocumentHighlight
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Mode
@@ -13,7 +16,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 
 @State(Scope.Benchmark)
-class DefinitionBench extends PcBenchmark {
+class DocumentHighlightBench extends PcBenchmark {
 
   var requests: Map[String, SourceRequest] = Map.empty
 
@@ -42,12 +45,12 @@ class DefinitionBench extends PcBenchmark {
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  def definition(): DefinitionResult = {
+  def documentHighlight(): ju.List[DocumentHighlight] = {
     val pc = presentationCompiler(scalaVersion)
-    currentDefinition.definition(pc)
+    currentHighlight.documentHighlight(pc)
   }
 
-  def currentDefinition: SourceRequest = requests(
+  def currentHighlight: SourceRequest = requests(
     currentRequest
   )
 

--- a/metals-bench/src/main/scala/scala/meta/bench/HoverBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/HoverBench.scala
@@ -1,9 +1,11 @@
-package bench
+package scala.meta.bench
 
 import java.util.concurrent.TimeUnit
-import java.{util => ju}
 
-import org.eclipse.lsp4j.DocumentHighlight
+import scala.meta.bench.PcBenchmark
+import scala.meta.bench.SourceRequest
+import scala.meta.pc.HoverSignature
+
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Mode
@@ -13,27 +15,27 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 
 @State(Scope.Benchmark)
-class DocumentHighlightBench extends PcBenchmark {
+class HoverBench extends PcBenchmark {
 
   var requests: Map[String, SourceRequest] = Map.empty
 
   def beforeAll(): Unit = {
+
     requests = Map(
-      "basic" -> SourceRequest.fromPath(
+      "scopeOpen" -> SourceRequest.fromPath(
         "A.scala",
         """|package a
            |
-           |object Main{
-           |  def foo(a: Int, bab: String, dbl: Double = 1.0)
-           |  foo(1, "")
+           |object Main extends App{
+           |  
            |}
            |""".stripMargin,
-        "  f@@oo(1, \"\")",
+        "object Main extends Ap@@p",
       )
     )
   }
 
-  @Param(Array("basic"))
+  @Param(Array("scopeOpen"))
   var currentRequest: String = _
 
   @Param(Array("3.3.1", "2.13.12"))
@@ -42,12 +44,12 @@ class DocumentHighlightBench extends PcBenchmark {
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  def documentHighlight(): ju.List[DocumentHighlight] = {
+  def hover(): HoverSignature = {
     val pc = presentationCompiler(scalaVersion)
-    currentHighlight.documentHighlight(pc)
+    currentHover.hover(pc).get()
   }
 
-  def currentHighlight: SourceRequest = requests(
+  def currentHover: SourceRequest = requests(
     currentRequest
   )
 

--- a/metals-bench/src/main/scala/scala/meta/bench/Inflated.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/Inflated.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import java.nio.charset.StandardCharsets
 

--- a/metals-bench/src/main/scala/scala/meta/bench/InlayHintsBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/InlayHintsBench.scala
@@ -1,9 +1,10 @@
-package bench
+package scala.meta.bench
 
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 
+import scala.meta.bench.PcBenchmark
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.metals.CompilerInlayHintsParams
 import scala.meta.internal.metals.CompilerRangeParams

--- a/metals-bench/src/main/scala/scala/meta/bench/MainBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/MainBench.scala
@@ -1,4 +1,5 @@
-package bench
+package scala.meta.bench
+import scala.meta.bench.ClasspathSymbolsBench
 
 object MainBench {
   def main(args: Array[String]): Unit = {

--- a/metals-bench/src/main/scala/scala/meta/bench/MetalsBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/MetalsBench.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import scala.reflect.internal.util.BatchSourceFile
 import scala.reflect.io.VirtualFile

--- a/metals-bench/src/main/scala/scala/meta/bench/PcBenchmark.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/PcBenchmark.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import java.nio.file.Path
 

--- a/metals-bench/src/main/scala/scala/meta/bench/SemanticTokensBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/SemanticTokensBench.scala
@@ -1,10 +1,11 @@
-package bench
+package scala.meta.bench
 
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
+import scala.meta.bench.PcBenchmark
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.CompilerVirtualFileParams

--- a/metals-bench/src/main/scala/scala/meta/bench/ServerInitializeBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/ServerInitializeBench.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors

--- a/metals-bench/src/main/scala/scala/meta/bench/SignatureHelpBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/SignatureHelpBench.scala
@@ -1,9 +1,11 @@
-package bench
+package scala.meta.bench
 
 import java.util.concurrent.TimeUnit
 
-import scala.meta.pc.HoverSignature
+import scala.meta.bench.PcBenchmark
+import scala.meta.bench.SourceRequest
 
+import org.eclipse.lsp4j.SignatureHelp
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Mode
@@ -13,27 +15,27 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 
 @State(Scope.Benchmark)
-class HoverBench extends PcBenchmark {
+class SignatureHelpBench extends PcBenchmark {
 
   var requests: Map[String, SourceRequest] = Map.empty
 
   def beforeAll(): Unit = {
-
     requests = Map(
-      "scopeOpen" -> SourceRequest.fromPath(
+      "basic" -> SourceRequest.fromPath(
         "A.scala",
         """|package a
            |
-           |object Main extends App{
-           |  
+           |object Main{
+           |  def foo(a: Int, bab: String, dbl: Double = 1.0)
+           |  foo(a = 12,)
            |}
            |""".stripMargin,
-        "object Main extends Ap@@p",
+        "  foo(a = 12,@@)",
       )
     )
   }
 
-  @Param(Array("scopeOpen"))
+  @Param(Array("basic"))
   var currentRequest: String = _
 
   @Param(Array("3.3.1", "2.13.12"))
@@ -42,12 +44,12 @@ class HoverBench extends PcBenchmark {
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  def hover(): HoverSignature = {
+  def signatureHelp(): SignatureHelp = {
     val pc = presentationCompiler(scalaVersion)
-    currentHover.hover(pc).get()
+    currentSignatureHelp.signatureHelp(pc)
   }
 
-  def currentHover: SourceRequest = requests(
+  def currentSignatureHelp: SourceRequest = requests(
     currentRequest
   )
 

--- a/metals-bench/src/main/scala/scala/meta/bench/SourceRequest.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/SourceRequest.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths

--- a/metals-bench/src/main/scala/scala/meta/bench/WorkspaceFuzzBench.scala
+++ b/metals-bench/src/main/scala/scala/meta/bench/WorkspaceFuzzBench.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import java.util.concurrent.TimeUnit
 

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -334,21 +334,18 @@ object SbtBuildTool {
     val mainMeta = projectRoot.resolve("project")
     val metaMeta = projectRoot.resolve("project").resolve("project")
 
+    val writtenPlugin =
+      writePlugins(mainMeta, metalsPluginDetails, debugAdapterPluginDetails)
     val isSbt2 =
       SbtBuildTool.loadVersion(projectRoot).exists(_.startsWith("2."))
     if (isSbt2) {
-      val writtenPlugin = writePlugins(mainMeta, metalsPluginDetails)
       val writtenMeta = writePlugins(
         metaMeta,
         metalsPluginDetails,
+        // sbt 2.x doesn't need sbt-jdi-tools plugin because it only runs on Java 17+ where the JDI tools are included.
       )
       writtenMeta || writtenPlugin
     } else {
-      val writtenPlugin = writePlugins(
-        mainMeta,
-        metalsPluginDetails,
-        debugAdapterPluginDetails,
-      )
       val writtenMeta =
         writePlugins(metaMeta, metalsPluginDetails, jdiToolsPluginDetails)
       writtenMeta || writtenPlugin

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
@@ -8,7 +8,6 @@ import scala.util.matching.Regex
 import scala.util.matching.Regex.Groups
 
 import scala.meta.internal.io.FileIO
-import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 
 object DotEnvFileParser {

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
@@ -390,7 +390,7 @@ class McpQueryEngine(
               super.apply(other)
           }
         }
-        shortenBodies(source).toString()
+        shortenBodies.transform(source).toString()
       case _ =>
         content
     }

--- a/project/V.scala
+++ b/project/V.scala
@@ -35,7 +35,7 @@ object V {
 
   val coursierInterfaces = "1.0.29-M2"
 
-  val debugAdapter = "4.2.12"
+  val debugAdapter = "4.2.13"
 
   val genyVersion = "1.1.1"
 
@@ -75,7 +75,7 @@ object V {
 
   val scalafmt = "3.11.1"
 
-  val scalameta = "4.17.2"
+  val scalameta = "4.17.3"
 
   val scribe = "3.19.0"
 

--- a/project/V.scala
+++ b/project/V.scala
@@ -35,7 +35,7 @@ object V {
 
   val coursierInterfaces = "1.0.29-M2"
 
-  val debugAdapter = "4.2.9"
+  val debugAdapter = "4.2.10"
 
   val genyVersion = "1.1.1"
 

--- a/project/V.scala
+++ b/project/V.scala
@@ -35,7 +35,7 @@ object V {
 
   val coursierInterfaces = "1.0.29-M2"
 
-  val debugAdapter = "4.2.10"
+  val debugAdapter = "4.2.11"
 
   val genyVersion = "1.1.1"
 

--- a/project/V.scala
+++ b/project/V.scala
@@ -35,7 +35,7 @@ object V {
 
   val coursierInterfaces = "1.0.29-M2"
 
-  val debugAdapter = "4.2.11"
+  val debugAdapter = "4.2.12"
 
   val genyVersion = "1.1.1"
 

--- a/project/V.scala
+++ b/project/V.scala
@@ -75,7 +75,7 @@ object V {
 
   val scalafmt = "3.11.1"
 
-  val scalameta = "4.17.0"
+  val scalameta = "4.17.2"
 
   val scribe = "3.19.0"
 

--- a/tests/slow/src/test/scala/tests/feature/WorkspaceSymbolRegressionSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/WorkspaceSymbolRegressionSuite.scala
@@ -1,8 +1,8 @@
 package tests.feature
 
+import scala.meta.bench.Corpus
 import scala.meta.io.AbsolutePath
 
-import bench.Corpus
 import tests.BaseWorkspaceSymbolSuite
 
 abstract class WorkspaceSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {

--- a/tests/unit/src/main/scala/scala/meta/bench/Corpus.scala
+++ b/tests/unit/src/main/scala/scala/meta/bench/Corpus.scala
@@ -1,4 +1,4 @@
-package bench
+package scala.meta.bench
 
 import java.net.URL
 import java.nio.file.Files

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/StepNavigator.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/StepNavigator.scala
@@ -3,7 +3,6 @@ package scala.meta.internal.metals.debug
 import scala.collection.mutable
 import scala.concurrent.Future
 
-import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.debug.StepNavigator._
 import scala.meta.io.AbsolutePath
 

--- a/tests/unit/src/test/resources/semanticdb/example/ImplicitClasses.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/ImplicitClasses.scala
@@ -1,10 +1,10 @@
 package example
 
 object ImplicitClasses/*example.ImplicitClasses.*/ {
-  implicit class Xtension/*example.ImplicitClasses.Xtension#*/(number/*example.ImplicitClasses.Xtension#number.*/: Int/*scala.Int#*/) {
+  implicit class Xtension/*example.ImplicitClasses.Xtension#*/(number/*example.ImplicitClasses.Xtension#number.*//*example.ImplicitClasses.Xtension#`<init>`().(number)*/: Int/*scala.Int#*/) {
     def increment/*example.ImplicitClasses.Xtension#increment().*/: Int/*scala.Int#*/ = number/*example.ImplicitClasses.Xtension#number.*/ +/*scala.Int#`+`(+4).*/ 1
   }
-  implicit class XtensionAnyVal/*example.ImplicitClasses.XtensionAnyVal#*/(private val number/*example.ImplicitClasses.XtensionAnyVal#number.*/: Int/*scala.Int#*/) extends AnyVal/*scala.AnyVal#*/ /*scala.AnyVal#`<init>`().*/{
+  implicit class XtensionAnyVal/*example.ImplicitClasses.XtensionAnyVal#*/(private val number/*example.ImplicitClasses.XtensionAnyVal#number.*//*example.ImplicitClasses.XtensionAnyVal#`<init>`().(number)*/: Int/*scala.Int#*/) extends AnyVal/*scala.AnyVal#*/ /*scala.AnyVal#`<init>`().*/{
     def double/*example.ImplicitClasses.XtensionAnyVal#double().*/: Int/*scala.Int#*/ = number/*example.ImplicitClasses.XtensionAnyVal#number.*/ */*scala.Int#`*`(+3).*/ 2
   }
 }

--- a/tests/unit/src/test/resources/semanticdb/example/MacroAnnotation.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/MacroAnnotation.scala
@@ -5,7 +5,7 @@ import io.circe.derivation.annotations.JsonCodec/*io.circe.derivation.annotation
 @/*local1*/JsonCodec/*example.MacroAnnotation#*//*java.lang.Object#`<init>`().*/
 // FIXME: https://github.com/scalameta/scalameta/issues/1789
 case class MacroAnnotation(
-    name/*example.MacroAnnotation#name.*/: String/*scala.Predef.String#*/
+    name/*example.MacroAnnotation#name.*//*example.MacroAnnotation#`<init>`().(name)*/: String/*scala.Predef.String#*/
 ) {
   def method/*example.MacroAnnotation#method().*/ = 42
 }

--- a/tests/unit/src/test/resources/semanticdb/example/MethodOverload.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/MethodOverload.scala
@@ -1,6 +1,6 @@
 package example
 
-class MethodOverload/*example.MethodOverload#*/(b/*example.MethodOverload#b.*/: String/*scala.Predef.String#*/) {
+class MethodOverload/*example.MethodOverload#*/(b/*example.MethodOverload#b.*//*example.MethodOverload#`<init>`().(b)*/: String/*scala.Predef.String#*/) {
   def this/*example.MethodOverload#`<init>`(+1).*/() = this("")
   def this/*example.MethodOverload#`<init>`(+2).*/(c/*example.MethodOverload#`<init>`(+2).(c)*/: Int/*scala.Int#*/) = this("")
   val a/*example.MethodOverload#a.*/ = 2

--- a/tests/unit/src/test/resources/semanticdb/example/NamedArguments.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/NamedArguments.scala
@@ -1,7 +1,7 @@
 package example
 
 case class User/*example.User#*/(
-    name/*example.User#name.*/: String/*scala.Predef.String#*/ = {
+    name/*example.User#name.*//*example.User#`<init>`().(name)*/: String/*scala.Predef.String#*/ = {
       // assert default values have occurrences
       Map/*scala.Predef.Map.*/.toString/*java.lang.Object#toString().*/
     }

--- a/tests/unit/src/test/resources/semanticdb/example/SQLQueries.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/SQLQueries.scala
@@ -1,7 +1,7 @@
 package example
 
 class SQLQueries/*example.SQLQueries#*/ {
-    implicit class SQLStringContext/*example.SQLQueries#SQLStringContext#*/(sc/*example.SQLQueries#SQLStringContext#sc.*/: StringContext/*scala.StringContext#*/) {
+    implicit class SQLStringContext/*example.SQLQueries#SQLStringContext#*/(sc/*example.SQLQueries#SQLStringContext#sc.*//*example.SQLQueries#SQLStringContext#`<init>`().(sc)*/: StringContext/*scala.StringContext#*/) {
         def sql/*example.SQLQueries#SQLStringContext#sql().*/(args/*example.SQLQueries#SQLStringContext#sql().(args)*/: Any/*scala.Any#*/*): String/*scala.Predef.String#*/ = sc/*example.SQLQueries#SQLStringContext#sc.*/.s/*scala.StringContext#s().*/(args/*example.SQLQueries#SQLStringContext#sql().(args)*/: _*)
     }
 

--- a/tests/unit/src/test/scala/tests/MtagsSuite.scala
+++ b/tests/unit/src/test/scala/tests/MtagsSuite.scala
@@ -78,7 +78,7 @@ class MtagsScala2Suite
         // don't assert fidelity where semanticdb-scalac has known bugs and mtags is correct.
         List(
           "ImplicitClasses", "PatternMatching", "ImplicitConversions",
-          "MacroAnnotation", "SQLQueries",
+          "MacroAnnotation", "SQLQueries", "MethodOverload", "NamedArguments",
         ).exists { name => file.file.toNIO.endsWith(s"$name.scala") }
       },
     )


### PR DESCRIPTION
Since version 4.3.10, the sbt-debug-adapter plugin is cross-built for sbt 2.x, so we inject it to enable running/debugging for upgraded projects. Implements the changes discussed in https://github.com/scalacenter/scala-debug-adapter/pull/986#issuecomment-4894479351.

I have briefly tested this in an actual VS Code instance by publishing locally, worked fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved generation of Metals SBT configuration so debug adapter support is included more consistently across sbt versions.

* **Chores**
  * Updated the bundled debug adapter to **4.2.12** and refreshed Scalameta to **4.17.2**.
  * Streamlined benchmark setup by removing an unused dependency and adjusting compiler initialization.
  * Removed a couple of unused imports in debug tooling code.

* **Tests**
  * Refreshed semanticdb test fixtures and adjusted Scala 2 comparison exclusions for certain examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->