### PR TITLE
bugfix: Fix a race condition in AddMissingReturnStatementLspSuite

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/AddMissingReturnStatement.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/AddMissingReturnStatement.scala
@@ -85,7 +85,7 @@ class AddMissingReturnStatement(
 object AddMissingReturnStatement {
   def title: String = "Add missing return statement"
 
-  private def hasMissingReturnMessage(diagnostic: l.Diagnostic): Boolean =
+  def hasMissingReturnMessage(diagnostic: l.Diagnostic): Boolean =
     Option(diagnostic.getMessage())
       .map(_.toString().toLowerCase())
       .exists(_.contains("missing return"))

--- a/metals/src/main/scala/scala/meta/internal/parsing/JavaTrees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/JavaTrees.scala
@@ -31,6 +31,7 @@ import com.sun.tools.javac.tree.{JCTree => JavacJCTree}
 import com.sun.tools.javac.util.Context
 import com.sun.tools.javac.util.Log
 import com.sun.tools.javac.util.Options
+import com.sun.tools.javac.util.{Position => JavacPosition}
 import org.eclipse.{lsp4j => l}
 
 class JavaTrees(buffers: Buffers) {
@@ -188,7 +189,14 @@ class JavaTrees(buffers: Buffers) {
       text: String,
       targetPos: l.Position,
   ) extends TreePathScanner[Unit, Unit] {
-    protected val lineMap: LineMap = cu.getLineMap()
+    // Don't use `cu.getLineMap()` here: javac's `LineMapImpl.getLineNumber`
+    // memoizes its last lookup in unsynchronized fields, and code-action
+    // providers run concurrently over the same cached tree, so sharing its
+    // line map across threads yields wrong line numbers (corrupt LSP ranges).
+    // Each finder is used by a single thread, so a private line map built from
+    // the same text is race-free and behaviorally identical.
+    protected val lineMap: LineMap =
+      JavacPosition.makeLineMap(text.toCharArray(), text.length(), false)
     protected val pos = new TreePositions(cu)
     protected val targetOffset: Int = lspPositionToOffset(lineMap, targetPos)
     protected var _result: Option[T] = None

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -8,6 +8,7 @@ import scala.meta.internal.metals.{BuildInfo => V}
 import munit.Location
 import munit.TestOptions
 import org.eclipse.lsp4j.CodeAction
+import org.eclipse.lsp4j.Diagnostic
 import tests.BaseLspSuite
 import tests.BuildServerInitializer
 import tests.FileLayout
@@ -21,6 +22,14 @@ abstract class BaseCodeActionLspSuite(
 ) extends BaseLspSuite(suiteName, initializer) {
 
   protected val scalaVersion: String = V.scala213
+
+  /**
+   * When set, `check` waits for a matching diagnostics publication before
+   * requesting code actions. Override in suites whose action is gated on an
+   * async diagnostic (e.g. presentation compiler); `checkNoAction` opts out.
+   */
+  protected def defaultAwaitDiagnostics: Option[Seq[Diagnostic] => Boolean] =
+    None
 
   def checkNoAction(
       name: TestOptions,
@@ -42,6 +51,7 @@ abstract class BaseCodeActionLspSuite(
       fileName = fileName,
       createInSrcDir = createInSrcDir,
       filterAction = filterAction,
+      awaitDiagnostics = None,
     )
   }
 
@@ -99,6 +109,8 @@ abstract class BaseCodeActionLspSuite(
       assume: () => Boolean = () => true,
       applyCodeAction: Boolean = true,
       dependencies: List[String] = Nil,
+      awaitDiagnostics: Option[Seq[Diagnostic] => Boolean] =
+        defaultAwaitDiagnostics,
   )(implicit loc: Location): Unit = {
     val scalacOptionsJson =
       if (scalacOptions.nonEmpty)
@@ -140,6 +152,7 @@ abstract class BaseCodeActionLspSuite(
       retryAction,
       assume,
       applyCodeAction,
+      awaitDiagnostics,
     )
   }
 
@@ -160,6 +173,8 @@ abstract class BaseCodeActionLspSuite(
       retryAction: Int = 0,
       assumeFunc: () => Boolean = () => true,
       applyCodeAction: Boolean = true,
+      awaitDiagnostics: Option[Seq[Diagnostic] => Boolean] =
+        defaultAwaitDiagnostics,
   )(implicit loc: Location): Unit = {
     val files = FileLayout.mapFromString(layout)
     val (path, input) = files
@@ -206,10 +221,18 @@ abstract class BaseCodeActionLspSuite(
             case None => Future {}
           }
         }
+        // Register before the change that publishes diagnostics, so we wait
+        // for the action's diagnostic instead of racing its publication.
+        diagnosticsPublished = awaitDiagnostics match {
+          case Some(condition) =>
+            client.nextDiagnosticsFor(server.toPath(path), condition)
+          case None => Future.unit
+        }
         _ <- server.didChange(
           path,
           changeFile(input).replace("<<", "").replace(">>", ""),
         )
+        _ <- diagnosticsPublished
         codeActions <- assertCodeAction(retryAction)
         _ <-
           if (applyCodeAction) {

--- a/tests/unit/src/test/scala/tests/codeactions/AddMissingReturnStatementLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/AddMissingReturnStatementLspSuite.scala
@@ -25,6 +25,13 @@ class AddMissingReturnStatementLspSuite
   private val onlyAddReturn: org.eclipse.lsp4j.CodeAction => Boolean =
     _.getTitle() == AddMissingReturnStatement.title
 
+  // Wait for the async "missing return" diagnostic
+  override protected def defaultAwaitDiagnostics
+      : Option[Seq[org.eclipse.lsp4j.Diagnostic] => Boolean] =
+    Some(
+      _.exists(AddMissingReturnStatement.hasMissingReturnMessage)
+    )
+
   check(
     "int",
     """|package a;

--- a/tests/unit/src/test/scala/tests/parsing/JavaTreesLineMapRaceSuite.scala
+++ b/tests/unit/src/test/scala/tests/parsing/JavaTreesLineMapRaceSuite.scala
@@ -1,0 +1,164 @@
+package tests.parsing
+
+import java.nio.file.Files
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.DurationInt
+
+import scala.meta.internal.metals.Buffers
+import scala.meta.internal.parsing.JavaRange
+import scala.meta.internal.parsing.JavaTrees
+import scala.meta.io.AbsolutePath
+
+import org.eclipse.lsp4j.Position
+import tests.BaseSuite
+
+/**
+ * Regression test for the corrupt-edit flakiness in
+ * `AddMissingReturnStatementLspSuite`.
+ *
+ * javac's `LineMapImpl.getLineNumber` memoizes in unsynchronized fields. Java
+ * code-action providers query the same cached tree's line map concurrently, so
+ * the memo races and returns wrong lines — ranges inconsistent with offsets.
+ *
+ * A single `findEnclosingJavaMethod` query already converts six distinct
+ * offsets (the endpoints of `range`, `nameRange` and `bodyRange`) through the
+ * memo, so threads querying even the same cursor drift out of phase and
+ * corrupt each other — just like code-action providers resolving one cursor.
+ * The concurrent test hammers the shared tree from a start barrier for a
+ * fixed time window; the single-threaded control must always pass.
+ */
+class JavaTreesLineMapRaceSuite extends BaseSuite {
+  private val text =
+    """|package a;
+       |
+       |public class Example {
+       |  public int answer() {
+       |  }
+       |}
+       |""".stripMargin
+
+  /** Cursor inside `answer`. */
+  private val position = new Position(3, 16)
+
+  // Enough for the failure message to show the corruption pattern; hitting it
+  // also stops a failing thread early instead of hammering out the window.
+  private val maxErrorsShown = 4
+
+  test("single-threaded-reads-of-line-map") {
+    val (javaTrees, path) = newCachedTrees()
+    val errors =
+      (0 until 10000).toList.flatMap { i =>
+        validateEnclosingJavaMethodRange(javaTrees, path, s"iter=$i")
+      }
+    assert(errors.isEmpty, clue = errors.take(5).mkString("\n"))
+  }
+
+  test("multi-threaded-reads-of-line-map") {
+    val (javaTrees, path) = newCachedTrees()
+    val threads = 4
+    val pool = Executors.newFixedThreadPool(threads)
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(pool)
+    val highLoadDuration = 2.seconds
+    val highLoadStartBarrier = new CyclicBarrier(threads)
+    try {
+      val workers = (0 until threads).toList.map { thread =>
+        Future {
+          // Release all threads together, then query continuously for a fixed
+          // window so their line-map lookups overlap for the whole duration.
+          highLoadStartBarrier.await()
+          val deadline = System.nanoTime() + highLoadDuration.toNanos
+          Iterator
+            .from(0)
+            .takeWhile(_ => System.nanoTime() < deadline)
+            .flatMap { i =>
+              validateEnclosingJavaMethodRange(
+                javaTrees,
+                path,
+                s"thread=$thread iter=$i",
+              )
+            }
+            .take(maxErrorsShown)
+            .toList
+        }
+      }
+      val errors =
+        Await.result(Future.sequence(workers), Duration("120s")).flatten
+      assert(
+        errors.isEmpty,
+        clue =
+          s"${errors.length} inconsistent ranges, e.g.:\n${errors.take(maxErrorsShown).mkString("\n")}",
+      )
+    } finally {
+      pool.shutdown()
+    }
+  }
+
+  private def newCachedTrees(): (JavaTrees, AbsolutePath) = {
+    val buffers = Buffers()
+    val javaTrees = new JavaTrees(buffers)
+    val path = AbsolutePath(Files.createTempFile("Example", ".java"))
+    buffers.put(path, text)
+    // Populate the cache so all reads share one tree (and one LineMapImpl).
+    javaTrees.didChange(path)
+    (javaTrees, path)
+  }
+
+  private def validateEnclosingJavaMethodRange(
+      javaTrees: JavaTrees,
+      path: AbsolutePath,
+      label: String,
+  ): List[String] =
+    javaTrees.findEnclosingJavaMethod(path, position) match {
+      case None =>
+        List(s"$label: expected to find enclosing method at $position")
+      case Some(method) =>
+        List(
+          s"$label range" -> method.range,
+          s"$label nameRange" -> method.nameRange,
+          s"$label bodyRange" -> method.bodyRange,
+        ).flatMap { case (rangeLabel, range) =>
+          positionErrors(rangeLabel, range)
+        }
+    }
+
+  /** LSP positions of a range must agree with its own byte offsets. */
+  private def positionErrors(
+      label: String,
+      range: JavaRange,
+  ): List[String] =
+    List(
+      positionError(
+        s"$label start",
+        range.startOffset,
+        range.range.getStart(),
+      ),
+      positionError(
+        s"$label end",
+        range.endOffset,
+        range.range.getEnd(),
+      ),
+    ).flatten
+
+  private def positionError(
+      label: String,
+      offset: Int,
+      actual: Position,
+  ): Option[String] = {
+    val expected = offsetToPosition(offset)
+    Option.when(expected != actual)(
+      s"$label: offset $offset is $expected but range was $actual"
+    )
+  }
+
+  private def offsetToPosition(offset: Int): Position = {
+    val prefix = text.substring(0, offset)
+    val line = prefix.count(_ == '\n')
+    new Position(line, offset - (prefix.lastIndexOf('\n') + 1))
+  }
+}


### PR DESCRIPTION
AddMissingReturnStatementLspSuite occasionally fails due to some race conditions

According to the analysis generated by Claude, it's related to Position.LineMapImpl not being thread-safe and the fact that code actions are available only after matching diagnostics are published

The issue can be reproduced (not 100% of the time, but still) by running either the original test `tests.codeactions.AddMissingReturnStatementLspSuite`
```bash
for i in {1..10}; do echo "run $i"; sbt --client 'unit/testOnly tests.codeactions.AddMissingReturnStatementLspSuite' 2>&1 | grep -E "Passed:|Failed:|==> X" | tail -5; done
```

or a new one - `JavaTreesLineMapRaceSuite` - which aims to make it the issue easier to spot
```bash
for i in {1..10}; do echo "run $i"; sbt --client 'unit/testOnly tests.parsing.JavaTreesLineMapRaceSuite' | grep -E "Passed:|Failed:|==> X" | tail -5; done
```

Note: When run from IntelliJ, the test requires the following VM arguments
```
--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.resources=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
```

Examples
<img width="1641" height="915" alt="Screenshot 2026-07-07 at 14 17 11" src="https://github.com/user-attachments/assets/72276c4f-525d-4210-9110-a2b96ae13041" />

<img width="1641" height="915" alt="Screenshot 2026-07-07 at 14 18 28" src="https://github.com/user-attachments/assets/64fbec73-6444-4312-97db-c5fb18502ffc" />

## Demo
AddMissingReturnStatementLspSuite repeated 10 times

```bash
for i in {1..10}; do echo "run $i"; sbt --client 'unit/testOnly tests.codeactions.AddMissingReturnStatementLspSuite' 2>&1 | grep -E "Passed:|Failed:|==> X" | tail -5; done
```

### Before (main-v2)
```
run 1
==> X tests.codeactions.AddMissingReturnStatementLspSuite.int 3.434s munit.ComparisonFailException: tests/unit/src/test/scala/tests/codeactions/AddMissingReturnStatementLspSuite.scala:28
[error] Failed: Total 22, Failed 1, Errors 0, Passed 21
run 2
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 3
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 4
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 5
==> X tests.codeactions.AddMissingReturnStatementLspSuite.generic 0.706s munit.ComparisonFailException: tests/unit/src/test/scala/tests/codeactions/AddMissingReturnStatementLspSuite.scala:224
[error] Failed: Total 22, Failed 1, Errors 0, Passed 21
run 6
==> X tests.codeactions.AddMissingReturnStatementLspSuite.int 3.31s munit.ComparisonFailException: tests/unit/src/test/scala/tests/codeactions/AddMissingReturnStatementLspSuite.scala:28
[error] Failed: Total 22, Failed 1, Errors 0, Passed 21
run 7
==> X tests.codeactions.AddMissingReturnStatementLspSuite.int 3.163s munit.ComparisonFailException: tests/unit/src/test/scala/tests/codeactions/AddMissingReturnStatementLspSuite.scala:28
[error] Failed: Total 22, Failed 1, Errors 0, Passed 21
run 8
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 9
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 10
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
```

### After
```
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 2
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 3
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 4
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 5
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 6
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 7
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 8
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 9
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
run 10
[info] Passed: Total 22, Failed 0, Errors 0, Passed 22
```

___

# Fix summary: `AddMissingReturnStatementLspSuite` flakiness

`AddMissingReturnStatementLspSuite` was flaky for **two independent reasons**.

## Bug 1 — corrupt edits: a data race on javac's `LineMap`

**Root cause.**

javac's `Position.LineMapImpl.getLineNumber` memoizes its last lookup in two
unsynchronized fields (`lastPosition`/`lastLine`), and `getColumnNumber`
re-calls it.

Metals caches one `CompilationUnitTree` per file (`JavaTrees.get`), and one
`textDocument/codeAction` request runs **all providers concurrently**
(`CodeActionProvider.codeActions` → `Future.sequence`). Seven Java providers
each call `findEnclosing*` on that shared tree from different threads.

The concurrent memo race returns wrong line numbers, so LSP ranges disagree
with their byte offsets. The edit then replaces the wrong span
(duplicated/truncated code), or the action vanishes when the corrupt range
fails the diagnostic-overlap check.

**Fix.**

In
[`JavaTrees.scala`](https://github.com/scalameta/metals/blob/main/metals/src/main/scala/scala/meta/internal/parsing/JavaTrees.scala),
each `EnclosingFinder` builds its **own** line map from the text via
`Position.makeLineMap(text.toCharArray(), text.length, expandTabs=false)`
instead of sharing the cached tree's `LineMapImpl`.

The tree stays cached; only the racy per-lookup memo object is thread-confined.

## Bug 2 — action absent: async diagnostic race

**Root cause.**

The action is gated on the presentation compiler's "missing return" diagnostic
being in the request context.

The test requested code actions immediately after `didChange`, racing the
async publication → empty context → no action.

**Fix.**

A `defaultAwaitDiagnostics` hook in
[`BaseCodeActionLspSuite.scala`](https://github.com/scalameta/metals/blob/main/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala)
registers `client.nextDiagnosticsFor` before `didChange` and awaits the gating
diagnostic (`checkNoAction` opts out).

The suite overrides it with `AddMissingReturnStatement.hasMissingReturnMessage`.