### PR TITLE
Improvement: smoothen out main-launching experience with MBT

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
@@ -50,10 +50,17 @@ class BuildTargetClassesFinder(
           val found = ex match {
             // We check whether there is a main in dependencies that is not reported via BSP
             case ClassNotFoundInBuildTargetException(className, target) =>
-              revertToDependencies(
-                className,
-                buildTargets.findByDisplayNameOrUri(target),
+              val targetOpt = buildTargets.findByDisplayNameOrUri(target)
+              val isMbtTarget = targetOpt.exists(t =>
+                buildTargets.buildServerOf(t.getId()).exists(_.isMbt)
               )
+              if (isMbtTarget) {
+                // We might not have dependency sources indexed so revertToDependencies
+                // will fail. Let's trust the input data
+                targetOpt.toList.map(t =>
+                  (new b.ScalaMainClass(className, Nil.asJava, Nil.asJava), t)
+                )
+              } else revertToDependencies(className, targetOpt)
             case _: NoMainClassFoundException =>
               revertToDependencies(className, buildTarget = None)
             case _ => Nil

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
@@ -161,29 +161,37 @@ class MbtDebugSessionStarter(
     )
     val toolName = launcher.executableName
     val cancelPromise = Promise[Unit]()
-    debugConfigCreator.create(target.id, cancelPromise, isTests = false) match {
-      case Left(error) => Future.failed(new IllegalStateException(error))
-      case Right(projectFuture) =>
-        projectFuture.map { project =>
-          val patched = patchProjectForRun(project, target, workspace, toolName)
-          scribe.info(
-            s"MBT debug session via $toolName: ${redactedCommand(command)}"
-          )
-          val debuggee = new BuildToolDebugAdapter(
-            Future.successful(command),
-            workspace,
-            env = javaHomeEnv(target),
-            patched,
-            userJavaHome(),
-          )
-          val handler = dap.DebugServer.run(
-            debuggee,
-            new MetalsDebugToolsResolver(),
-            new DebugLogger(),
-            gracePeriod = Duration(debuggeeGracePeriodSeconds, TimeUnit.SECONDS),
-          )
-          handler.uri
-        }
+    compile(target, workspace, scribe.info(_), scribe.warn(_)).flatMap { _ =>
+      debugConfigCreator.create(
+        target.id,
+        cancelPromise,
+        isTests = false,
+      ) match {
+        case Left(error) => Future.failed(new IllegalStateException(error))
+        case Right(projectFuture) =>
+          projectFuture.map { project =>
+            val patched =
+              patchProjectForRun(project, target, workspace, toolName)
+            scribe.info(
+              s"MBT debug session via $toolName: ${redactedCommand(command)}"
+            )
+            val debuggee = new BuildToolDebugAdapter(
+              Future.successful(command),
+              workspace,
+              env = javaHomeEnv(target),
+              patched,
+              userJavaHome(),
+            )
+            val handler = dap.DebugServer.run(
+              debuggee,
+              new MetalsDebugToolsResolver(),
+              new DebugLogger(),
+              gracePeriod =
+                Duration(debuggeeGracePeriodSeconds, TimeUnit.SECONDS),
+            )
+            handler.uri
+          }
+      }
     }
   }
 


### PR DESCRIPTION
Two fixes (in two commits):
* Add a compilation step before the running the binary in MBT
This mirrors the behavior for tests in MBT. The main purpose here
is to avoid timeouts in case the project wasn't precompiled before
launching (we have the 60 second timeout in which we expect the binary
to be already launched and connected to the debugger).

* For MBT targets, don't validate explicitly passed targets
This is because we might not have the -sources.jar resolved for the
dependencies, at which point it would always fail. To be honest, personally, I think it would made sense to remove that additional validation here for all build servers and just return the manually constructed ScalaMainClass (like it's done at the end of revertToDependencies anyway)
