### PR TITLE
Fix MB bazel test query and ignore user-configured test filtering

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -191,13 +191,25 @@ case class BazelBuildTool(
       case Nil => Future.successful(List(target.name))
       case single :: Nil => Future.successful(List(single))
       case multiple =>
-        val filenames = sourceFiles.map(_.filename).distinct
+        val packagePath = target.name.stripPrefix("//").split(":", 2).head
+        val packageDir = workspace.resolve(packagePath)
+        val filenames = sourceFiles
+          .flatMap(_.toRelativeInside(packageDir))
+          .map(_.toNIO.toString.replace('\\', '/'))
+          .distinct
         if (filenames.isEmpty) Future.successful(List(multiple.head))
         else {
           val setExpr =
             s"set(${multiple.flatMap(BazelQuery.quoteTarget).mkString(" ")})"
           val queryStr = filenames
-            .map(filename => s"attr(srcs, $filename, $setExpr)")
+            .map { filename =>
+              val pattern = java.util.regex.Pattern.quote(filename)
+              // "srcs" attribute will appear as [//pkg:sub/dir/File.scala]
+              // or as list [//pkg:a.scala, //pkg:sub/b.scala].
+              // We try to match the file path relative to BUILD.bazel directory
+              val quoted = s"\"[:]$pattern[,\\]]\""
+              s"attr(srcs, $quoted, $setExpr)"
+            }
             .mkString(" union ")
           val env =
             BazelQuery.Env(projectRoot, shellRunner, userConfig().javaHome)

--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -251,7 +251,7 @@ case class BazelBuildTool(
       jvmFlags.map(flag => s"--test_arg=--wrapper_script_flag=--jvm_flag=$flag")
     List(
       "bazel", "test", "--ui_event_filters=-info,-stderr,-warning",
-      "--noshow_progress", "--test_output=all",
+      "--noshow_progress", "--test_output=all", "--test_tag_filters=",
     ) ::: runTargets ::: testFilterArgs ::: jvmFlagsArgs
   }
 


### PR DESCRIPTION
Two changes:
* Fix issue with MBT bazel test query matching too many targets
When querying for SomeTest.scala with a target containing SomeTest.scala and a target containing AnotherSomeTest.scala, both were incorrectly matched. Now we make sure to match by file path relative to targets' `BUILD.bazel`.
* Make user configured test target filter empty before running
It's the added empty "--test_tag_filters=", which overrides filter setup in `.bazelrc`. I feel the main reason someone would use this is to quickly choose which tests to run with `bazel test //...` by default, which doesn't really matter for an IDE, so I feel like this is a safe change