### PR TITLE
bugfix: Highlight only the constructor name when it's clicked

### DIFF
--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDefinitionProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaDefinitionProvider.scala
@@ -318,7 +318,7 @@ class JavaDefinitionProvider(
       }
 
     if (startPos >= 0 && endPos >= 0) {
-      val elementName = targetElement.getSimpleName().toString()
+      val elementName = compiler.sourceName(targetElement)
       val (start, end) = compiler.findIndentifierStartAndEnd(
         params.text(),
         elementName,

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaMetalsCompiler.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaMetalsCompiler.scala
@@ -8,6 +8,7 @@ import java.nio.file.Path
 import java.util.concurrent.ScheduledExecutorService
 import java.{util => ju}
 import javax.lang.model.element.Element
+import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.TypeElement
 import javax.tools.JavaCompiler
@@ -244,6 +245,17 @@ class JavaMetalsCompiler(
    * @param originalStart
    * @param originalEnd
    */
+  /**
+   * The name of the element as it appears in source. For constructors
+   * `getSimpleName` returns the internal `<init>`, so we fall back to the
+   * enclosing type's name, which is what is actually written in the source.
+   */
+  def sourceName(element: Element): String =
+    if (element.getKind() == ElementKind.CONSTRUCTOR)
+      element.getEnclosingElement().getSimpleName().toString()
+    else
+      element.getSimpleName().toString()
+
   def findIndentifierStartAndEnd(
       text: String,
       elementName: String,

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaRenameProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaRenameProvider.scala
@@ -65,7 +65,7 @@ class JavaRenameProvider(
             sourcePositions.getEndPosition(compile.cu, treePath.getLeaf())
           val (realStart, realEnd) = compiler.findIndentifierStartAndEnd(
             params.text(),
-            element.getSimpleName().toString(),
+            compiler.sourceName(element),
             start.toInt,
             end.toInt,
             treePath.getLeaf(),

--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/ReferenceScanner.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/ReferenceScanner.scala
@@ -37,7 +37,7 @@ abstract class ReferenceScanner[T](
         val treeEnd = sourcePositions.getEndPosition(root, tree)
         if (treeStart >= 0 && treeEnd >= 0) {
           // Extract just the name position from the full tree range
-          val elementName = element.getSimpleName().toString()
+          val elementName = compiler.sourceName(element)
 
           // Find the name as a complete identifier, not as a substring
           val (start, end) = compiler.findIndentifierStartAndEnd(

--- a/tests/javapc/src/test/scala/highlight/JavaDocumentHighlightSuite.scala
+++ b/tests/javapc/src/test/scala/highlight/JavaDocumentHighlightSuite.scala
@@ -233,6 +233,30 @@ class JavaDocumentHighlightSuite extends BaseJavaPCSuite with RangeReplace {
   )
 
   check(
+    "constructor-name-def",
+    """|class Foo {
+       |    public <<F@@oo>>() {}
+       |    public static Foo create() {
+       |        return new <<Foo>>();
+       |    }
+       |}
+       |""".stripMargin,
+  )
+
+  // Clicking on `new Foo()` resolves to the type `Foo`, so all type
+  // occurrences are highlighted (not just the constructor).
+  check(
+    "constructor-name-usage",
+    """|class <<Foo>> {
+       |    public Foo() {}
+       |    public static <<Foo>> create() {
+       |        return new <<F@@oo>>();
+       |    }
+       |}
+       |""".stripMargin,
+  )
+
+  check(
     "this-reference",
     """|class Foo {
        |    private int <<value>>;


### PR DESCRIPTION
fixes #8591 

## DEMO
### Before
https://github.com/user-attachments/assets/7212fb73-c969-4788-aed9-2b0fbde9142e

### After
https://github.com/user-attachments/assets/22d6861d-e61d-46a1-a756-a06412b4e8c0

___

# Fix: Constructor name highlighting/rename covered the whole constructor

## Problem
Placing the cursor on a Java constructor name (e.g. `Sample` in `public Sample(String name)`)
highlighted the **entire constructor** instead of just its name. The same issue affected
find-references, rename, and go-to-definition for constructors.

## Root cause
The name lookup searched the source text for `element.getSimpleName()`. For constructors that
simple name is the internal `<init>`, which never appears in source. `String.indexOf("<init>")`
returned `-1`, so `JavaMetalsCompiler.findIndentifierStartAndEnd` fell through to its
whole-tree-span fallback `(originalStart, originalEnd)` — the full constructor range.

## Fix
Added a `sourceName(element)` helper in `JavaMetalsCompiler` that returns the enclosing type's
simple name for constructors (what is actually written in source) and the element's simple name
otherwise. Routed the three name-lookup call sites through it:

- `mtags-java/.../jpc/JavaMetalsCompiler.scala` — new `sourceName` helper
- `mtags-java/.../jpc/ReferenceScanner.scala` — fixes document highlight **and** find-references
- `mtags-java/.../jpc/JavaRenameProvider.scala` — fixes `prepareRename` range
- `mtags-java/.../jpc/JavaDefinitionProvider.scala` — fixes go-to-definition landing range

## Tests
Added regression tests in `tests/javapc/.../highlight/JavaDocumentHighlightSuite.scala`:

- `constructor-name-def` — cursor on the constructor declaration name now highlights just the name.
- `constructor-name-usage` — documents that clicking `new Foo()` resolves to the *type* (an
  unrelated pre-existing behavior).

All 73 highlight + rename tests pass; `mtags-java` compiles clean; formatted with scalafmt and
scalafixAll.

## Known limitation (pre-existing, not changed)
Clicking on a constructor **call** (`new Foo()`) resolves to the type element, so it highlights
all type occurrences rather than only the specific constructor overload.
