### PR TITLE
improvement: Don't wait for turbine in wrapping up phase

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -679,7 +679,15 @@ class ConnectionProvider(
         }
         _ = compilers.cancel()
         buildChange <- index(check, progress)
-        _ <- refreshMbtTurbineClasspath(session).withInterrupt
+        // When testing we need to make sure the classpath is refreshed after mbt.json is generated
+        _ <- {
+          if (MetalsServerConfig.isTesting)
+            refreshMbtTurbineClasspath(session).withInterrupt
+          else
+            Future {
+              refreshMbtTurbineClasspath(session)
+            }.withInterrupt
+        }
       } yield {
         syncStatusReporter.importFinished(focusedDocument.map(_.toURI.toString))
         buildChange


### PR DESCRIPTION
We would wait until next compilation and "wrapping up" would only disapear later.