### PR TITLE
Resolve artifact symlinks if they come from an unpinned repository

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMavenJsonImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMavenJsonImporter.scala
@@ -27,7 +27,7 @@ object BazelMavenJsonImporter {
   private val gson = new Gson()
 
   /** Pre-scanned snapshot of an external directory listing. */
-  private[importer] case class ScannedExtDir(
+  case class ScannedExtDir(
       dir: AbsolutePath,
       entries: List[AbsolutePath],
   )

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/bazel/MavenLockFileParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/bazel/MavenLockFileParser.scala
@@ -13,14 +13,22 @@ import com.google.gson.JsonObject
 object MavenLockFileParser {
   def create(json: JsonObject): Option[MavenLockFileParser] = {
     Option(json.getAsJsonObject("artifacts")) match {
-      case Some(artifacts) => Some(new V5LockFileParser(artifacts))
+      case Some(artifacts) =>
+        scribe.debug("Using the v5 parser for the rules_jvm_external lock file")
+        Some(new V5LockFileParser(artifacts))
       case None =>
         Option(json.getAsJsonObject("dependency_tree"))
           .flatMap(dt => Option(dt.getAsJsonArray("dependencies"))) match {
           case Some(dependencies) =>
+            scribe.debug(
+              "Using the legacy (v4 and earlier) parser for the rules_jvm_external lock file"
+            )
             Some(new LegacyLockFileParser(dependencies))
           case None =>
             // Unknown format; possibly a newer version, or not a lock file at all
+            scribe.warn(
+              "Could not determine the format of rules_jvm_external lock file; skipping"
+            )
             None
         }
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/bazel/MavenLockFileParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/bazel/MavenLockFileParser.scala
@@ -84,7 +84,15 @@ trait MavenLockFileParser {
         )
       }
 
-      found
+      found.map { maybeSymlink =>
+        // The "unpinned" repository is a symlink to the actual location of the artifacts.
+        // If the workspace uses the lock file, this symlink may be removed automatically
+        // once the dependencies have been pinned.
+        // To ensure the JAR is still found, we need to dealias the symlink.
+        val actualPath = maybeSymlink.dealias
+        scribe.debug(s"Dealiased $maybeSymlink to $actualPath")
+        actualPath
+      }
     }
   }
 

--- a/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
@@ -222,7 +222,7 @@ class BazelDapMbtLspSuite
     } yield assertContains(output, "FooBar")
   }
 
-  test("bazel-mbt-test-multiple-test-targets-same-build-file", maxRetry = 3) {
+  test("bazel-mbt-test-multiple-test-targets-same-build-file") {
     client.selectedServer = Messages.ChooseBuildServer.mbt
     cleanWorkspace()
 

--- a/tests/unit/src/test/scala/tests/bazel/MavenLockFileParserTest.scala
+++ b/tests/unit/src/test/scala/tests/bazel/MavenLockFileParserTest.scala
@@ -4,6 +4,7 @@ import java.nio.file.Files
 
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.mbt.MbtDependencyModule
+import scala.meta.internal.metals.mbt.importer.BazelMavenJsonImporter.ScannedExtDir
 import scala.meta.internal.metals.mbt.importer.bazel.MavenLockFileParser
 import scala.meta.io.AbsolutePath
 
@@ -14,22 +15,27 @@ import tests.BaseSuite
 class MavenLockFileParserTest extends BaseSuite {
 
   private val gson = new Gson()
-  private var tmpDir: Option[AbsolutePath] = None
+  private var tmpDir: AbsolutePath = null
 
   override def beforeAll(): Unit = {
-    val tmp = AbsolutePath(Files.createTempDirectory("mock artifact repo "))
-    tmpDir = Some(tmp)
+    tmpDir = AbsolutePath(Files.createTempDirectory("mock artifact repo "))
+    tmpDir.resolve("external").createDirectories()
+    Seq(
+      "rules_jvm_external~~maven~com_fasterxml_jackson_core_jackson_annotations_2_16_1/file/v1/com/fasterxml/jackson/core/jackson-annotations/2.16.1/jackson-annotations-2.16.1.jar",
+      "rules_jvm_external~~maven~com_fasterxml_jackson_core_jackson_core_2_16_1/file/v1/com/fasterxml/jackson/core/jackson-core/2.16.1/jackson-core-2.16.1.jar",
+      "rules_jvm_external~~maven~com_fasterxml_jackson_core_jackson_databind_2_16_1/file/v1/com/fasterxml/jackson/core/jackson-databind/2.16.1/jackson-databind-2.16.1.jar",
+    ).foreach { path =>
+      tmpDir.resolve("external").resolve(path).writeBytes(Array.emptyByteArray)
+    }
   }
 
   override def afterAll(): Unit = {
-    tmpDir.foreach(_.deleteRecursively())
+    Option(tmpDir).foreach(_.deleteRecursively())
   }
 
-  private def toUriString(relativePath: String) =
-    userHome.resolve(relativePath).toUri().toString()
-
   test("parsing legacy lock file (up to version 4)") {
-    // Excerpt from a real project
+    // Excerpt from a real project.
+    // Some fields are omitted for brevity, because the parser doesn't rely on them anyway.
     // https://github.com/wix-incubator/exodus/blob/dfb0c9713b07a8b6a49b548b7b543021e748d80b/maven_install.json#L142-L189
     val lockFileContents =
       """|{
@@ -37,30 +43,12 @@ class MavenLockFileParserTest extends BaseSuite {
          |    "dependencies": [
          |      {
          |        "coord": "com.fasterxml.jackson.core:jackson-annotations:2.9.6",
-         |        "dependencies": [],
-         |        "directDependencies": [],
          |        "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.6/jackson-annotations-2.9.6.jar",
-         |        "mirror_urls": [
-         |          "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.6/jackson-annotations-2.9.6.jar",
-         |          "https://mvnrepository.com/artifact/com/fasterxml/jackson/core/jackson-annotations/2.9.6/jackson-annotations-2.9.6.jar",
-         |          "https://maven-central.storage.googleapis.com/com/fasterxml/jackson/core/jackson-annotations/2.9.6/jackson-annotations-2.9.6.jar",
-         |          "http://gitblit.github.io/gitblit-maven/com/fasterxml/jackson/core/jackson-annotations/2.9.6/jackson-annotations-2.9.6.jar"
-         |        ],
-         |        "sha256": "4d1ce5575ad53bee8caae4c15016878e2c3ea47276e675a35ea6bdde3bb0e653",
          |        "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.6/jackson-annotations-2.9.6.jar"
          |      },
          |      {
          |        "coord": "com.fasterxml.jackson.core:jackson-core:2.9.6",
-         |        "dependencies": [],
-         |        "directDependencies": [],
          |        "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar",
-         |        "mirror_urls": [
-         |          "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar",
-         |          "https://mvnrepository.com/artifact/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar",
-         |          "https://maven-central.storage.googleapis.com/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar",
-         |          "http://gitblit.github.io/gitblit-maven/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar"
-         |        ],
-         |        "sha256": "fab8746aedd6427788ee390ea04d438ec141bff7eb3476f8bdd5d9110fb2718a",
          |        "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar"
          |      },
          |      {
@@ -74,13 +62,6 @@ class MavenLockFileParserTest extends BaseSuite {
          |          "com.fasterxml.jackson.core:jackson-core:2.9.6"
          |        ],
          |        "file": "v1/https/repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.6/jackson-databind-2.9.6.jar",
-         |        "mirror_urls": [
-         |          "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.6/jackson-databind-2.9.6.jar",
-         |          "https://mvnrepository.com/artifact/com/fasterxml/jackson/core/jackson-databind/2.9.6/jackson-databind-2.9.6.jar",
-         |          "https://maven-central.storage.googleapis.com/com/fasterxml/jackson/core/jackson-databind/2.9.6/jackson-databind-2.9.6.jar",
-         |          "http://gitblit.github.io/gitblit-maven/com/fasterxml/jackson/core/jackson-databind/2.9.6/jackson-databind-2.9.6.jar"
-         |        ],
-         |        "sha256": "657e3e979446d61f88432b9c50f0ccd9c1fe4f1c822d533f5572e4c0d172a125",
          |        "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.6/jackson-databind-2.9.6.jar"
          |      },
          |    ]
@@ -98,23 +79,32 @@ class MavenLockFileParserTest extends BaseSuite {
     val expectedOutput = Seq(
       MbtDependencyModule(
         "com.fasterxml.jackson.core:jackson-annotations:2.9.6",
-        toUriString(
-          ".m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.9.6/jackson-annotations-2.9.6.jar"
-        ),
+        userHome
+          .resolve(
+            ".m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.9.6/jackson-annotations-2.9.6.jar"
+          )
+          .toUri()
+          .toString(),
         null,
       ),
       MbtDependencyModule(
         "com.fasterxml.jackson.core:jackson-core:2.9.6",
-        toUriString(
-          ".m2/repository/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar"
-        ),
+        userHome
+          .resolve(
+            ".m2/repository/com/fasterxml/jackson/core/jackson-core/2.9.6/jackson-core-2.9.6.jar"
+          )
+          .toUri()
+          .toString(),
         null,
       ),
       MbtDependencyModule(
         "com.fasterxml.jackson.core:jackson-databind:2.9.6",
-        toUriString(
-          ".m2/repository/com/fasterxml/jackson/core/jackson-databind/2.9.6/jackson-databind-2.9.6.jar"
-        ),
+        userHome
+          .resolve(
+            ".m2/repository/com/fasterxml/jackson/core/jackson-databind/2.9.6/jackson-databind-2.9.6.jar"
+          )
+          .toUri()
+          .toString(),
         null,
       ),
     )
@@ -122,30 +112,19 @@ class MavenLockFileParserTest extends BaseSuite {
   }
 
   test("parsing version 5 lock file") {
-    // Excerpt from a real project
+    // Excerpt from a real project.
+    // Some fields are omitted for brevity, because the parser doesn't rely on them anyway.
     // https://github.com/VirtusLab/bazel-steward/blob/bbe566eb97156b923df8d25c0e69ba469324b793/maven_install.json
     val lockFileContents =
       """|{
          |  "artifacts": {
          |    "com.fasterxml.jackson.core:jackson-annotations": {
-         |      "shasums": {
-         |        "jar": "a4730771e6a495dd3793a42cdb8ce6bddb96c77e15f40c98fd8d9a7ae09e7286",
-         |        "sources": "cebdb714198d5b3a152efb9e940dc9eb26cb37aa688ce34431b99afb790f6be3"
-         |      },
          |      "version": "2.16.1"
          |    },
          |    "com.fasterxml.jackson.core:jackson-core": {
-         |      "shasums": {
-         |        "jar": "f5f8ef90609e64fec82eb908e497dc7d81b2eb983fe509b870292a193cde4dfb",
-         |        "sources": "1bd334b0de7d02d7f8a6591f775a28126b1cdce9cd9ae6dc260482b7bdd9a04c"
-         |      },
          |      "version": "2.16.1"
          |    },
          |    "com.fasterxml.jackson.core:jackson-databind": {
-         |      "shasums": {
-         |        "jar": "baf8a8ebee8f45ef68cdd5e2dd3923b3e296c0937b96ec0b4806aa3a31bccd1d",
-         |        "sources": "91390204018cbeb9c5ed6e60c2624b63c8221082af9b0e94ce7f2d926ec48e2c"
-         |      },
          |      "version": "2.16.1"
          |    }
          |  },
@@ -153,16 +132,6 @@ class MavenLockFileParserTest extends BaseSuite {
          |    "com.fasterxml.jackson.core:jackson-databind": [
          |      "com.fasterxml.jackson.core:jackson-annotations",
          |      "com.fasterxml.jackson.core:jackson-core"
-         |    ]
-         |  },
-         |  "repositories": {
-         |    "https://repo.maven.apache.org/maven2/": [
-         |      "com.fasterxml.jackson.core:jackson-annotations",
-         |      "com.fasterxml.jackson.core:jackson-annotations:jar:sources",
-         |      "com.fasterxml.jackson.core:jackson-core",
-         |      "com.fasterxml.jackson.core:jackson-core:jar:sources",
-         |      "com.fasterxml.jackson.core:jackson-databind",
-         |      "com.fasterxml.jackson.core:jackson-databind:jar:sources"
          |    ]
          |  }
          |}
@@ -173,7 +142,61 @@ class MavenLockFileParserTest extends BaseSuite {
       parser.isDefined,
       "Could not find a matching parser for the lock file",
     )
-    // TODO set up the scanned directories and assert that dependency modules are created correctly
+    val repositoryNames = Seq("maven")
+    val repoDir = tmpDir.resolve("external")
+    val scannedRepoDirs = Seq(
+      ScannedExtDir(
+        dir = repoDir,
+        entries = List(
+          repoDir.resolve(
+            "rules_jvm_external~~maven~com_fasterxml_jackson_core_jackson_annotations_2_16_1"
+          ),
+          repoDir.resolve(
+            "rules_jvm_external~~maven~com_fasterxml_jackson_core_jackson_core_2_16_1"
+          ),
+          repoDir.resolve(
+            "rules_jvm_external~~maven~com_fasterxml_jackson_core_jackson_databind_2_16_1"
+          ),
+        ),
+      )
+    )
+    val output = parser.get.parse(repositoryNames, scannedRepoDirs)
+    val expectedOutput = Seq(
+      MbtDependencyModule(
+        "com.fasterxml.jackson.core:jackson-annotations:2.16.1",
+        tmpDir
+          .resolve("external")
+          .resolve(
+            "rules_jvm_external~~maven~com_fasterxml_jackson_core_jackson_annotations_2_16_1/file/v1/com/fasterxml/jackson/core/jackson-annotations/2.16.1/jackson-annotations-2.16.1.jar"
+          )
+          .toURI
+          .toString(),
+        null,
+      ),
+      MbtDependencyModule(
+        "com.fasterxml.jackson.core:jackson-core:2.16.1",
+        tmpDir
+          .resolve("external")
+          .resolve(
+            "rules_jvm_external~~maven~com_fasterxml_jackson_core_jackson_core_2_16_1/file/v1/com/fasterxml/jackson/core/jackson-core/2.16.1/jackson-core-2.16.1.jar"
+          )
+          .toURI
+          .toString(),
+        null,
+      ),
+      MbtDependencyModule(
+        "com.fasterxml.jackson.core:jackson-databind:2.16.1",
+        tmpDir
+          .resolve("external")
+          .resolve(
+            "rules_jvm_external~~maven~com_fasterxml_jackson_core_jackson_databind_2_16_1/file/v1/com/fasterxml/jackson/core/jackson-databind/2.16.1/jackson-databind-2.16.1.jar"
+          )
+          .toURI
+          .toString(),
+        null,
+      ),
+    )
+    assertEquals(output, expectedOutput)
   }
 
 }


### PR DESCRIPTION
### Refactoring
* Improved the test for the new lock file parser
* Log the chosen parser type when reading the lock file
### Resolve artifact symlinks if they come from an unpinned repository
These changes have exposed a bug in the way we handle resolved paths to Maven artifacts. Here's a summary of the problem (courtesy of AI):

> Bazel keeps Maven artifacts in two places:
> 1. **Output base** (`/private/var/tmp/_bazel_.../external/`) — full cache of everything Bazel has fetched
> 2. **Workspace-local external** (`<project>/bazel-<name>/external/`) — symlinks to repos the **current build graph** actually needs
>
> With `rules_jvm_external` under bzlmod, `unpinned_maven` is an internal **hub repo** used while pinning/fetching:
> - It holds the aggregated `v1/https/...` mirror layout
> - It’s used by `bazel run @maven//:pin` and related fetch steps
> Actual build targets don’t depend on it.

To put it shortly,

> `unpinned_maven` paths go stale because Bazel treats that repo as temporary infrastructure, while Metals snapshots a workspace-local path that Bazel later removes from the project’s external view. If per-artifact repos aren’t listed yet at import time, it falls through to `unpinned_maven` and records that transient path.

This problem had gone largely without consequences because of the way we have been building the index of repository listings — the unreliable unpinned paths were nearly always last in the list. However, it had manifested itself in test flakiness, so it might have some impact in real usage as well.