### PR TITLE
improvement: Extract Java files generated from Protobuf definitions from source JARs

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -78,6 +78,7 @@ final class DefinitionProvider(
     mbt,
     definitionProviders,
     protobufLspConfig,
+    mtags,
   )
   val destinationProvider = new DestinationProvider(
     index,

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProviderProtobufSupport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProviderProtobufSupport.scala
@@ -2,15 +2,20 @@ package scala.meta.internal.metals
 
 import java.{util => ju}
 
+import scala.util.Try
 import scala.util.control.NonFatal
 
+import scala.meta.dialects
 import scala.meta.internal.jmbt.Mbt
 import scala.meta.internal.metals.Configs.DefinitionProviderConfig
 import scala.meta.internal.metals.Configs.ProtobufLspConfig
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
+import scala.meta.internal.metals.mbt.ProtoGeneratedJavaFiles
 import scala.meta.internal.metals.mbt.ProtoJavaVirtualFile
+import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.Symbol
+import scala.meta.internal.semanticdb.SymbolOccurrence
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 
@@ -22,6 +27,7 @@ final class DefinitionProviderProtobufSupport(
     mbt: MbtWorkspaceSymbolProvider,
     definitionProviders: () => DefinitionProviderConfig,
     protobufLspConfig: () => ProtobufLspConfig,
+    mtags: () => Mtags,
 ) {
 
   def hasProtoJavaLocation(res: DefinitionResult): Boolean =
@@ -88,11 +94,17 @@ final class DefinitionProviderProtobufSupport(
   def handleProtoJavaDefinition(
       res: DefinitionResult
   ): Option[DefinitionResult] = {
-    val mbtResult = mbt.definition(res.symbol)
-    if (mbtResult.nonEmpty) {
-      val locations = new ju.ArrayList[Location](mbtResult.size)
-      mbtResult.foreach(locations.add)
-      return Some(
+    // When the proto file declares no java_package option, the proto package
+    // matches the generated Java package, so the MBT index resolves the Java
+    // symbol straight to the proto document. Those proto-file hits are ignored
+    // here so the generated srcjar lookup still runs; the proto file stays
+    // reachable through the fallback below.
+    val mbtJavaResult =
+      mbt.definition(res.symbol).filterNot(_.getUri.isProtoFilename)
+    if (mbtJavaResult.nonEmpty) {
+      val locations = new ju.ArrayList[Location](mbtJavaResult.size)
+      mbtJavaResult.foreach(locations.add)
+      Some(
         DefinitionResult(
           locations,
           res.symbol,
@@ -101,11 +113,16 @@ final class DefinitionProviderProtobufSupport(
           res.querySymbol,
         )
       )
-    }
+    } else {}
 
-    val protoUri =
-      if (res.locations.isEmpty) None
-      else ProtoJavaVirtualFile.extractProtoPath(res.locations.get(0).getUri())
+    val virtualUri = Try(res.locations.get(0)).toOption.map(_.getUri())
+    val protoUri = virtualUri.flatMap(ProtoJavaVirtualFile.extractProtoPath)
+
+    val generatedJavaLocation = for {
+      uri <- virtualUri
+      protoPath <- protoUri
+      location <- findGeneratedJavaFromOutline(protoPath, res.symbol, uri)
+    } yield location
 
     val protoClassLocation = protoUri.flatMap { protoPath =>
       findProtoClassFromJavaSymbol(protoPath, res.symbol)
@@ -123,24 +140,110 @@ final class DefinitionProviderProtobufSupport(
       }
     }
 
-    protoRpcLocation match {
-      case Some(loc) =>
-        Some(
-          DefinitionResult(
-            ju.Collections.singletonList(loc),
-            res.symbol,
-            None,
-            None,
-            res.querySymbol,
-          )
+    val allLocations = (generatedJavaLocation ++ protoRpcLocation).toList
+    if (allLocations.nonEmpty) {
+      Some(
+        DefinitionResult(
+          allLocations.asJava,
+          res.symbol,
+          None,
+          None,
+          res.querySymbol,
         )
-      case None =>
-        scribe.debug(
-          s"proto-java: could not resolve symbol ${res.symbol} to proto"
-        )
-        Some(DefinitionResult.empty)
+      )
+    } else {
+      scribe.debug(
+        s"proto-java: could not resolve symbol ${res.symbol} to proto"
+      )
+      Some(DefinitionResult.empty)
     }
   }
+
+  /**
+   * Finds the definition of `javaSymbol` in the Java source that Metals
+   * synthesizes from the proto file. The outline is derived purely from the
+   * `.proto`, so this works for any build tool without a build or any
+   * configuration; it is materialized to a read-only file on disk so the
+   * client can open it.
+   */
+  private def findGeneratedJavaFromOutline(
+      protoPath: AbsolutePath,
+      javaSymbol: String,
+      virtualUri: String,
+  ): Option[Location] = try {
+    for {
+      className <- ProtoJavaVirtualFile.extractClassName(virtualUri)
+      outline <- mbt
+        .protoJavaOutlines(protoPath)
+        .find(outline =>
+          ProtoJavaVirtualFile
+            .extractClassName(outline.uri().toString())
+            .contains(className)
+        )
+      javaFile <- ProtoGeneratedJavaFiles.materialize(
+        workspace,
+        protoPath,
+        outline.pkg,
+        className,
+        outline.text,
+      )
+      range <- findJavaSymbolRange(javaFile, javaSymbol)
+    } yield new Location(javaFile.toURI.toString(), range.toLsp)
+  } catch {
+    case NonFatal(e) =>
+      scribe.debug(
+        s"proto-java: failed to resolve generated Java outline for $javaSymbol",
+        e,
+      )
+      None
+  }
+
+  /**
+   * Locates the definition range of `javaSymbol` in the given Java file,
+   * falling back to enclosing classes when the exact symbol is absent, for
+   * example when method overload disambiguators computed from the generated
+   * outline don't line up with the real generated source.
+   */
+  private def findJavaSymbolRange(
+      javaFile: AbsolutePath,
+      javaSymbol: String,
+  ): Option[s.Range] = {
+    val input = javaFile.toInputFromBuffers(buffers)
+    val doc = mtags().allToplevels(input, dialects.Scala213)
+    val definitions =
+      doc.occurrences.filter(_.role == s.SymbolOccurrence.Role.DEFINITION)
+
+    def loop(sym: Symbol): Option[s.Range] = {
+      if (sym.isNone || sym.isPackage) None
+      else findRange(sym.value, definitions).orElse(loop(sym.owner))
+    }
+
+    val querySym = Symbol(javaSymbol)
+    // For type symbols, require the type itself to be present: a message or
+    // enum missing from the generated source means the srcjar is stale or
+    // belongs to a different proto, and the proto fallback is more precise
+    // than an approximate enclosing-class location. Members may still fall
+    // back to their enclosing classes, since accessor overloads in the real
+    // generated source don't always line up with the synthesized outline.
+    if (querySym.isType) findRange(querySym.value, definitions)
+    else loop(querySym)
+  }
+
+  private def findRange(
+      symbol: String,
+      definitions: Iterable[SymbolOccurrence],
+  ): Option[s.Range] = {
+    val exact = definitions.find(_.symbol == symbol)
+    exact
+      .orElse {
+        val normalized = stripDisambiguators(symbol)
+        definitions.find(occ => stripDisambiguators(occ.symbol) == normalized)
+      }
+      .flatMap(_.range)
+  }
+
+  private def stripDisambiguators(symbol: String): String =
+    symbol.replaceAll("""\(\+\d+\)""", "()")
 
   private def symbolSuffixAfterPackage(sym: Symbol): List[String] = {
     val pkg = sym.enclosingPackage

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/GitVCS.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/GitVCS.scala
@@ -152,57 +152,70 @@ object GitVCS {
         val extractDir = workspace
           .resolve(Directories.dependencies)
           .resolveZipPath(relPath)
-        val jarMetaFile = extractDir.resolve(".jar.meta")
-        val currentMeta =
-          s"${Files.getLastModifiedTime(srcJar.toNIO).toMillis}\n${srcJar.toNIO}"
-        val cachedMeta =
-          if (jarMetaFile.exists)
-            Some(FileIO.slurp(jarMetaFile, StandardCharsets.UTF_8))
-          else None
-        if (cachedMeta.contains(currentMeta) && extractDir.exists) {
-          if (!extractOnly)
-            lsFilesFromDirs(Seq(extractDir), isRelevantPath).foreach(
-              result += _
-            )
-        } else {
-          extractDir.deleteRecursively()
-          if (!extractDir.exists) extractDir.createDirectories()
-          FileIO.withJarFileSystem(srcJar, create = false) { root =>
-            root.listRecursive.foreach { path =>
-              val blob = new GitBlob(path.toNIO.toString, Array.emptyByteArray)
-              if (path.isFile && isRelevantPath(blob)) {
-                try {
-                  val diskPath = extractDir.resolveZipPath(path.toNIO)
-                  Files.createDirectories(diskPath.toNIO.getParent)
-                  Files.copy(
-                    path.toNIO,
-                    diskPath.toNIO,
-                    StandardCopyOption.REPLACE_EXISTING,
-                  )
-                  if (!extractOnly) {
-                    val oid = OID.fromBlob(Files.readAllBytes(diskPath.toNIO))
-                    result += new GitBlob(
-                      diskPath.toString,
-                      oid.getBytes(StandardCharsets.UTF_8),
-                    )
-                  }
-                } catch {
-                  case NonFatal(_) =>
-                }
-              }
-            }
-          }
-          Files.write(
-            jarMetaFile.toNIO,
-            currentMeta.getBytes(StandardCharsets.UTF_8),
-          )
-        }
+        extractSrcJarInto(
+          srcJar,
+          extractDir,
+          isRelevantPath,
+          if (extractOnly) None else Some(result),
+        )
       } catch {
         case NonFatal(e) =>
           scribe.warn(s"mbt-v2: failed to read srcjar $srcJar", e)
       }
     }
     result.result()
+  }
+
+  private def extractSrcJarInto(
+      srcJar: AbsolutePath,
+      extractDir: AbsolutePath,
+      isRelevantPath: GitBlob => Boolean,
+      result: Option[mutable.Growable[GitBlob]],
+  ): Unit = {
+    val jarMetaFile = extractDir.resolve(".jar.meta")
+    val currentMeta =
+      s"${Files.getLastModifiedTime(srcJar.toNIO).toMillis}\n${srcJar.toNIO}"
+    val cachedMeta =
+      if (jarMetaFile.exists)
+        Some(FileIO.slurp(jarMetaFile, StandardCharsets.UTF_8))
+      else None
+    if (cachedMeta.contains(currentMeta) && extractDir.exists) {
+      result.foreach { r =>
+        lsFilesFromDirs(Seq(extractDir), isRelevantPath).foreach(r += _)
+      }
+    } else {
+      extractDir.deleteRecursively()
+      if (!extractDir.exists) extractDir.createDirectories()
+      FileIO.withJarFileSystem(srcJar, create = false) { root =>
+        root.listRecursive.foreach { path =>
+          val blob = new GitBlob(path.toNIO.toString, Array.emptyByteArray)
+          if (path.isFile && isRelevantPath(blob)) {
+            try {
+              val diskPath = extractDir.resolveZipPath(path.toNIO)
+              Files.createDirectories(diskPath.toNIO.getParent)
+              Files.copy(
+                path.toNIO,
+                diskPath.toNIO,
+                StandardCopyOption.REPLACE_EXISTING,
+              )
+              result.foreach { r =>
+                val oid = OID.fromBlob(Files.readAllBytes(diskPath.toNIO))
+                r += new GitBlob(
+                  diskPath.toString,
+                  oid.getBytes(StandardCharsets.UTF_8),
+                )
+              }
+            } catch {
+              case NonFatal(_) =>
+            }
+          }
+        }
+      }
+      Files.write(
+        jarMetaFile.toNIO,
+        currentMeta.getBytes(StandardCharsets.UTF_8),
+      )
+    }
   }
 
   private def isIgnoredDirectory(dir: Path): Boolean = {

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/IndexedDocument.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/IndexedDocument.scala
@@ -61,6 +61,16 @@ case class IndexedDocument(
     cachedProtobufJavaOutlines.set(null)
   }
 
+  /**
+   * The generated Java outlines cached by a previous
+   * [[getOrComputeJavaOutlines]] call, without computing them. Reading the
+   * cache matters when the proto file has changed on disk or in buffers:
+   * recomputing would produce outlines for the new content, while the cache
+   * still describes what earlier consumers (like the turbine classpath) saw.
+   */
+  def cachedJavaOutlines: Seq[VirtualTextDocument] =
+    Option(cachedProtobufJavaOutlines.get()).getOrElse(Seq.empty)
+
   def toSemanticdbCompilationUnit(
       input: Input.VirtualFile
   ): SemanticdbCompilationUnit with JavaFileObject = {

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
@@ -230,7 +230,11 @@ object MbtBuild {
           .getOrElse(ju.Collections.emptyList())
           .asScala).distinct.asJava
 
-    MbtBuild(mergedModules, mergedNamespaces, mergedUncheckedSources)
+    MbtBuild(
+      mergedModules,
+      mergedNamespaces,
+      mergedUncheckedSources,
+    )
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtProtobufWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtProtobufWorkspaceSymbolProvider.scala
@@ -87,7 +87,19 @@ final class MbtProtobufWorkspaceSymbolProvider(
   ): Iterator[VirtualTextDocument] = {
     val packagePath = requestedPackage.stripSuffix("/").replace('/', '.')
 
-    val allOutlines = doc.getOrComputeJavaOutlines(() =>
+    allJavaOutlines(doc).iterator.filter { outline =>
+      outline.packages.headOption
+        .map(_.stripSuffix("/").replace('/', '.'))
+        .contains(packagePath)
+    }
+  }
+
+  /**
+   * All Java outlines generated from the given proto document, regardless of
+   * package.
+   */
+  def allJavaOutlines(doc: IndexedDocument): Seq[VirtualTextDocument] = {
+    doc.getOrComputeJavaOutlines(() =>
       try {
         val input = doc.file.toInputFromBuffers(buffers)
         val source = new ProtoSourceFile(input.path, input.text)
@@ -136,12 +148,6 @@ final class MbtProtobufWorkspaceSymbolProvider(
           Seq.empty
       }
     )
-
-    allOutlines.iterator.filter { outline =>
-      outline.packages.headOption
-        .map(_.stripSuffix("/").replace('/', '.'))
-        .contains(packagePath)
-    }
   }
 
   def findProtoRpcDefinition(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -125,19 +125,45 @@ class MbtWorkspaceSymbolProvider(
 
   private val indexFile: AbsolutePath = workspace.resolve(".metals/index.mbt")
   private val isIndexing: AtomicBoolean = new AtomicBoolean(false)
+
   private lazy val protobufWorkspace = new MbtProtobufWorkspaceSymbolProvider(
     buffers,
     protobufLspConfig,
     clearAllProtobufCaches,
   )
+
+  /**
+   * The Java outlines synthesized from the given `.proto` file (one per
+   * generated top-level class). Empty when the file isn't an indexed proto or
+   * proto Java-package indexing is disabled.
+   */
+  def protoJavaOutlines(file: AbsolutePath): Seq[VirtualTextDocument] =
+    documents.get(file).toSeq.flatMap(protobufWorkspace.allJavaOutlines)
   private val turbineCompiler: TurbineCompiler[AbsolutePath] =
     new TurbineCompiler[AbsolutePath](
       () => documentsKeys,
       file =>
-        if (!file.toLanguage.isJava) None
-        else
+        if (file.toLanguage.isJava) {
           toInput(file)
-            .map(input => new SourceFile(file.toString(), input.text)),
+            .map(input => new SourceFile(file.toString(), input.text))
+            .toList
+        } else if (
+          file.isProtoFilename &&
+          protobufWorkspace.isJavaPackageIndexingEnabled
+        ) {
+          // Include the Java outlines generated from proto files so that
+          // turbine can resolve references to proto-generated classes when it
+          // header-compiles the workspace. Without these, a Java method
+          // returning a proto-generated class gets its signature erased to
+          // java.lang.Object in the compiled classfile, breaking hover and
+          // completion in files that use that method.
+          for {
+            doc <- documents.get(file).toList
+            outline <- protobufWorkspace.allJavaOutlines(doc)
+          } yield new SourceFile(outline.getName(), outline.text)
+        } else {
+          Nil
+        },
       () => fallbackClasspaths().javaCompilerClasspath(),
       progress,
       // We don't need to re-compile the workspace super regularly because we can
@@ -173,7 +199,32 @@ class MbtWorkspaceSymbolProvider(
    */
   def didSave(path: AbsolutePath): Unit = {
     if (path.isProtoFilename) {
-      documents.get(path).foreach(_.clearProtobufJavaOutlinesCache())
+      documents.get(path).foreach { doc =>
+        invalidateCompiledProtoJavaOutlines(path, doc)
+        doc.clearProtobufJavaOutlinesCache()
+      }
+    }
+  }
+
+  /**
+   * Excludes proto-generated classes that were compiled into the turbine
+   * classpath from a previous version of the given proto file. Javac keeps
+   * resolving the current classes from fresh SOURCE_PATH outlines; without
+   * this, classes removed from the proto file would remain resolvable from
+   * stale classfiles until the next turbine recompile.
+   */
+  private def invalidateCompiledProtoJavaOutlines(
+      file: AbsolutePath,
+      doc: IndexedDocument,
+  ): Unit = {
+    if (javaSymbolLoader().isTurbineClasspath) {
+      val binaryNames = doc.cachedJavaOutlines
+        .flatMap(_.toplevelSymbols().asScala)
+        .map(_.stripSuffix("#").stripSuffix("."))
+      if (binaryNames.nonEmpty) {
+        turbineCompiler.onDidDelete(binaryNames, file.toURI.toString())
+        turbineCompiler.scheduleCompile().ignoreValue
+      }
     }
   }
   private def clearAllProtobufCaches(): Unit = {
@@ -407,6 +458,9 @@ class MbtWorkspaceSymbolProvider(
             case None =>
               Future.unit
           }
+        } else if (doc.language.isProtobuf) {
+          invalidateCompiledProtoJavaOutlines(file, doc)
+          Future.unit
         } else {
           Future.unit
         }
@@ -916,6 +970,16 @@ class MbtWorkspaceSymbolProvider(
           case None =>
             Future.unit
         }
+      } else if (
+        updateDocumentKeys &&
+        doc.language.isProtobuf &&
+        javaSymbolLoader().isTurbineClasspath
+      ) {
+        // Covers proto files changed outside the editor (e.g. git checkout);
+        // for editor saves, didSave already invalidated before the outline
+        // cache was cleared.
+        old.foreach(invalidateCompiledProtoJavaOutlines(file, _))
+        Future.unit
       } else {
         Future.unit
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/ProtoGeneratedJavaFiles.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/ProtoGeneratedJavaFiles.scala
@@ -1,0 +1,72 @@
+package scala.meta.internal.metals.mbt
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import scala.util.control.NonFatal
+
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.metals.Directories
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+/**
+ * Materializes the Java source that Metals synthesizes from a `.proto` file
+ * (via [[MbtProtobufWorkspaceSymbolProvider]]) into a read-only file on disk,
+ * so that goto-definition on a proto-generated class can open it.
+ *
+ * The outline is derived purely from the `.proto` file, so this needs no build
+ * output and no configuration and works for every build tool. Files live under
+ * `.metals/readonly/` so clients treat them as read-only dependency sources.
+ */
+object ProtoGeneratedJavaFiles {
+
+  /** Subdirectory of `.metals/readonly/dependencies` for generated outlines. */
+  private val rootDirName = "proto-generated"
+
+  /**
+   * Writes `content` for `javaPackagePath/className.java` generated from
+   * `protoPath` to a stable on-disk location and returns it.
+   *
+   * @param javaPackagePath slash-separated package with a trailing slash
+   *                        (e.g. `com/example/jproto/`), or empty for the
+   *                        default package
+   */
+  def materialize(
+      workspace: AbsolutePath,
+      protoPath: AbsolutePath,
+      javaPackagePath: String,
+      className: String,
+      content: String,
+  ): Option[AbsolutePath] =
+    try {
+      protoPath.toRelativeInside(workspace).map { protoRelative =>
+        val javaFile = workspace
+          .resolve(Directories.dependencies)
+          .resolve(rootDirName)
+          .resolveZipPath(protoRelative.toNIO)
+          .resolveZipPath(Paths.get(javaPackagePath))
+          .resolve(s"$className.java")
+        writeIfChanged(javaFile, content)
+        javaFile
+      }
+    } catch {
+      case NonFatal(e) =>
+        scribe.debug(
+          s"proto-java: failed to materialize generated outline for $className",
+          e,
+        )
+        None
+    }
+
+  private def writeIfChanged(file: AbsolutePath, content: String): Unit = {
+    val current =
+      if (file.exists) Some(FileIO.slurp(file, StandardCharsets.UTF_8))
+      else None
+    if (!current.contains(content)) {
+      Files.createDirectories(file.toNIO.getParent)
+      Files.write(file.toNIO, content.getBytes(StandardCharsets.UTF_8))
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
@@ -47,7 +47,7 @@ object TurbineCompiler {
 
   def compileClassfiles[T](
       toParse: ParArray[T],
-      toSourceFile: T => Option[SourceFile],
+      toSourceFile: T => Seq[SourceFile],
       classpath: Seq[Path],
       progressBars: ProgressBars,
   )(implicit rc: ReportContext): TurbineCompileResult = {
@@ -68,16 +68,14 @@ object TurbineCompiler {
 
   private def parseInputs[T](
       inputs: ParArray[T],
-      toSourceFile: T => Option[SourceFile],
+      toSourceFile: T => Seq[SourceFile],
   ): ImmutableList[Tree.CompUnit] = {
     val result = new ConcurrentLinkedQueue[Tree.CompUnit]()
     inputs.foreach { input =>
       try {
-        toSourceFile(input) match {
-          case None =>
-          // Silently ignore entries that may not exist
-          case Some(source) =>
-            result.add(Parser.parse(source))
+        // An empty result means the entry doesn't exist or isn't Java-related.
+        toSourceFile(input).foreach { source =>
+          result.add(Parser.parse(source))
         }
       } catch {
         case NonFatal(_) =>
@@ -127,7 +125,7 @@ private case class SourcepathJavaFileObject(
 
 class TurbineCompiler[T](
     allCompilationUnits: () => ParArray[T],
-    parseUnit: T => Option[SourceFile],
+    parseUnit: T => Seq[SourceFile],
     classpath: () => Seq[Path],
     progressBars: ProgressBars,
     debounceDelay: FiniteDuration,

--- a/tests/unit/src/test/scala/tests/p/ProtoPCJavaSuite.scala
+++ b/tests/unit/src/test/scala/tests/p/ProtoPCJavaSuite.scala
@@ -1,5 +1,9 @@
 package tests.p
 
+import scala.concurrent.Future
+
+import org.eclipse.lsp4j.Location
+
 /**
  * Tests for Java-to-proto code navigation.
  *
@@ -7,6 +11,22 @@ package tests.p
  * navigate to the original proto file definitions.
  */
 class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
+
+  // Goto-definition on a proto-generated Java symbol now also returns the
+  // synthesized Java outline; these tests assert the proto declaration only,
+  // so they filter to the `.proto` location. Navigation to the generated
+  // outline is covered by the `java-navigates-to-generated-outline` tests.
+  private def assertProtoDefinition(
+      filename: String,
+      query: String,
+      expected: String,
+  )(implicit loc: munit.Location): Future[List[Location]] =
+    server.assertDefinition(
+      filename,
+      query,
+      expected,
+      includeLocation = _.getUri().endsWith(".proto"),
+    )
 
   // Test multiple messages from the same proto file in the same package
   test("java-imports-multiple-proto-messages") {
@@ -42,7 +62,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       // No "package does not exist" diagnostic for proto-generated Java package
       _ = assertNoDiagnostics()
       // Navigate from Authentication import in Java to its definition in client.proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Client.java",
         "import com.example.api.jproto.Authentic@@ation;",
         """|a/src/main/proto/client.proto:5:9: definition
@@ -51,7 +71,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from Authorization import in Java to its definition in client.proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Client.java",
         "import com.example.api.jproto.Authoriz@@ation;",
         """|a/src/main/proto/client.proto:9:9: definition
@@ -92,7 +112,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       // No "package does not exist" diagnostic for enum import package
       _ = assertNoDiagnostics()
       // Navigate from Status import in Java to enum definition in status.proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Service.java",
         "import com.example.api.jproto.Sta@@tus;",
         """|a/src/main/proto/status.proto:5:6: definition
@@ -101,7 +121,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from return type Status to enum definition in status.proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Service.java",
         "public Sta@@tus getStatus() { return null; }",
         """|a/src/main/proto/status.proto:5:6: definition
@@ -143,7 +163,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       // No diagnostics for import of generated outer message class
       _ = assertNoDiagnostics()
       // Navigate from Container import in Java to message definition in nested.proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Handler.java",
         "import com.example.api.jproto.Contai@@ner;",
         """|a/src/main/proto/nested.proto:5:9: definition
@@ -152,7 +172,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from method parameter type Container to proto definition
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Handler.java",
         "public void handle(Contai@@ner container) {}",
         """|a/src/main/proto/nested.proto:5:9: definition
@@ -190,7 +210,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/api/Consumer.java")
       _ = assertNoDiagnostics()
       // Navigate from unqualified Java type to proto message via package fallback
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/api/Consumer.java",
         "public void consume(SimpleMess@@age msg) {}",
         """|a/src/main/proto/simple.proto:4:9: definition
@@ -239,7 +259,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       // All three imports should resolve to the same proto file
       _ <- server.didFocus("a/src/main/java/com/example/Api.java")
       _ = assertNoDiagnostics()
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Api.java",
         "import com.example.api.jproto.Requ@@est;",
         """|a/src/main/proto/multi.proto:5:9: definition
@@ -247,7 +267,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |        ^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Api.java",
         "import com.example.api.jproto.Respo@@nse;",
         """|a/src/main/proto/multi.proto:8:9: definition
@@ -255,7 +275,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |        ^^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Api.java",
         "import com.example.api.jproto.ErrorCo@@de;",
         """|a/src/main/proto/multi.proto:11:6: definition
@@ -306,7 +326,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/UserBuilder.java")
       _ = assertNoDiagnostics()
       // Navigate from setName to the name field in proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/UserBuilder.java",
         ".setNa@@me(\"Alice\")",
         """|a/src/main/proto/user.proto:6:10: definition
@@ -315,7 +335,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from setAge to the age field in proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/UserBuilder.java",
         ".setA@@ge(30)",
         """|a/src/main/proto/user.proto:7:9: definition
@@ -367,7 +387,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/ContextBuilder.java")
       _ = assertNoDiagnostics()
       // Navigate from setAuthorizingPrincipal to authorizing_principal field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ContextBuilder.java",
         ".setAuthorizingPrinci@@pal(",
         """|a/src/main/proto/principal.proto:10:13: definition
@@ -376,7 +396,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from setId on nested builder to id field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ContextBuilder.java",
         ".setI@@d(123L)",
         """|a/src/main/proto/principal.proto:6:9: definition
@@ -422,7 +442,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/PersonReader.java")
       _ = assertNoDiagnostics()
       // Navigate from getFirstName to first_name field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/PersonReader.java",
         "p.getFirstNa@@me()",
         """|a/src/main/proto/person.proto:6:10: definition
@@ -431,7 +451,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from getLastName to last_name field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/PersonReader.java",
         "p.getLastNa@@me()",
         """|a/src/main/proto/person.proto:7:10: definition
@@ -484,7 +504,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/OrderHandler.java")
       _ = assertNoDiagnostics()
       // Navigate from addItems to items field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/OrderHandler.java",
         ".addIte@@ms(\"apple\")",
         """|a/src/main/proto/order.proto:6:19: definition
@@ -493,7 +513,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from getItemsList to items field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/OrderHandler.java",
         "o.getItemsLi@@st()",
         """|a/src/main/proto/order.proto:6:19: definition
@@ -502,7 +522,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from getItemsCount to items field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/OrderHandler.java",
         "o.getItemsCou@@nt()",
         """|a/src/main/proto/order.proto:6:19: definition
@@ -554,7 +574,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/ConfigHandler.java")
       _ = assertNoDiagnostics()
       // Navigate from putProperties to properties field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ConfigHandler.java",
         ".putProperti@@es(\"key\", \"value\")",
         """|a/src/main/proto/config.proto:6:23: definition
@@ -563,7 +583,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from getPropertiesMap to properties field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ConfigHandler.java",
         "c.getPropertiesMa@@p()",
         """|a/src/main/proto/config.proto:6:23: definition
@@ -572,7 +592,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from containsProperties to properties field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ConfigHandler.java",
         "c.containsProperti@@es(key)",
         """|a/src/main/proto/config.proto:6:23: definition
@@ -619,7 +639,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/StatusChecker.java")
       _ = assertNoDiagnostics()
       // Navigate from Status.PENDING to PENDING enum value
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/StatusChecker.java",
         "Status.PENDI@@NG",
         """|a/src/main/proto/status.proto:7:3: definition
@@ -628,7 +648,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from Status.APPROVED to APPROVED enum value
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/StatusChecker.java",
         "Status.APPROV@@ED",
         """|a/src/main/proto/status.proto:8:3: definition
@@ -679,7 +699,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/ContactHandler.java")
       _ = assertNoDiagnostics()
       // Navigate from hasEmail to email field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ContactHandler.java",
         "c.hasEma@@il()",
         """|a/src/main/proto/optional.proto:9:19: definition
@@ -688,7 +708,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from hasAddress to address field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ContactHandler.java",
         "c.hasAddre@@ss()",
         """|a/src/main/proto/optional.proto:10:11: definition
@@ -697,7 +717,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from clearEmail to email field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ContactHandler.java",
         ".clearEma@@il()",
         """|a/src/main/proto/optional.proto:9:19: definition
@@ -749,7 +769,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/EchoClient.java")
       _ = assertNoDiagnostics()
       // setMessage on EchoRequest.Builder should go to EchoRequest.message
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/EchoClient.java",
         "EchoRequest.newBuilder().setMess@@age(text)",
         """|a/src/main/proto/echo.proto:9:19: definition
@@ -758,7 +778,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // setMessage on ForwardDelayedEchoRequest.Builder should go to ForwardDelayedEchoRequest.message
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/EchoClient.java",
         "ForwardDelayedEchoRequest.newBuilder().setMess@@age(text)",
         """|a/src/main/proto/echo.proto:6:19: definition
@@ -816,7 +836,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/EventHandler.java")
       _ = assertNoDiagnostics()
       // Navigate from hasTextPayload to text_payload field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/EventHandler.java",
         "e.hasTextPaylo@@ad()",
         """|a/src/main/proto/event.proto:8:12: definition
@@ -825,7 +845,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from getTextPayload to text_payload field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/EventHandler.java",
         "e.getTextPaylo@@ad()",
         """|a/src/main/proto/event.proto:8:12: definition
@@ -834,7 +854,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from setTextPayload to text_payload field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/EventHandler.java",
         ".setTextPaylo@@ad(text)",
         """|a/src/main/proto/event.proto:8:12: definition
@@ -939,7 +959,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/AllFieldTypes.java")
       _ = assertNoDiagnostics()
       // -- scalar (line 13) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getTitl@@e()",
         """|a/src/main/proto/comprehensive.proto:13:10: definition
@@ -947,7 +967,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |         ^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.setTitl@@e(\"x\")",
         """|a/src/main/proto/comprehensive.proto:13:10: definition
@@ -955,7 +975,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |         ^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.clearTitl@@e()",
         """|a/src/main/proto/comprehensive.proto:13:10: definition
@@ -964,7 +984,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- message field (line 15) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getAddre@@ss()",
         """|a/src/main/proto/comprehensive.proto:15:11: definition
@@ -972,7 +992,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |          ^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.hasAddre@@ss()",
         """|a/src/main/proto/comprehensive.proto:15:11: definition
@@ -980,7 +1000,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |          ^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.setAddre@@ss(",
         """|a/src/main/proto/comprehensive.proto:15:11: definition
@@ -989,7 +1009,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- repeated scalar (line 17) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getTagsLi@@st()",
         """|a/src/main/proto/comprehensive.proto:17:19: definition
@@ -997,7 +1017,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                  ^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getTagsCou@@nt()",
         """|a/src/main/proto/comprehensive.proto:17:19: definition
@@ -1005,7 +1025,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                  ^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.addTa@@gs(\"t\")",
         """|a/src/main/proto/comprehensive.proto:17:19: definition
@@ -1014,7 +1034,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- repeated message (line 19) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getItemsLi@@st()",
         """|a/src/main/proto/comprehensive.proto:19:17: definition
@@ -1022,7 +1042,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                ^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.addIte@@ms(",
         """|a/src/main/proto/comprehensive.proto:19:17: definition
@@ -1031,7 +1051,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- map (line 21) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getCountsMa@@p()",
         """|a/src/main/proto/comprehensive.proto:21:22: definition
@@ -1039,7 +1059,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                     ^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.containsCoun@@ts(k)",
         """|a/src/main/proto/comprehensive.proto:21:22: definition
@@ -1047,7 +1067,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                     ^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.putCoun@@ts(\"k\",1)",
         """|a/src/main/proto/comprehensive.proto:21:22: definition
@@ -1056,7 +1076,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- oneof scalar (line 24, PLAT-154011) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getTextPaylo@@ad()",
         """|a/src/main/proto/comprehensive.proto:24:12: definition
@@ -1064,7 +1084,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |           ^^^^^^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.hasTextPaylo@@ad()",
         """|a/src/main/proto/comprehensive.proto:24:12: definition
@@ -1072,7 +1092,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |           ^^^^^^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.setTextPaylo@@ad(\"t\")",
         """|a/src/main/proto/comprehensive.proto:24:12: definition
@@ -1081,7 +1101,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- oneof message (line 25, PLAT-154011) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getLocationPaylo@@ad()",
         """|a/src/main/proto/comprehensive.proto:25:13: definition
@@ -1089,7 +1109,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |            ^^^^^^^^^^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.hasLocationPaylo@@ad()",
         """|a/src/main/proto/comprehensive.proto:25:13: definition
@@ -1097,7 +1117,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |            ^^^^^^^^^^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.setLocationPaylo@@ad(",
         """|a/src/main/proto/comprehensive.proto:25:13: definition
@@ -1106,7 +1126,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- optional (line 28) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getNot@@e()",
         """|a/src/main/proto/comprehensive.proto:28:19: definition
@@ -1114,7 +1134,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                  ^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.hasNot@@e()",
         """|a/src/main/proto/comprehensive.proto:28:19: definition
@@ -1122,7 +1142,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                  ^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.setNot@@e(\"n\")",
         """|a/src/main/proto/comprehensive.proto:28:19: definition
@@ -1176,7 +1196,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/GreeterService.java")
       _ = assertNoDiagnostics()
       // Navigate from the GreeterGrpc import to the Greeter service in the proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/GreeterService.java",
         "import com.example.api.jproto.GreeterGr@@pc;",
         """|a/src/main/proto/greeter.proto:11:9: definition
@@ -1185,7 +1205,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Also navigate from GreeterGrpc used as a qualifier in a method body
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/GreeterService.java",
         "return GreeterGr@@pc.class;",
         """|a/src/main/proto/greeter.proto:11:9: definition
@@ -1280,7 +1300,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/GreeterClient.java")
       _ = assertNoDiagnostics()
       // Navigate from stub.sayHello to rpc SayHello definition (line 12 is 0-based, so line 13 in 1-based)
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/GreeterClient.java",
         "stub.sayHel@@lo(request)",
         """|a/src/main/proto/greeter.proto:12:7: definition
@@ -1358,4 +1378,173 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       )
     } yield ()
   }
+
+  // Goto-definition on a proto-generated class navigates to the Java source
+  // that Metals synthesizes from the proto file (materialized read-only under
+  // .metals/readonly), alongside the proto declaration. This needs no build
+  // output and no configuration.
+  test("java-navigates-to-generated-outline") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/client.proto
+           |syntax = "proto3";
+           |package com.example.api;
+           |option java_package = "com.example.api.jproto";
+           |option java_outer_classname = "ClientProtos";
+           |message Authentication {
+           |  string token = 1;
+           |}
+           |/a/src/main/java/com/example/Client.java
+           |package com.example;
+           |import com.example.api.jproto.ClientProtos;
+           |public class Client {
+           |  public void auth(ClientProtos.Authentication auth) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/Client.java")
+      _ <- server.didFocus("a/src/main/java/com/example/Client.java")
+      _ = assertNoDiagnostics()
+      locations <- server.definitionSubstringQuery(
+        "a/src/main/java/com/example/Client.java",
+        "public void auth(ClientProtos.Authentic@@ation auth) {}",
+      )
+      uris = locations.map(_.getUri())
+      _ = assert(
+        uris.exists(
+          _.endsWith(
+            ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/com/example/api/jproto/ClientProtos.java"
+          )
+        ),
+        s"expected a generated-outline location, got:\n${uris.mkString("\n")}",
+      )
+      _ = assert(
+        uris.exists(_.endsWith("a/src/main/proto/client.proto")),
+        s"expected the proto location, got:\n${uris.mkString("\n")}",
+      )
+    } yield ()
+  }
+
+  // Same as above but the proto declares no java_package option (proto package
+  // equals the generated Java package, java_multiple_files), so the class is
+  // generated as a top-level Java file rather than nested in an outer class.
+  test("java-navigates-to-generated-outline-without-java-package-option") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/client.proto
+           |syntax = "proto3";
+           |package com.example.api.jproto;
+           |option java_multiple_files = true;
+           |message Authentication {
+           |  string token = 1;
+           |}
+           |/a/src/main/java/com/example/Client.java
+           |package com.example;
+           |import com.example.api.jproto.Authentication;
+           |public class Client {
+           |  public void auth(Authentication auth) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/Client.java")
+      _ <- server.didFocus("a/src/main/java/com/example/Client.java")
+      _ = assertNoDiagnostics()
+      locations <- server.definitionSubstringQuery(
+        "a/src/main/java/com/example/Client.java",
+        "public void auth(Authentic@@ation auth) {}",
+      )
+      uris = locations.map(_.getUri())
+      _ = assert(
+        uris.exists(
+          _.endsWith(
+            ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/com/example/api/jproto/Authentication.java"
+          )
+        ),
+        s"expected a generated-outline location, got:\n${uris.mkString("\n")}",
+      )
+      _ = assert(
+        uris.exists(_.endsWith("a/src/main/proto/client.proto")),
+        s"expected the proto location, got:\n${uris.mkString("\n")}",
+      )
+    } yield ()
+  }
+
+  // Hover and completion on a method whose return type is a proto-generated
+  // class, accessed transitively from another Java file.
+  test("java-transitive-proto-return-type") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/client.proto
+           |syntax = "proto3";
+           |package com.example.api;
+           |option java_package = "com.example.api.jproto";
+           |option java_multiple_files = true;
+           |message Authentication {
+           |  string token = 1;
+           |}
+           |/a/src/main/java/com/example/AuthProvider.java
+           |package com.example;
+           |import com.example.api.jproto.Authentication;
+           |public class AuthProvider {
+           |  public Authentication readAuthentication() { return null; }
+           |}
+           |/a/src/main/java/com/example/AuthConsumer.java
+           |package com.example;
+           |public class AuthConsumer {
+           |  void consume(AuthProvider provider) {
+           |    provider.readAuthentication();
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/AuthConsumer.java")
+      _ <- server.didFocus("a/src/main/java/com/example/AuthConsumer.java")
+      _ = assertNoDiagnostics()
+      _ <- server.assertHover(
+        "a/src/main/java/com/example/AuthConsumer.java",
+        """|package com.example;
+           |public class AuthConsumer {
+           |  void consume(AuthProvider provider) {
+           |    provider.readAuthenticat@@ion();
+           |  }
+           |}
+           |""".stripMargin,
+        """|```java
+           |public com.example.api.jproto.Authentication readAuthentication()
+           |```
+           |""".stripMargin,
+      )
+      _ <- server.didChange("a/src/main/java/com/example/AuthConsumer.java") {
+        _ =>
+          """|package com.example;
+             |public class AuthConsumer {
+             |  void consume(AuthProvider provider) {
+             |    provider.readAuthentication().
+             |  }
+             |}
+             |""".stripMargin
+      }
+      completions <- server.completion(
+        "a/src/main/java/com/example/AuthConsumer.java",
+        "provider.readAuthentication().@@",
+      )
+      _ = assert(
+        completions.contains("getToken"),
+        s"expected getToken in completions:\n$completions",
+      )
+    } yield ()
+  }
+
 }


### PR DESCRIPTION
# Java support for classes generated from Protobuf definitions

Improves how Metals handles Java code that uses protobuf-generated classes
(messages, enums, gRPC stubs). Previously such classes only "half-existed" in
Metals — resolved from an in-memory outline synthesized from the `.proto` —
which meant navigation only reached the `.proto` file and type information was
lost across files. This fix makes go-to-definition, hover, and completion all
work end-to-end, without a build and without configuration, for every build
tool.

## User-visible behavior

- **Go-to-definition** on a proto-generated class (e.g. `WorkResponse`) now
  lands in the generated Java source, alongside the `.proto` declaration.
- **Hover** on a method whose return type is a proto-generated class shows the
  real type (e.g. `WorkerProtocol.WorkResponse waitAndRead()`) instead of
  `java.lang.Object`, including when the method is used from another Java file.
- **Completion** offers the fields and methods of the generated class (e.g.
  `getOutput()` on the value returned by `waitAndRead()`).
- Works whether or not the proto sets `option java_package`, and for
  `java_multiple_files` as well as nested/outer-class layouts.

## How it works

Metals already synthesizes a Java outline from each `.proto` (via
`JavaOutlineGenerator`). This fix wires that outline through the whole PC
pipeline:

- **Navigation** — `DefinitionProviderProtobufSupport.handleProtoJavaDefinition`
  materializes the synthesized outline to a read-only file under
  `.metals/readonly/dependencies/proto-generated/…` and returns it as the
  definition target, together with the `.proto` location. No build output and
  no configuration are needed.
- **Hover / completion** — the turbine batch compile that builds the workspace
  classpath now includes the proto outlines (`TurbineCompiler.parseUnit`
  returns `Seq[SourceFile]`, one unit per generated class). Without this,
  turbine erased proto-generated return types to `java.lang.Object` in the
  compiled classfiles, breaking type resolution in files that consumed those
  types.
- **Invalidation** — when a `.proto` is saved, changed, or deleted, the classes
  compiled from the previous version are dropped from the turbine classpath so
  stale generated types don't linger.
- **`java_package` edge case** — when a proto declares no `java_package`, the
  proto package equals the generated Java package, so the MBT index resolves
  the Java symbol straight to the `.proto`; those proto hits are filtered out
  so the generated-Java lookup still runs.

## Tests

`tests.p.ProtoPCJavaSuite` covers navigation, hover, and completion. Java→proto
navigation tests filter to the `.proto` location (the generated-outline location
is additive and covered by dedicated `java-navigates-to-generated-outline`
tests).
