### PR TITLE
feat(mcp): Add show-implicits MCP tool for inspecting implicits

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -703,67 +703,6 @@ class Compilers(
 
   }
 
-  /**
-   * Buffer-safe, clamped entry point for callers that only have a file (e.g. the
-   * `show-implicits` MCP tool), rather than a fully built [[InlayHintParams]].
-   *
-   * This owns range construction and clamping against the *buffer* text so the
-   * range handed to the presentation compiler is always in bounds. An
-   * out-of-bounds LSP range is otherwise silently dropped to `None` by `toMeta`,
-   * which would yield zero hints. The caller's `range` endpoints are treated as
-   * whole-line, 1-based, source-coordinate positions with `endLine` inclusive;
-   * columns are recomputed here and let `sourceAdjustments` map them into PC
-   * coordinates (so worksheets/`.sc` scripts keep working).
-   */
-  def inlayHints(
-      path: AbsolutePath,
-      range: Option[LspRange],
-      options: InlayHintsOptions,
-  ): Future[ju.List[InlayHint]] = {
-    val text = path.toInputFromBuffers(buffers).text
-    val params = new InlayHintParams(
-      new TextDocumentIdentifier(path.toURI.toString()),
-      wholeLineRange(text, range),
-    )
-    inlayHints(params, EmptyCancelToken, Some(options))
-  }
-
-  /**
-   * Builds a whole-line LSP range against `text`, clamping a caller-provided
-   * range into the buffer bounds.
-   *
-   *   - endpoints are 0-based and `endLine` is inclusive;
-   *   - the range always covers whole lines (start column 0, end column = end of
-   *     `endLine`); columns in the input range are ignored;
-   *   - when no range is supplied, or the parsed range is empty
-   *     (`startLine > endLine` after clamping), the whole file is used.
-   */
-  private def wholeLineRange(
-      text: String,
-      range: Option[LspRange],
-  ): LspRange = {
-    val lines = text.split("\n", -1)
-    val lastLine = math.max(0, lines.length - 1)
-    def lineEndCol(line: Int): Int = lines(line).length
-    def wholeFile =
-      new LspRange(
-        new LspPosition(0, 0),
-        new LspPosition(lastLine, lineEndCol(lastLine)),
-      )
-    range match {
-      case Some(r) =>
-        val startLine = math.max(0, math.min(r.getStart().getLine(), lastLine))
-        val endLine = math.max(0, math.min(r.getEnd().getLine(), lastLine))
-        if (startLine > endLine) wholeFile
-        else
-          new LspRange(
-            new LspPosition(startLine, 0),
-            new LspPosition(endLine, lineEndCol(endLine)),
-          )
-      case None => wholeFile
-    }
-  }
-
   def inlayHints(
       params: InlayHintParams,
       token: CancelToken,

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -703,9 +703,71 @@ class Compilers(
 
   }
 
+  /**
+   * Buffer-safe, clamped entry point for callers that only have a file (e.g. the
+   * `show-implicits` MCP tool), rather than a fully built [[InlayHintParams]].
+   *
+   * This owns range construction and clamping against the *buffer* text so the
+   * range handed to the presentation compiler is always in bounds. An
+   * out-of-bounds LSP range is otherwise silently dropped to `None` by `toMeta`,
+   * which would yield zero hints. The caller's `range` endpoints are treated as
+   * whole-line, 1-based, source-coordinate positions with `endLine` inclusive;
+   * columns are recomputed here and let `sourceAdjustments` map them into PC
+   * coordinates (so worksheets/`.sc` scripts keep working).
+   */
+  def inlayHints(
+      path: AbsolutePath,
+      range: Option[LspRange],
+      options: InlayHintsOptions,
+  ): Future[ju.List[InlayHint]] = {
+    val text = path.toInputFromBuffers(buffers).text
+    val params = new InlayHintParams(
+      new TextDocumentIdentifier(path.toURI.toString()),
+      wholeLineRange(text, range),
+    )
+    inlayHints(params, EmptyCancelToken, Some(options))
+  }
+
+  /**
+   * Builds a whole-line LSP range against `text`, clamping a caller-provided
+   * range into the buffer bounds.
+   *
+   *   - endpoints are 0-based and `endLine` is inclusive;
+   *   - the range always covers whole lines (start column 0, end column = end of
+   *     `endLine`); columns in the input range are ignored;
+   *   - when no range is supplied, or the parsed range is empty
+   *     (`startLine > endLine` after clamping), the whole file is used.
+   */
+  private def wholeLineRange(
+      text: String,
+      range: Option[LspRange],
+  ): LspRange = {
+    val lines = text.split("\n", -1)
+    val lastLine = math.max(0, lines.length - 1)
+    def lineEndCol(line: Int): Int = lines(line).length
+    def wholeFile =
+      new LspRange(
+        new LspPosition(0, 0),
+        new LspPosition(lastLine, lineEndCol(lastLine)),
+      )
+    range match {
+      case Some(r) =>
+        val startLine = math.max(0, math.min(r.getStart().getLine(), lastLine))
+        val endLine = math.max(0, math.min(r.getEnd().getLine(), lastLine))
+        if (startLine > endLine) wholeFile
+        else
+          new LspRange(
+            new LspPosition(startLine, 0),
+            new LspPosition(endLine, lineEndCol(endLine)),
+          )
+      case None => wholeFile
+    }
+  }
+
   def inlayHints(
       params: InlayHintParams,
       token: CancelToken,
+      optionsOverride: Option[InlayHintsOptions] = None,
   ): Future[ju.List[InlayHint]] = {
     withPCAndAdjustLsp(params) { (pc, pos, adjust) =>
       def inlayHintsFallback(
@@ -756,7 +818,7 @@ class Compilers(
           token,
           outlineFilesProvider.getOutlineFiles(pc.buildTargetId()),
         )
-      val options = userConfig().inlayHintsOptions
+      val options = optionsOverride.getOrElse(userConfig().inlayHintsOptions)
       val pcParams = CompilerInlayHintsParams(
         rangeParams,
         inferredTypes = options.inferredType,

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -254,6 +254,7 @@ class ProjectMetalsLspService(
       scalaVersionSelector,
       mcpSearch,
       folder,
+      buffers,
     )
 
   lazy val mcpTestRunner =

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpPrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpPrinter.scala
@@ -56,43 +56,6 @@ object McpPrinter {
       s"${result.path.toRelative(projectRoot)}:${result.line}"
   }
 
-  implicit class XtensionImplicitsResult(result: ImplicitsResult) {
-    def show: String = result match {
-      case ImplicitsResult.NoFile(requested) =>
-        val what = requested.getOrElse("<no file provided>")
-        s"Error: could not resolve file: $what"
-      case ImplicitsResult.Found(file, arguments, conversions) =>
-        if (arguments.isEmpty && conversions.isEmpty)
-          s"No implicits found in $file"
-        else
-          List(
-            "Implicit arguments:" -> arguments,
-            "Implicit conversions:" -> conversions,
-          ).collect {
-            case (header, hints) if hints.nonEmpty =>
-              (header :: hints.map(showImplicitHint(file, _))).mkString("\n")
-          }.mkString("\n")
-    }
-  }
-
-  /**
-   * Renders a single implicit hint line. Positions are 1-based `line:col`
-   * (human/editor convention), converted from the 0-based positions the
-   * presentation compiler returns. `->` targets are semanticdb symbols for
-   * out-of-file implicits or `(line:col)` (1-based) for in-file definitions;
-   * the `->` is omitted entirely when there are no targets.
-   */
-  private def showImplicitHint(file: String, hint: ImplicitHint): String = {
-    val line = hint.position.getLine() + 1
-    val col = hint.position.getCharacter() + 1
-    val targets = hint.targets.map {
-      case Left(symbol) => symbol
-      case Right(pos) => s"(${pos.getLine() + 1}:${pos.getCharacter() + 1})"
-    }
-    val arrow = if (targets.isEmpty) "" else s"  ->  ${targets.mkString(", ")}"
-    s"  $file:$line:$col  ${hint.label}$arrow"
-  }
-
   implicit class XtensionSymbolInspectResultList(
       result: List[SymbolInspectResult]
   ) {

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpPrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpPrinter.scala
@@ -56,6 +56,43 @@ object McpPrinter {
       s"${result.path.toRelative(projectRoot)}:${result.line}"
   }
 
+  implicit class XtensionImplicitsResult(result: ImplicitsResult) {
+    def show: String = result match {
+      case ImplicitsResult.NoFile(requested) =>
+        val what = requested.getOrElse("<no file provided>")
+        s"Error: could not resolve file: $what"
+      case ImplicitsResult.Found(file, arguments, conversions) =>
+        if (arguments.isEmpty && conversions.isEmpty)
+          s"No implicits found in $file"
+        else
+          List(
+            "Implicit arguments:" -> arguments,
+            "Implicit conversions:" -> conversions,
+          ).collect {
+            case (header, hints) if hints.nonEmpty =>
+              (header :: hints.map(showImplicitHint(file, _))).mkString("\n")
+          }.mkString("\n")
+    }
+  }
+
+  /**
+   * Renders a single implicit hint line. Positions are 1-based `line:col`
+   * (human/editor convention), converted from the 0-based positions the
+   * presentation compiler returns. `->` targets are semanticdb symbols for
+   * out-of-file implicits or `(line:col)` (1-based) for in-file definitions;
+   * the `->` is omitted entirely when there are no targets.
+   */
+  private def showImplicitHint(file: String, hint: ImplicitHint): String = {
+    val line = hint.position.getLine() + 1
+    val col = hint.position.getCharacter() + 1
+    val targets = hint.targets.map {
+      case Left(symbol) => symbol
+      case Right(pos) => s"(${pos.getLine() + 1}:${pos.getCharacter() + 1})"
+    }
+    val arrow = if (targets.isEmpty) "" else s"  ->  ${targets.mkString(", ")}"
+    s"  $file:$line:$col  ${hint.label}$arrow"
+  }
+
   implicit class XtensionSymbolInspectResultList(
       result: List[SymbolInspectResult]
   ) {

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
@@ -6,9 +6,11 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import scala.meta._
+import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Compilers
 import scala.meta.internal.metals.Docstrings
+import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.metals.InlayHintsOption
 import scala.meta.internal.metals.InlayHintsOptions
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -25,7 +27,9 @@ import scala.meta.transversers.Transformer
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import com.google.gson.JsonElement
 import org.eclipse.lsp4j.InlayHint
+import org.eclipse.lsp4j.InlayHintParams
 import org.eclipse.lsp4j.SymbolKind
+import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.{lsp4j => l}
 
 /**
@@ -42,6 +46,7 @@ class McpQueryEngine(
     scalaVersionSelector: ScalaVersionSelector,
     mcpSearch: McpSymbolSearch,
     workspace: AbsolutePath,
+    buffers: Buffers,
 )(implicit ec: ExecutionContext) {
   private val mcpDefinitionProvider =
     new McpSymbolProvider(scalaVersionSelector, mcpSearch)
@@ -372,8 +377,8 @@ class McpQueryEngine(
           Map(InlayHintsOption.ImplicitConversions -> true)
         )
         for {
-          argHints <- compilers.inlayHints(file, range, argumentsOptions)
-          convHints <- compilers.inlayHints(file, range, conversionsOptions)
+          argHints <- inlayHints(file, range, argumentsOptions)
+          convHints <- inlayHints(file, range, conversionsOptions)
         } yield {
           val arguments = argHints.asScala.toList.map(toImplicitHint)
           // Implicit conversions emit a pair of hints per conversion: an opening
@@ -410,6 +415,55 @@ class McpQueryEngine(
     // The conversion opening hint's label ends in a `(` separator part; strip it
     // so the rendered label is just the conversion name (e.g. `augmentString`).
     ImplicitHint(hint.getPosition(), rawLabel.stripSuffix("("), targets)
+  }
+
+  /**
+   * Buffer-safe `inlayHints` entry point for callers that only have a file,
+   * building and constraining the range to the buffer text so an out-of-bounds
+   * range isn't silently dropped to zero hints.
+   */
+  private def inlayHints(
+      path: AbsolutePath,
+      range: Option[l.Range],
+      options: InlayHintsOptions,
+  ): Future[ju.List[InlayHint]] = {
+    val text = path.toInputFromBuffers(buffers).text
+    val params = new InlayHintParams(
+      new TextDocumentIdentifier(path.toURI.toString()),
+      wholeLineRange(text, range),
+    )
+    compilers.inlayHints(params, EmptyCancelToken, Some(options))
+  }
+
+  /**
+   * Builds a whole-line LSP range against `text`, constraining the caller's
+   * range to the buffer bounds; falls back to the whole file when no (or an
+   * empty) range is given. Endpoints are 0-based, `endLine` inclusive.
+   */
+  private def wholeLineRange(
+      text: String,
+      range: Option[l.Range],
+  ): l.Range = {
+    val lines = text.split("\n", -1)
+    val lastLine = math.max(0, lines.length - 1)
+    def lineEndCol(line: Int): Int = lines(line).length
+    def wholeFile =
+      new l.Range(
+        new l.Position(0, 0),
+        new l.Position(lastLine, lineEndCol(lastLine)),
+      )
+    range match {
+      case Some(r) =>
+        val startLine = math.max(0, math.min(r.getStart().getLine(), lastLine))
+        val endLine = math.max(0, math.min(r.getEnd().getLine(), lastLine))
+        if (startLine > endLine) wholeFile
+        else
+          new l.Range(
+            new l.Position(startLine, 0),
+            new l.Position(endLine, lineEndCol(endLine)),
+          )
+      case None => wholeFile
+    }
   }
 
   /**
@@ -485,14 +539,37 @@ case class ImplicitHint(
     position: l.Position,
     label: String,
     targets: List[Either[String, l.Position]],
-)
+) {
+
+  /**
+   * Renders a single implicit hint line. Positions are 1-based `line:col`
+   * (human/editor convention), converted from the 0-based positions the
+   * presentation compiler returns. `->` targets are semanticdb symbols for
+   * out-of-file implicits or `(line:col)` (1-based) for in-file definitions;
+   * the `->` is omitted entirely when there are no targets.
+   */
+  def show(file: String): String = {
+    val line = position.getLine() + 1
+    val col = position.getCharacter() + 1
+    val targetStrings = targets.map {
+      case Left(symbol) => symbol
+      case Right(pos) => s"(${pos.getLine() + 1}:${pos.getCharacter() + 1})"
+    }
+    val arrow =
+      if (targetStrings.isEmpty) ""
+      else s"  ->  ${targetStrings.mkString(", ")}"
+    s"  $file:$line:$col  $label$arrow"
+  }
+}
 
 /**
  * Result of `resolveImplicits`. Distinguishes a successful analysis (possibly
  * with no implicits) from an unresolved file, so the tool layer can set
  * `CallToolResult.isError` correctly.
  */
-sealed trait ImplicitsResult
+sealed trait ImplicitsResult {
+  def show: String
+}
 object ImplicitsResult {
 
   /**
@@ -504,10 +581,27 @@ object ImplicitsResult {
       file: String,
       arguments: List[ImplicitHint],
       conversions: List[ImplicitHint],
-  ) extends ImplicitsResult
+  ) extends ImplicitsResult {
+    override def show: String =
+      if (arguments.isEmpty && conversions.isEmpty)
+        s"No implicits found in $file"
+      else
+        List(
+          "Implicit arguments:" -> arguments,
+          "Implicit conversions:" -> conversions,
+        ).collect {
+          case (header, hints) if hints.nonEmpty =>
+            (header :: hints.map(_.show(file))).mkString("\n")
+        }.mkString("\n")
+  }
 
   /** No file could be resolved from the request; rendered as a tool error. */
-  case class NoFile(requested: Option[String]) extends ImplicitsResult
+  case class NoFile(requested: Option[String]) extends ImplicitsResult {
+    override def show: String = {
+      val what = requested.getOrElse("<no file provided>")
+      s"Error: could not resolve file: $what"
+    }
+  }
 }
 
 /**

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
@@ -9,10 +9,13 @@ import scala.meta._
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Compilers
 import scala.meta.internal.metals.Docstrings
+import scala.meta.internal.metals.InlayHintsOption
+import scala.meta.internal.metals.InlayHintsOptions
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ReferenceProvider
 import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.mcp.McpPrinter._
+import scala.meta.internal.pc.InlayHints
 import scala.meta.internal.pc.JavaSourceShortener
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.ContentType
@@ -20,7 +23,10 @@ import scala.meta.pc.ParentSymbols
 import scala.meta.transversers.Transformer
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import com.google.gson.JsonElement
+import org.eclipse.lsp4j.InlayHint
 import org.eclipse.lsp4j.SymbolKind
+import org.eclipse.{lsp4j => l}
 
 /**
  * Query engine for searching symbols in the workspace and classpath.
@@ -342,6 +348,85 @@ class McpQueryEngine(
   }
 
   /**
+   * Show the implicits (implicit/`using` parameters and implicit conversions)
+   * that the compiler silently inserts in a file — the parts of Scala that are
+   * invisible in the source text.
+   *
+   * This is strictly file-scoped: it analyzes exactly `path` and never falls
+   * back to a different file, so it does NOT call `resolveEffectivePath` and
+   * exposes no `module` knob (the underlying `Compilers.inlayHints` ->
+   * `inverseSources` chain gives no seam to honor a caller-chosen build target).
+   *
+   * @param path  the focused document to analyze
+   * @param range optional whole-line range to focus on; both endpoints are
+   *              expected upstream. Range construction and clamping is delegated
+   *              to the buffer-safe [[Compilers.inlayHints]] entry point.
+   */
+  def showImplicits(
+      path: Option[AbsolutePath],
+      range: Option[l.Range],
+  ): Future[ImplicitsResult] = {
+    path.filter(_.exists) match {
+      case None =>
+        Future.successful(ImplicitsResult.NoFile(path.map(_.toString)))
+      case Some(file) =>
+        val relativeFile = file
+          .toRelativeInside(workspace)
+          .map(_.toString)
+          .getOrElse(file.toString)
+
+        // NOTE: the two separate passes below are deliberate and load-bearing.
+        // A returned InlayHint carries only a coarse kind, not its fine-grained
+        // origin, so a single mixed pass could not be grouped by category. Do
+        // not "optimize" this into one pass.
+        val argumentsOptions = InlayHintsOptions(
+          Map(InlayHintsOption.ImplicitArguments -> true)
+        )
+        val conversionsOptions = InlayHintsOptions(
+          Map(InlayHintsOption.ImplicitConversions -> true)
+        )
+        for {
+          argHints <- compilers.inlayHints(file, range, argumentsOptions)
+          convHints <- compilers.inlayHints(file, range, conversionsOptions)
+        } yield {
+          val arguments = argHints.asScala.toList.map(toImplicitHint)
+          // Implicit conversions emit a pair of hints per conversion: an opening
+          // `name(` hint and a standalone `)` close hint. Drop the close hints.
+          val conversions = convHints.asScala.toList
+            .map(toImplicitHint)
+            .filterNot(_.label == ")")
+          ImplicitsResult.Found(relativeFile, arguments, conversions)
+        }
+    }
+  }
+
+  private def toImplicitHint(hint: InlayHint): ImplicitHint = {
+    val labelEither = hint.getLabel()
+    val rawLabel =
+      if (labelEither.isLeft) labelEither.getLeft()
+      else labelEither.getRight().asScala.map(_.getValue()).mkString
+    // A single implicit-argument hint yields one decoded target entry per label
+    // *part* (see InlayHints.makeInlayHint), so the meaningful targets are
+    // interleaved with separator parts (`(`, `, `, `)`, ...) that decode to
+    // `Left("")`. Filtering those out is load-bearing for essentially every
+    // typed hint, not an edge case.
+    val targets = Option(hint.getData()) match {
+      case Some(data) =>
+        InlayHints
+          .fromData(data.asInstanceOf[JsonElement])
+          ._2
+          .filter {
+            case Left("") => false
+            case _ => true
+          }
+      case None => Nil
+    }
+    // The conversion opening hint's label ends in a `(` separator part; strip it
+    // so the rendered label is just the conversion name (e.g. `augmentString`).
+    ImplicitHint(hint.getPosition(), rawLabel.stripSuffix("("), targets)
+  }
+
+  /**
    * Shortens source by reducing method/body content: Scala uses ??? for bodies;
    * Java keeps only signatures (empty bodies). Returns the original content on failure.
    */
@@ -409,6 +494,45 @@ case class SymbolUsage(
     path: AbsolutePath,
     line: Int,
 )
+
+/**
+ * A single compiler-inserted implicit (implicit/`using` parameter group or an
+ * implicit conversion) resolved at a call site.
+ *
+ * @param position 0-based, adjusted position in the analyzed file
+ * @param label    the concatenated label the PC renders at that position
+ * @param targets  resolved targets, already filtered of empty separator parts:
+ *                 `Left(symbol)` is an out-of-file semanticdb symbol,
+ *                 `Right(pos)` is an in-file definition position (0-based)
+ */
+case class ImplicitHint(
+    position: l.Position,
+    label: String,
+    targets: List[Either[String, l.Position]],
+)
+
+/**
+ * Result of `resolveImplicits`. Distinguishes a successful analysis (possibly
+ * with no implicits) from an unresolved file, so the tool layer can set
+ * `CallToolResult.isError` correctly.
+ */
+sealed trait ImplicitsResult
+object ImplicitsResult {
+
+  /**
+   * @param file        the analyzed file, workspace-relative (absolute fallback)
+   * @param arguments   implicit/`using` parameter hints
+   * @param conversions implicit conversion hints (close-paren hints removed)
+   */
+  case class Found(
+      file: String,
+      arguments: List[ImplicitHint],
+      conversions: List[ImplicitHint],
+  ) extends ImplicitsResult
+
+  /** No file could be resolved from the request; rendered as a tool error. */
+  case class NoFile(requested: Option[String]) extends ImplicitsResult
+}
 
 /**
  * Result of an inspect operation with metadata about searched targets.

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
@@ -347,21 +347,7 @@ class McpQueryEngine(
     }
   }
 
-  /**
-   * Show the implicits (implicit/`using` parameters and implicit conversions)
-   * that the compiler silently inserts in a file — the parts of Scala that are
-   * invisible in the source text.
-   *
-   * This is strictly file-scoped: it analyzes exactly `path` and never falls
-   * back to a different file, so it does NOT call `resolveEffectivePath` and
-   * exposes no `module` knob (the underlying `Compilers.inlayHints` ->
-   * `inverseSources` chain gives no seam to honor a caller-chosen build target).
-   *
-   * @param path  the focused document to analyze
-   * @param range optional whole-line range to focus on; both endpoints are
-   *              expected upstream. Range construction and clamping is delegated
-   *              to the buffer-safe [[Compilers.inlayHints]] entry point.
-   */
+  /** Shows the implicits (implicit/`using` parameters and implicit conversions) inserted by the compiler in a file. */
   def showImplicits(
       path: Option[AbsolutePath],
       range: Option[l.Range],
@@ -495,16 +481,6 @@ case class SymbolUsage(
     line: Int,
 )
 
-/**
- * A single compiler-inserted implicit (implicit/`using` parameter group or an
- * implicit conversion) resolved at a call site.
- *
- * @param position 0-based, adjusted position in the analyzed file
- * @param label    the concatenated label the PC renders at that position
- * @param targets  resolved targets, already filtered of empty separator parts:
- *                 `Left(symbol)` is an out-of-file semanticdb symbol,
- *                 `Right(pos)` is an in-file definition position (0-based)
- */
 case class ImplicitHint(
     position: l.Position,
     label: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpTools.scala
@@ -43,6 +43,7 @@ import io.modelcontextprotocol.spec.McpSchema.Tool
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.services.LanguageClient
+import org.eclipse.{lsp4j => l}
 import reactor.core.publisher.Mono
 import tools.jackson.databind.json.JsonMapper
 
@@ -636,6 +637,70 @@ trait MetalsMcpTools extends Cancelable {
                 .isError(false)
                 .build()
             )
+        }.toMono
+      },
+    )
+  }
+
+  protected def createShowImplicitsTool(): AsyncToolSpecification = {
+    val schema = """
+      {
+        "type": "object",
+        "properties": {
+          "fileInFocus": {
+            "type": "string",
+            "description": "The file to analyze. If not provided, uses the currently focused document."
+          },
+          "startLine": {
+            "type": "integer",
+            "description": "Optional 1-based start line to focus on. Only applied when BOTH startLine and endLine are provided; otherwise the whole file is analyzed."
+          },
+          "endLine": {
+            "type": "integer",
+            "description": "Optional 1-based end line to focus on (inclusive). Only applied when BOTH startLine and endLine are provided; otherwise the whole file is analyzed."
+          }
+        }
+      }
+    """
+    val tool = Tool
+      .builder()
+      .name("show-implicits")
+      .description(
+        """|Show the implicits the Scala compiler silently inserts in a file —
+           |implicit/using parameters and implicit conversions — and the symbols or
+           |in-file definitions they resolve to. Invisible in the source, so use it
+           |when debugging implicit-resolution errors ("could not find implicit value"
+           |/ "no given instance") or before refactoring code that relies on implicits.
+           |Works for Scala 2 and 3 (given/using); output positions are 1-based line:col.""".stripMargin
+      )
+      .inputSchema(jsonMapper, schema)
+      .build()
+    new AsyncToolSpecification(
+      tool,
+      withErrorHandling { (exchange, arguments) =>
+        val pathOpt = arguments.getFileInFocusOpt
+        val range =
+          for {
+            start <- arguments.getOptAs[Int]("startLine")
+            end <- arguments.getOptAs[Int]("endLine")
+          } yield new l.Range(
+            new l.Position(start - 1, 0),
+            new l.Position(end - 1, 0),
+          )
+        indexingPromise.future.flatMap { _ =>
+          queryEngine
+            .showImplicits(pathOpt, range)
+            .map { result =>
+              val isError = result match {
+                case _: ImplicitsResult.NoFile => true
+                case _ => false
+              }
+              CallToolResult
+                .builder()
+                .content(createContent(result.show))
+                .isError(isError)
+                .build()
+            }
         }.toMono
       },
     )
@@ -1295,6 +1360,7 @@ trait MetalsMcpTools extends Cancelable {
     asyncServer.addTool(createGlobSearchTool()).subscribe()
     asyncServer.addTool(createTypedGlobSearchTool()).subscribe()
     asyncServer.addTool(createInspectTool()).subscribe()
+    asyncServer.addTool(createShowImplicitsTool()).subscribe()
     asyncServer.addTool(createGetDocsTool()).subscribe()
     asyncServer.addTool(createGetUsagesTool()).subscribe()
     asyncServer.addTool(importBuildTool()).subscribe()

--- a/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
@@ -51,6 +51,45 @@ class TestMcpClient(url: String, val port: Int)(implicit ec: ExecutionContext)
       )
   }
 
+  /**
+   * Like [[callTool]], but surfaces `CallToolResult.isError` alongside the text
+   * content (the plain `callTool` discards it). Needed to assert error wiring.
+   */
+  def callToolRaw(
+      toolName: String,
+      params: tools.jackson.databind.node.ObjectNode,
+  ): Future[(Boolean, List[String])] = {
+    val callToolRequest =
+      new CallToolRequest(
+        jsonMapper,
+        toolName,
+        objectMapper.writeValueAsString(params),
+      )
+    client
+      .callTool(callToolRequest)
+      .toFuture()
+      .toScala
+      .map { result =>
+        val isError = Option(result.isError()).exists(_.booleanValue())
+        val texts = result.content.asScala.collect { case text: TextContent =>
+          text.text
+        }.toList
+        (isError, texts)
+      }
+  }
+
+  def showImplicits(
+      filePath: Option[String],
+      startLine: Option[Int] = None,
+      endLine: Option[Int] = None,
+  ): Future[(Boolean, List[String])] = {
+    val params = objectMapper.createObjectNode()
+    filePath.foreach(p => params.put("fileInFocus", p))
+    startLine.foreach(line => params.put("startLine", line))
+    endLine.foreach(line => params.put("endLine", line))
+    callToolRaw("show-implicits", params)
+  }
+
   override def initialize(): Future[InitializeResult] = {
     client.initialize().toFuture().asScala
   }

--- a/tests/unit/src/test/scala/tests/mcp/McpResolveImplicitsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpResolveImplicitsLspSuite.scala
@@ -1,0 +1,225 @@
+package tests.mcp
+
+import scala.meta.internal.metals.mcp.McpPrinter._
+
+import org.eclipse.{lsp4j => l}
+import tests.BaseLspSuite
+
+class McpShowImplicitsLspSuite
+    extends BaseLspSuite("show-implicits")
+    with McpTestUtils {
+
+  test("implicit-conversion") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{"a": {}}
+            |/a/src/main/scala/Conv.scala
+            |object Conv {
+            |  val reversed = "abc".reverse
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Conv.scala")
+      _ = assertNoDiagnostics()
+      path = server.toPath("a/src/main/scala/Conv.scala")
+      result <- server.headServer.queryEngine.showImplicits(Some(path), None)
+      // Exactly one rendered conversion line: the standalone `)` close hint is
+      // filtered out, so only the meaningful opening hint remains.
+      _ = assertNoDiff(
+        result.show,
+        """|Implicit conversions:
+           |  a/src/main/scala/Conv.scala:2:18  augmentString  ->  scala/Predef.augmentString().
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("multi-target-implicit-arguments") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{"a": {}}
+            |/a/src/main/scala/Instances.scala
+            |trait Eq[A]
+            |trait Semigroup[A]
+            |object Instances {
+            |  implicit def instancesString: Eq[String] with Semigroup[String] = ???
+            |}
+            |object Demo {
+            |  import Instances._
+            |  def checkThing2[A](implicit ev: Eq[A], sem: Semigroup[A]): Unit = ()
+            |  val x = checkThing2[String]
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Instances.scala")
+      _ = assertNoDiagnostics()
+      path = server.toPath("a/src/main/scala/Instances.scala")
+      result <- server.headServer.queryEngine.showImplicits(Some(path), None)
+      // One implicit-argument hint whose two label parts both resolve to the
+      // in-file `instancesString` def; the `(`, `, `, `)` separator parts must
+      // NOT leak as empty targets.
+      _ = assertNoDiff(
+        result.show,
+        """|Implicit arguments:
+           |  a/src/main/scala/Instances.scala:9:30  (instancesString, instancesString)  ->  (4:16), (4:16)
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("range-narrowing-and-clamping") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{"a": {}}
+            |/a/src/main/scala/Ranges.scala
+            |object Ranges {
+            |  val sorted = List(3, 1, 2).sorted
+            |  val reversed = "abc".reverse
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Ranges.scala")
+      _ = assertNoDiagnostics()
+      path = server.toPath("a/src/main/scala/Ranges.scala")
+      // Narrow to line 1 (0-based) only -> just the implicit Ordering argument.
+      narrowed <- server.headServer.queryEngine.showImplicits(
+        Some(path),
+        Some(new l.Range(new l.Position(1, 0), new l.Position(1, 0))),
+      )
+      _ = assertNoDiff(
+        narrowed.show,
+        """|Implicit arguments:
+           |  a/src/main/scala/Ranges.scala:2:36  (Int)  ->  scala/math/Ordering.Int.
+           |""".stripMargin,
+      )
+      // Deliberately out-of-bounds endLine is clamped, not dropped: still returns
+      // the in-file hints across the whole file.
+      clamped <- server.headServer.queryEngine.showImplicits(
+        Some(path),
+        Some(new l.Range(new l.Position(0, 0), new l.Position(999, 0))),
+      )
+      _ = assertNoDiff(
+        clamped.show,
+        """|Implicit arguments:
+           |  a/src/main/scala/Ranges.scala:2:36  (Int)  ->  scala/math/Ordering.Int.
+           |Implicit conversions:
+           |  a/src/main/scala/Ranges.scala:3:18  augmentString  ->  scala/Predef.augmentString().
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("client-range-is-1-based") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{"a": {}}
+            |/a/src/main/scala/Ranges.scala
+            |object Ranges {
+            |  val sorted = List(3, 1, 2).sorted
+            |  val reversed = "abc".reverse
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Ranges.scala")
+      _ = assertNoDiagnostics()
+      client <- startMcpServer()
+      path = server.toPath("a/src/main/scala/Ranges.scala")
+      // 1-based startLine/endLine of 2 brackets only the `sorted` line, which is
+      // exactly the 1-based line reported in the hint below -- locks in that the
+      // public range inputs are now 1-based, matching the output convention.
+      (isError, texts) <- client.showImplicits(
+        Some(path.toString),
+        startLine = Some(2),
+        endLine = Some(2),
+      )
+      _ = assert(!isError)
+      _ = assertNoDiff(
+        texts.mkString,
+        """|Implicit arguments:
+           |  a/src/main/scala/Ranges.scala:2:36  (Int)  ->  scala/math/Ordering.Int.
+           |""".stripMargin,
+      )
+      _ <- client.shutdown()
+    } yield ()
+  }
+
+  test("no-file-resolved") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{"a": {}}
+            |/a/src/main/scala/Conv.scala
+            |object Conv {
+            |  val reversed = "abc".reverse
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Conv.scala")
+      // No path and no way to resolve one -> NoFile, rendered as an error message.
+      result <- server.headServer.queryEngine.showImplicits(None, None)
+      _ = assertNoDiff(
+        result.show,
+        "Error: could not resolve file: <no file provided>",
+      )
+    } yield ()
+  }
+
+  test("no-implicits-found") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{"a": {}}
+            |/a/src/main/scala/Plain.scala
+            |object Plain {
+            |  val x: Int = 1 + 2
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Plain.scala")
+      _ = assertNoDiagnostics()
+      path = server.toPath("a/src/main/scala/Plain.scala")
+      result <- server.headServer.queryEngine.showImplicits(Some(path), None)
+      _ = assertNoDiff(
+        result.show,
+        "No implicits found in a/src/main/scala/Plain.scala",
+      )
+    } yield ()
+  }
+
+  // Only the client-level path exercises schema parsing, tool registration, and
+  // the isError branch (engine-only tests cannot reach these).
+  test("is-error-wiring") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{"a": {}}
+            |/a/src/main/scala/Conv.scala
+            |object Conv {
+            |  val reversed = "abc".reverse
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Conv.scala")
+      _ = assertNoDiagnostics()
+      client <- startMcpServer()
+      path = server.toPath("a/src/main/scala/Conv.scala")
+      (normalIsError, _) <- client.showImplicits(Some(path.toString))
+      _ = assert(!normalIsError, "normal file should not be an error")
+      missing = path.toNIO.resolveSibling("DoesNotExist.scala").toString
+      (missingIsError, _) <- client.showImplicits(Some(missing))
+      _ = assert(missingIsError, "missing file should be an error")
+      _ <- client.shutdown()
+    } yield ()
+  }
+}


### PR DESCRIPTION
Implicits and using parameters are invisible in source code, making it difficult to understand implicit dependencies, debug resolution errors, or safely refactor implicit-heavy code.

This new MCP tool shows all implicit/using parameters and implicit conversions that the Scala compiler inserts in a file, along with the symbols or in-file definitions they resolve to. This enables developers to:

- Inspect what implicits are being silently inserted and where they come from
- Debug implicit-resolution errors ("could not find implicit value", "no given instance")
- Understand implicit dependencies before refactoring code that relies on them
- Verify implicit resolution is working as intended

The tool works for both Scala 2 and Scala 3 (given/using syntax).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the MCP `show-implicits` tool to show implicit arguments and implicit conversions for a Scala file.
  - Supports optional 1-based line range filtering and reports when the requested file/path can’t be found.
  - Returns rendered hints split into arguments vs conversions with positions and resolved targets.

- **Bug Fixes**
  - Improved LSP range clamping/narrowing to reliably extract hints within valid buffer bounds.
  - Filters out irrelevant conversion-closing hints and separator artifacts.

- **Tests**
  - Added end-to-end coverage for conversions, multi-target arguments, range behavior, missing files, empty results, and error wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->