### PR TITLE
Add `.mbt.bat` Windows batch script support to MBT importer

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/ScriptMbtImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/ScriptMbtImporter.scala
@@ -19,6 +19,7 @@ import scala.meta.io.AbsolutePath
  * Supported script types:
  *  - `.mbt.scala` / `.mbt.java` — run with Scala CLI
  *  - `.mbt.sh`                  — run with `sh`
+ *  - `.mbt.bat`                 — run directly
  *
  * The script receives:
  *  - `MBT_OUTPUT_FILE` env var: path to write build JSON
@@ -85,6 +86,8 @@ final class ScriptMbtImporter(
   private[importer] def buildCommand(workspace: AbsolutePath): List[String] = {
     if (scriptPath.toFile.getName().endsWith(".mbt.sh"))
       List("sh", scriptPath.toString)
+    else if (scriptPath.toFile.getName().endsWith(".mbt.bat"))
+      List(scriptPath.toString)
     else {
       // .mbt.scala or .mbt.java — use Scala CLI
       val launcher = userConfig().scalaCliLauncher.getOrElse("scala-cli")
@@ -103,5 +106,5 @@ final class ScriptMbtImporter(
 
 object ScriptMbtImporter {
   val scriptExtensions: List[String] =
-    List(".mbt.scala", ".mbt.java", ".mbt.sh")
+    List(".mbt.scala", ".mbt.java", ".mbt.sh", ".mbt.bat")
 }

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/mbt/importer/ScriptMbtImporterSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/mbt/importer/ScriptMbtImporterSuite.scala
@@ -44,6 +44,12 @@ class ScriptMbtImporterSuite extends FunSuite {
     assertEquals(importer(script).name, "exporter-sh")
   }
 
+  test("name-strips-mbt-bat") {
+    val dir = AbsolutePath(Files.createTempDirectory("mbt-script-name"))
+    val script = makeScript(dir, "exporter.mbt.bat")
+    assertEquals(importer(script).name, "exporter-bat")
+  }
+
   test("name-unknown-extension-unchanged") {
     val dir = AbsolutePath(Files.createTempDirectory("mbt-script-name"))
     val script = makeScript(dir, "weird.txt")
@@ -82,6 +88,13 @@ class ScriptMbtImporterSuite extends FunSuite {
     assertEquals(cmd(1), script.toString)
   }
 
+  test("buildCommand-bat-uses-script-directly") {
+    val dir = AbsolutePath(Files.createTempDirectory("mbt-cmd"))
+    val script = makeScript(dir, "run.mbt.bat")
+    val cmd = importer(script).buildCommand(dir)
+    assertEquals(cmd, List(script.toString))
+  }
+
   test("buildCommand-scala-uses-scala-cli") {
     val dir = AbsolutePath(Files.createTempDirectory("mbt-cmd"))
     val workspace = AbsolutePath(Files.createTempDirectory("mbt-cmd-ws"))
@@ -118,12 +131,20 @@ class ScriptMbtImporterSuite extends FunSuite {
     val ws = AbsolutePath(Files.createTempDirectory("mbt-collision-ws"))
     val scalaScript = makeScript(dir, "foo.mbt.scala")
     val shScript = makeScript(dir, "foo.mbt.sh")
+    val batScript = makeScript(dir, "foo.mbt.bat")
     val nameScala = importer(scalaScript).name
     val nameSh = importer(shScript).name
+    val nameBat = importer(batScript).name
     assertNotEquals(nameScala, nameSh)
+    assertNotEquals(nameScala, nameBat)
+    assertNotEquals(nameSh, nameBat)
     assertNotEquals(
       importer(scalaScript).outputPath(ws),
       importer(shScript).outputPath(ws),
+    )
+    assertNotEquals(
+      importer(scalaScript).outputPath(ws),
+      importer(batScript).outputPath(ws),
     )
   }
 

--- a/tests/unit/src/test/scala/tests/mbt/MbtImporterDiscoverySuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtImporterDiscoverySuite.scala
@@ -71,11 +71,27 @@ class MbtImporterDiscoverySuite extends BaseSuite {
     assertEquals(importers.head.name, "gen-sh")
   }
 
+  test("discover-mbt-bat-script") {
+    val workspace = AbsolutePath(Files.createTempDirectory("mbt-disco"))
+    write(workspace.resolve("gen.mbt.bat"), "@echo off")
+
+    val importers = buildTools(workspace).mbtImporters(
+      shellRunner = null,
+      userConfig = () => UserConfiguration(),
+      languageClient = None,
+      tables = None,
+    )
+    assertEquals(importers.length, 1)
+    assert(importers.head.isInstanceOf[ScriptMbtImporter])
+    assertEquals(importers.head.name, "gen-bat")
+  }
+
   test("discover-multiple-scripts") {
     val workspace = AbsolutePath(Files.createTempDirectory("mbt-disco"))
     write(workspace.resolve("a.mbt.scala"))
     write(workspace.resolve("b.mbt.sh"))
     write(workspace.resolve("c.mbt.java"))
+    write(workspace.resolve("d.mbt.bat"))
 
     val importers = buildTools(workspace).mbtImporters(
       shellRunner = null,
@@ -84,10 +100,10 @@ class MbtImporterDiscoverySuite extends BaseSuite {
       tables = None,
     )
     val scriptImporters = importers.collect { case s: ScriptMbtImporter => s }
-    assertEquals(scriptImporters.length, 3)
+    assertEquals(scriptImporters.length, 4)
     assertEquals(
       scriptImporters.map(_.name).toSet,
-      Set("a-scala", "b-sh", "c-java"),
+      Set("a-scala", "b-sh", "c-java", "d-bat"),
     )
   }
 
@@ -96,6 +112,7 @@ class MbtImporterDiscoverySuite extends BaseSuite {
     write(workspace.resolve("exporter.scala"))
     write(workspace.resolve("exporter.sh"))
     write(workspace.resolve("exporter.java"))
+    write(workspace.resolve("exporter.bat"))
 
     val importers = buildTools(workspace).mbtImporters(
       shellRunner = null,


### PR DESCRIPTION
Extracted from https://github.com/scalameta/metals/pull/8360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Windows batch-based MBT scripts (`.mbt.bat`).
  * Batch scripts are now discovered automatically and executed directly.

* **Bug Fixes**
  * Improved script naming and output handling for batch-based MBT scripts.
  * Non-MBT batch files continue to be excluded from discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->