### PR TITLE
Metals V2 ignores 'metals.java-turbine-recompile-delay'

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -142,7 +142,7 @@ class MbtWorkspaceSymbolProvider(
       progress,
       // We don't need to re-compile the workspace super regularly because we can
       // load recently changed files from the sourcepath.
-      turbineRecompileDelay().duration,
+      () => turbineRecompileDelay(),
       listProtoJavaOutlinesForPackage = pkg =>
         protobufWorkspace.listProtoJavaOutlinesForPackage(
           pkg,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
@@ -19,6 +19,7 @@ import scala.util.control.NonFatal
 
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.BatchedFunction
+import scala.meta.internal.metals.Configs.TurbineRecompileDelayConfig
 import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.Sleeper
@@ -130,7 +131,7 @@ class TurbineCompiler[T](
     parseUnit: T => Option[SourceFile],
     classpath: () => Seq[Path],
     progressBars: ProgressBars,
-    debounceDelay: FiniteDuration,
+    turbineRecompileDelay: () => TurbineRecompileDelayConfig,
     listProtoJavaOutlinesForPackage: String => Iterator[JavaFileObject],
     sleeper: Sleeper,
     onIndexingDone: () => Unit,
@@ -152,9 +153,10 @@ class TurbineCompiler[T](
       sourcepathJavaFileObject <- deque.asScala.iterator
     } yield sourcepathJavaFileObject
   }.toSeq
+  private def debounceDelay: FiniteDuration = turbineRecompileDelay().duration
   // When delay is >= 1 hour, consider turbine recompilation effectively disabled.
   // In this mode, we rely entirely on SOURCE_PATH fallback for updated sources.
-  private val isRecompilationDisabled: Boolean =
+  private def isRecompilationDisabled: Boolean =
     debounceDelay.toMillis >= 3600000
 
   private val doCompile =


### PR DESCRIPTION
Fixes #8677 