### PR TITLE
mbt(bazel): map root-package file labels without a leading slash

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelLabels.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelLabels.scala
@@ -1,0 +1,29 @@
+package scala.meta.internal.metals.mbt.importer
+
+object BazelLabels {
+
+  /** Split an in-repo label `//pkg/path:name` into (`pkg/path`, `name`). */
+  def splitLabel(label: String): Option[(String, String)] = {
+    val s = label.trim
+    if (s.startsWith("//")) {
+      val rest = s.substring(2)
+      val colon = rest.lastIndexOf(':')
+      if (colon < 0) None
+      else Some((rest.substring(0, colon), rest.substring(colon + 1)))
+    } else None
+  }
+
+  def packageKey(ruleLabel: String): Option[String] =
+    splitLabel(ruleLabel).map { case (pkg, _) => s"//$pkg" }
+
+  /**
+   * Map a Bazel file label `//path/to:File.ext` to a workspace-relative path
+   * `path/to/File.ext`.
+   */
+  def fileLabelToWorkspaceRelativePath(fileLabel: String): Option[String] =
+    splitLabel(fileLabel).collect {
+      case (pkg, name) if name.nonEmpty =>
+        if (pkg.isEmpty) name else s"$pkg/$name"
+    }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtBuildSupport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtBuildSupport.scala
@@ -83,7 +83,7 @@ object BazelMbtBuildSupport {
           keys,
         )
       val srcFilesByTarget = srcsByTarget.map { case (k, v) =>
-        k -> v.flatMap(fileLabelToWorkspaceRelativePath)
+        k -> v.flatMap(BazelLabels.fileLabelToWorkspaceRelativePath)
       }
       val namespaces = new ju.LinkedHashMap[String, MbtNamespace]()
 
@@ -187,41 +187,10 @@ object BazelMbtBuildSupport {
   ): String =
     if (granularity == BazelMbtNamespaceMode.Workspace) workspaceNamespaceName
     else if (granularity == BazelMbtNamespaceMode.BuildFile) {
-      packageKey(ruleLabel).getOrElse(ruleLabel)
+      BazelLabels.packageKey(ruleLabel).getOrElse(ruleLabel)
     } else {
       ruleLabel
     }
-
-  def packageKey(ruleLabel: String): Option[String] = {
-    val s = ruleLabel.trim
-    if (!s.startsWith("//")) None
-    else {
-      val rest = s.substring(2)
-      val c = rest.lastIndexOf(':')
-      if (c < 0) None
-      else Some("//" + rest.substring(0, c))
-    }
-  }
-
-  /**
-   * Map a Bazel file label `//path/to:File.ext` to a workspace-relative path
-   * `path/to/File.ext`.
-   */
-  def fileLabelToWorkspaceRelativePath(fileLabel: String): Option[String] = {
-    val s = fileLabel.trim
-    if (!s.startsWith("//")) None
-    else {
-      val rest = s.substring(2)
-      val c = rest.lastIndexOf(':')
-      if (c < 0) None
-      else {
-        val pkg = rest.substring(0, c)
-        val name = rest.substring(c + 1)
-        if (name.isEmpty) None
-        else Some(s"$pkg/$name")
-      }
-    }
-  }
 
   private def computeDependsOn(
       granularity: BazelMbtNamespaceMode,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
@@ -178,7 +178,7 @@ abstract class BazelMbtImporter(
         output <- ruleOutputsByTarget
           .getOrElse(target, Nil)
           .find(isClassJarOutput)
-        relative <- BazelMbtBuildSupport.fileLabelToWorkspaceRelativePath(
+        relative <- BazelLabels.fileLabelToWorkspaceRelativePath(
           output
         )
       } yield target -> bin.resolve(relative).toString
@@ -313,37 +313,35 @@ abstract class BazelMbtImporter(
     }
 
   private def moduleIdFromJarLabel(label: String): Option[String] =
-    BazelMbtBuildSupport.fileLabelToWorkspaceRelativePath(label).map {
-      relative =>
-        val lastSlash = relative.lastIndexOf('/')
-        if (lastSlash >= 0) {
-          val pkg = relative.substring(0, lastSlash).replace('/', '.')
-          val fileName = relative.substring(lastSlash + 1)
-          s"$pkg:$fileName:local"
-        } else {
-          s"root:$relative:local"
-        }
+    BazelLabels.fileLabelToWorkspaceRelativePath(label).map { relative =>
+      val lastSlash = relative.lastIndexOf('/')
+      if (lastSlash >= 0) {
+        val pkg = relative.substring(0, lastSlash).replace('/', '.')
+        val fileName = relative.substring(lastSlash + 1)
+        s"$pkg:$fileName:local"
+      } else {
+        s"root:$relative:local"
+      }
     }
 
   private def resolveJarUri(
       label: String,
       bazelBin: Option[Path],
   ): Option[String] = {
-    BazelMbtBuildSupport.fileLabelToWorkspaceRelativePath(label).flatMap {
-      relative =>
-        val candidate = projectRoot.resolve(relative)
-        if (Files.exists(candidate.toNIO)) Some(candidate.toURI.toString)
-        else {
-          val generatedCandidate = bazelBin.map(_.resolve(relative))
-          generatedCandidate.filter(Files.exists(_)) match {
-            case Some(path) => Some(path.toUri.toString)
-            case None =>
-              scribe.warn(
-                s"bazel-mbt: could not resolve jar for label $label"
-              )
-              None
-          }
+    BazelLabels.fileLabelToWorkspaceRelativePath(label).flatMap { relative =>
+      val candidate = projectRoot.resolve(relative)
+      if (Files.exists(candidate.toNIO)) Some(candidate.toURI.toString)
+      else {
+        val generatedCandidate = bazelBin.map(_.resolve(relative))
+        generatedCandidate.filter(Files.exists(_)) match {
+          case Some(path) => Some(path.toUri.toString)
+          case None =>
+            scribe.warn(
+              s"bazel-mbt: could not resolve jar for label $label"
+            )
+            None
         }
+      }
     }
   }
 

--- a/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
@@ -18,6 +18,7 @@ import tests.BaseLspSuite
 import tests.BaseMbtSuite
 import tests.BazelBuildLayout
 import tests.MbtTestInitializer
+import tests.ScriptsAssertions
 import tests.TestHovers
 
 /**
@@ -27,6 +28,7 @@ import tests.TestHovers
 class BazelMbtLspSuite
     extends BaseLspSuite("bazel-mbt", MbtTestInitializer)
     with TestHovers
+    with ScriptsAssertions
     with BaseMbtSuite {
 
   private val bazelVersion = "8.2.1"
@@ -955,6 +957,142 @@ class BazelMbtLspSuite
             |  },
             |  "uncheckedSources": []
             |}""".stripMargin,
+      )
+    } yield ()
+  }
+
+  // A source declared in the root BUILD file has the root-package label
+  // `//:Greeter.scala` (empty package). Its consumer lives in a sub-package so
+  // navigation must cross from `//app` into the root-package source.
+  private def rootPackageWorkspaceLayout: String =
+    """|/.bazelproject
+       |targets:
+       |    //...
+       |
+       |/BUILD
+       |load("@rules_scala//scala:scala.bzl", "scala_library")
+       |
+       |scala_library(
+       |    name = "greeter",
+       |    srcs = ["Greeter.scala"],
+       |    visibility = ["//visibility:public"],
+       |)
+       |
+       |/Greeter.scala
+       |package greeter
+       |
+       |object Greeter {
+       |
+       |  /** Build a friendly greeting for the given name. */
+       |  def greet(name: String): String =
+       |    "Hello, " + name + "!"
+       |
+       |}
+       |
+       |/app/BUILD
+       |load("@rules_scala//scala:scala.bzl", "scala_binary")
+       |
+       |scala_binary(
+       |    name = "app",
+       |    srcs = ["Main.scala"],
+       |    main_class = "app.Main",
+       |    deps = ["//:greeter"],
+       |)
+       |
+       |/app/Main.scala
+       |package app
+       |
+       |import greeter.Greeter
+       |
+       |object Main {
+       |
+       |  def main(args: Array[String]): Unit =
+       |    println(Greeter.greet("World"))
+       |
+       |}
+       |""".stripMargin
+
+  test("bazel-import-mbt-root-package-navigation") {
+    client.selectedServer = Messages.ChooseBuildServer.mbt
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        BazelBuildLayout(rootPackageWorkspaceLayout, V.scala213, bazelVersion)
+      )
+      _ <- server.headServer.connectionProvider.buildServerPromise.future
+      mbtFile = workspace.resolve(".metals/mbt.json").readText
+      _ = assertNoDiff(
+        escapeMbtFile(mbtFile),
+        s"""|{
+            |  "dependencyModules": [],
+            |  "namespaces": {
+            |    "//": {
+            |      "sources": [
+            |        "Greeter.scala"
+            |      ],
+            |      "scalacOptions": [],
+            |      "javacOptions": [],
+            |      "dependencyModules": [],
+            |      "scalaVersion": "2.13.18",
+            |      "dependsOn": [],
+            |      "classDirectories": []
+            |    },
+            |    "//app": {
+            |      "sources": [
+            |        "app/Main.scala"
+            |      ],
+            |      "scalacOptions": [],
+            |      "javacOptions": [],
+            |      "dependencyModules": [],
+            |      "scalaVersion": "2.13.18",
+            |      "dependsOn": [
+            |        "//"
+            |      ],
+            |      "classDirectories": ["<classDirectories-path>"],
+            |      "configurations": [
+            |        "//app:app"
+            |      ]
+            |    }
+            |  },
+            |  "uncheckedSources": []
+            |}""".stripMargin,
+      )
+      _ <- server.didOpen("app/Main.scala")
+      _ = assertNoDiagnostics()
+      _ <- server.assertHover(
+        "app/Main.scala",
+        """|package app
+           |
+           |import greeter.Greeter
+           |
+           |object Main {
+           |
+           |  def main(args: Array[String]): Unit =
+           |    println(Greeter.gr@@eet("World"))
+           |
+           |}
+           |""".stripMargin,
+        """|```scala
+           |def greet(name: String): String
+           |```
+           |Build a friendly greeting for the given name.
+           |""".stripMargin.hover,
+      )
+      _ <- assertDefinitionAtLocation(
+        "app/Main.scala",
+        "Greeter.gr@@eet",
+        "Greeter.scala",
+      )
+      _ <- server.assertReferencesSubquery(
+        "Greeter.scala",
+        "def gr@@eet",
+        """|Greeter.scala:6:7: reference
+           |  def greet(name: String): String =
+           |      ^^^^^
+           |app/Main.scala:8:21: reference
+           |    println(Greeter.greet("World"))
+           |                    ^^^^^
+           |""".stripMargin,
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/bazel/BazelLabelsSuite.scala
+++ b/tests/unit/src/test/scala/tests/bazel/BazelLabelsSuite.scala
@@ -1,0 +1,35 @@
+package tests.bazel
+
+import scala.meta.internal.metals.mbt.importer.BazelLabels
+
+import tests.BaseSuite
+
+class BazelLabelsSuite extends BaseSuite {
+
+  test("file-label-to-workspace-relative-path") {
+    assertEquals(
+      BazelLabels.fileLabelToWorkspaceRelativePath("//path/to:File.scala"),
+      Some("path/to/File.scala"),
+    )
+    assertEquals(
+      BazelLabels.fileLabelToWorkspaceRelativePath("//pkg:sub/dir/File.scala"),
+      Some("pkg/sub/dir/File.scala"),
+    )
+  }
+
+  test("root-package-file-label-has-no-leading-slash") {
+    assertEquals(
+      BazelLabels.fileLabelToWorkspaceRelativePath("//:File.scala"),
+      Some("File.scala"),
+    )
+  }
+
+  test("rejects-non-file-and-external-labels") {
+    assertEquals(BazelLabels.fileLabelToWorkspaceRelativePath("//pkg:"), None)
+    assertEquals(
+      BazelLabels.fileLabelToWorkspaceRelativePath("@maven//:artifact"),
+      None,
+    )
+    assertEquals(BazelLabels.fileLabelToWorkspaceRelativePath("//pkg"), None)
+  }
+}


### PR DESCRIPTION
A source declared in the root BUILD file (`//:File.scala`) mapped to the workspace-relative path "/File.scala": the empty package still contributed its separator. Everything downstream that resolves such paths against the workspace (namespace sources, class directories, import-jar URIs) got a wrong path, so root-package sources dropped out of navigation.

The main change https://github.com/scalameta/metals/pull/8684#discussion_r3568598917

Part of the changes from #8494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bazel workspace imports by correctly resolving files in the root package.
  * Fixed navigation, hover information, and references for sources defined at the workspace root.
  * Improved conversion of Bazel file labels into workspace-relative paths.

* **Tests**
  * Added coverage for root-package Bazel labels and invalid or external labels.
  * Added end-to-end validation for cross-package navigation in Bazel MBT projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->