### PR TITLE
process: support capturing raw stdout bytes in SystemProcess/ShellRunner

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -18,6 +18,7 @@ import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.Timer
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.process.ExitCodes
+import scala.meta.internal.process.ProcessOutput
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
 
@@ -72,7 +73,7 @@ class ShellRunner(
       dir,
       redirectErrorOutput,
       javaHome,
-      processOut = processOut,
+      processOut = ProcessOutput.Lines(processOut),
       processErr = processErr,
       propagateError = propagateError,
     )
@@ -85,7 +86,7 @@ class ShellRunner(
       redirectErrorOutput: Boolean,
       javaHome: Option[String],
       additionalEnv: Map[String, String] = Map.empty,
-      processOut: String => Unit = scribe.info(_),
+      processOut: ProcessOutput = ProcessOutput.Lines(scribe.info(_)),
       processErr: String => Unit = scribe.error(_),
       propagateError: Boolean = false,
       logInfo: Boolean = true,
@@ -155,7 +156,7 @@ object ShellRunner {
       directory,
       redirectErrorOutput,
       env,
-      Some(s => {
+      Some(ProcessOutput.Lines { s =>
         sbOut.append(s)
         sbOut.append(Properties.lineSeparator)
       }),

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -33,6 +33,7 @@ import scala.meta.internal.mtags.URIEncoderDecoder
 import scala.meta.internal.parsing.ClassArtifact
 import scala.meta.internal.parsing.ClassFinder
 import scala.meta.internal.parsing.ClassFinderGranularity
+import scala.meta.internal.process.ProcessOutput
 import scala.meta.internal.semanticdb.TextDocument
 import scala.meta.io.AbsolutePath
 import scala.meta.metap.Format
@@ -635,7 +636,7 @@ final class FileDecoderProvider(
             redirectErrorOutput = false,
             userConfig().javaHome,
             Map.empty,
-            s => {
+            ProcessOutput.Lines { s =>
               sbOut.append(s)
               sbOut.append(Properties.lineSeparator)
             },

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/server/BuildToolDebugAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/server/BuildToolDebugAdapter.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import scala.meta.internal.process.ProcessOutput
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
 
@@ -38,7 +39,7 @@ class BuildToolDebugAdapter(
         cwd = workspace,
         redirectErrorOutput = false,
         env = env,
-        processOut = Some(logger.logOutput),
+        processOut = Some(ProcessOutput.Lines(logger.logOutput)),
         processErr = Some(logger.logError),
       )
       processRef.set(Some(process))

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/server/ForkedTestDebugAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/server/ForkedTestDebugAdapter.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import scala.meta.internal.process.ProcessOutput
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
 
@@ -53,7 +54,7 @@ class ForkedTestDebugAdapter(
         cwd = workspace,
         redirectErrorOutput = false,
         env = env,
-        processOut = Some(logger.logOutput),
+        processOut = Some(ProcessOutput.Lines(logger.logOutput)),
         processErr = Some(logger.logError),
       )
       processRef.set(Some(process))

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/server/Run.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/server/Run.scala
@@ -7,6 +7,7 @@ import scala.concurrent.ExecutionContext
 
 import scala.meta.internal.metals.JavaBinary
 import scala.meta.internal.metals.ManifestJar
+import scala.meta.internal.process.ProcessOutput
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
 
@@ -54,7 +55,7 @@ object Run {
           redirectErrorOutput = false,
           envOptions,
           processErr = Some(logger.logError),
-          processOut = Some(logger.logOutput),
+          processOut = Some(ProcessOutput.Lines(logger.logOutput)),
         )
       } else {
         ManifestJar.withTempManifestJar(classPath) { manifestJar =>
@@ -67,7 +68,7 @@ object Run {
             redirectErrorOutput = false,
             envOptions,
             processErr = Some(logger.logError),
-            processOut = Some(logger.logOutput),
+            processOut = Some(ProcessOutput.Lines(logger.logOutput)),
           )
         }
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
@@ -16,6 +16,7 @@ import scala.meta.internal.metals.debug.server.DebugeeParamsCreator
 import scala.meta.internal.metals.debug.server.DebugeeProject
 import scala.meta.internal.metals.debug.server.ForkedTestDebugAdapter
 import scala.meta.internal.metals.debug.server.MetalsDebugToolsResolver
+import scala.meta.internal.process.ProcessOutput
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
 
@@ -73,7 +74,7 @@ class MbtDebugSessionStarter(
           workspace,
           redirectErrorOutput = false,
           env = javaHomeEnv(target),
-          processOut = Some(out),
+          processOut = Some(ProcessOutput.Lines(out)),
           processErr = Some(err),
         )
         .complete,
@@ -97,7 +98,7 @@ class MbtDebugSessionStarter(
         workspace,
         redirectErrorOutput = false,
         env = javaHomeEnv(target),
-        processOut = Some(out),
+        processOut = Some(ProcessOutput.Lines(out)),
         processErr = Some(err),
       )
       .complete
@@ -139,7 +140,7 @@ class MbtDebugSessionStarter(
             workspace,
             redirectErrorOutput = false,
             env = javaHomeEnv(target),
-            processOut = Some(out),
+            processOut = Some(ProcessOutput.Lines(out)),
             processErr = Some(err),
           )
           .complete,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
@@ -18,6 +18,7 @@ import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.mbt.MbtBuild
 import scala.meta.internal.metals.mbt.MbtDependencyModule
 import scala.meta.internal.process.ExitCodes
+import scala.meta.internal.process.ProcessOutput
 import scala.meta.io.AbsolutePath
 
 /**
@@ -494,7 +495,7 @@ abstract class BazelMbtImporter(
         projectRoot,
         redirectErrorOutput = false,
         javaHome = userConfig().javaHome,
-        processOut = line => buf.append(line),
+        processOut = ProcessOutput.Lines(line => buf.append(line)),
         processErr = _ => (),
       )
       .future

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
@@ -11,6 +11,7 @@ import scala.meta.internal.builds.BazelProjectViewTargets
 import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.process.ExitCodes
+import scala.meta.internal.process.ProcessOutput
 import scala.meta.io.AbsolutePath
 
 object BazelQuery {
@@ -137,7 +138,7 @@ case class BazelQuery(
         projectRoot,
         redirectErrorOutput = false,
         javaHome,
-        processOut = line => {
+        processOut = ProcessOutput.Lines { line =>
           buf.append(line)
           buf.append(System.lineSeparator())
         },

--- a/metals/src/main/scala/scala/meta/internal/process/ProcessOutput.scala
+++ b/metals/src/main/scala/scala/meta/internal/process/ProcessOutput.scala
@@ -1,0 +1,11 @@
+package scala.meta.internal.process
+
+import java.io.OutputStream
+
+sealed trait ProcessOutput
+
+object ProcessOutput {
+
+  final case class Lines(f: String => Unit) extends ProcessOutput
+  final case class RawBytes(sink: OutputStream) extends ProcessOutput
+}

--- a/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
+++ b/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
@@ -9,6 +9,8 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.sys.process.BasicIO
+import scala.util.Using
+import scala.util.Using.Releasable
 import scala.util.control.NonFatal
 
 import scala.meta.internal.ansi.AnsiFilter
@@ -30,7 +32,9 @@ object SystemProcess {
       cwd: AbsolutePath,
       redirectErrorOutput: Boolean,
       env: Map[String, String],
-      processOut: Option[String => Unit] = Some(scribe.info(_)),
+      processOut: Option[ProcessOutput] = Some(
+        ProcessOutput.Lines(scribe.info(_))
+      ),
       processErr: Option[String => Unit] = Some(scribe.error(_)),
       propagateError: Boolean = false,
       discardInput: Boolean = true,
@@ -68,30 +72,20 @@ object SystemProcess {
   def wrapProcess(
       ps: Process,
       redirectErrorOutput: Boolean,
-      processOut: Option[String => Unit],
+      processOut: Option[ProcessOutput],
       processErr: Option[String => Unit],
       discardInput: Boolean,
       threadNamePrefix: String,
   )(implicit ec: ExecutionContext): SystemProcess = {
-    def readOutput(
-        name: String,
-        stream: InputStream,
-        f: String => Unit,
-    ): Thread = {
-      val filter = AnsiFilter()
+    def spawnReader(name: String)(body: => Unit): Thread = {
       val thread = new Thread {
-        override def run(): Unit = {
-          // use scala.sys.process implementation
-          try {
-            BasicIO.processFully(line => f(filter(line)))(
-              stream
-            )
-          } catch {
+        override def run(): Unit =
+          try body
+          catch {
             case _: IOException => // that's ok, happens on cancel
             case NonFatal(e) =>
               scribe.error("Unexcepted error in reading out", e)
           }
-        }
       }
       if (threadNamePrefix.nonEmpty)
         thread.setName(s"$threadNamePrefix-$name")
@@ -100,14 +94,42 @@ object SystemProcess {
       thread
     }
 
+    def readOutput(
+        name: String,
+        stream: InputStream,
+        f: String => Unit,
+    ): Thread = {
+      val filter = AnsiFilter()
+      // use scala.sys.process implementation
+      spawnReader(name)(BasicIO.processFully(line => f(filter(line)))(stream))
+    }
+
+    def readRawOutput(
+        name: String,
+        stream: InputStream,
+        out: OutputStream,
+    ): Thread = {
+      // `out` is caller-owned, so it is released by flushing
+      implicit val flushSink: Releasable[OutputStream] = _.flush()
+      spawnReader(name)(
+        Using.resource(stream)(in => Using.resource(out)(in.transferTo))
+      )
+    }
+
     if (discardInput) {
       // sbt might ask - Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)
       // and stuck there
       ps.getOutputStream().close
     }
 
+    val stdoutReader = processOut.map {
+      case ProcessOutput.Lines(f) =>
+        readOutput("stdout", ps.getInputStream(), f)
+      case ProcessOutput.RawBytes(sink) =>
+        readRawOutput("stdout", ps.getInputStream(), sink)
+    }
     val outReaders = List(
-      processOut.map(f => readOutput("stdout", ps.getInputStream(), f)),
+      stdoutReader,
       if (redirectErrorOutput) None
       else processErr.map(f => readOutput("stderr", ps.getErrorStream(), f)),
     ).flatten

--- a/tests/unit/src/test/scala/tests/SystemProcessSuite.scala
+++ b/tests/unit/src/test/scala/tests/SystemProcessSuite.scala
@@ -1,10 +1,17 @@
 package tests
 
+import java.io.BufferedOutputStream
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Properties
 
+import scala.meta.internal.process.ProcessOutput
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
 
@@ -58,4 +65,74 @@ class SystemProcessSuite extends FunSuite {
     val exitCode = Await.result(ps.complete, 1.seconds)
     assertEquals(exitCode, 1)
   }
+
+  test("capture-raw-stdout") {
+    // The newline bytes would be dropped (and lines split) by the text reader;
+    // `ProcessOutput.RawBytes` must return stdout byte-for-byte instead.
+    assume(!Properties.isWin, "binary printf is POSIX-only")
+    val expected = List[Byte]('a', '\n', 'b', '\n', 'c')
+    val out = new ByteArrayOutputStream()
+    val ps = SystemProcess.run(
+      List("/bin/sh", "-c", "printf 'a\\nb\\nc'"),
+      AbsolutePath(sys.props.get("user.dir").get),
+      redirectErrorOutput = false,
+      Map.empty,
+      processOut = Some(ProcessOutput.RawBytes(out)),
+    )
+    val exitCode = Await.result(ps.complete, 5.seconds)
+    assertEquals(exitCode, 0)
+    assertEquals(out.toByteArray.toList, expected)
+  }
+
+  test("capture-raw-stdout-flushes-buffered-sink") {
+    // A BufferedOutputStream holds its last chunk until flush/close. The reader
+    // must flush the caller-owned sink on completion, so the bytes are readable
+    // from the underlying stream without the caller flushing or closing it.
+    assume(!Properties.isWin, "binary printf is POSIX-only")
+    val underlying = new ByteArrayOutputStream()
+    val buffered = new BufferedOutputStream(underlying)
+    val ps = SystemProcess.run(
+      List("/bin/sh", "-c", "printf 'abc'"),
+      AbsolutePath(sys.props.get("user.dir").get),
+      redirectErrorOutput = false,
+      Map.empty,
+      processOut = Some(ProcessOutput.RawBytes(buffered)),
+    )
+    val exitCode = Await.result(ps.complete, 5.seconds)
+    assertEquals(exitCode, 0)
+    assertEquals(underlying.toByteArray.toList, List[Byte]('a', 'b', 'c'))
+  }
+
+  test("raw-reader-closes-process-stdout") {
+    val stdout = new TrackingInputStream("abc".getBytes)
+    val stderr = new TrackingInputStream(Array.emptyByteArray)
+    val ps = SystemProcess.wrapProcess(
+      new FakeProcess(stdout, stderr),
+      redirectErrorOutput = false,
+      processOut = Some(ProcessOutput.RawBytes(new ByteArrayOutputStream())),
+      processErr = None,
+      discardInput = false,
+      threadNamePrefix = "",
+    )
+    Await.result(ps.complete, 5.seconds)
+    assert(stdout.closed, "raw reader must close the drained stdout stream")
+  }
+}
+
+class TrackingInputStream(bytes: Array[Byte])
+    extends ByteArrayInputStream(bytes) {
+  @volatile var closed = false
+  override def close(): Unit = {
+    closed = true
+    super.close()
+  }
+}
+
+class FakeProcess(stdout: InputStream, stderr: InputStream) extends Process {
+  override def getOutputStream: OutputStream = new ByteArrayOutputStream()
+  override def getInputStream: InputStream = stdout
+  override def getErrorStream: InputStream = stderr
+  override def waitFor(): Int = 0
+  override def exitValue(): Int = 0
+  override def destroy(): Unit = ()
 }


### PR DESCRIPTION
Support capturing of binary output from stdout.
Add `ProcessOutput.RawBytes`.
Existing `String => Unit` calls are wrapped in `ProcessOutput.Lines` to keep a single `processOut` argument.

`RawBytes` is not used yet in any of the queries. It will be used once we replace Bazel query xml output with streamed_proto #8494
`bazel query --output=streamed_proto`