### PR TITLE
build(deps): update mdoc to 2.9.1

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -57,7 +57,8 @@ object V {
 
   val mill = "1.1.7"
 
-  val mdoc = "2.9.0"
+  // use from project/plugins.sbt
+  val mdoc = _root_.mdoc.BuildInfo.version
 
   val modelContextProtocol = "2.0.0"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.0")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.9.0")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.9.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.6.0")
 

--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "start": "docusaurus start",
     "build": "docusaurus build",
-    "publish-gh-pages": "docusaurus deploy",
+    "deploy": "docusaurus deploy",
     "swizzle": "docusaurus swizzle",
     "docusaurus": "docusaurus",
     "serve": "docusaurus serve"


### PR DESCRIPTION
Bump sbt-mdoc from 2.9.0 to 2.9.1 in project/plugins.sbt, and derive V.mdoc from the plugin (mdoc.BuildInfo.version) instead of hardcoding the version, so the two can't drift (matching how scalafmt does it).

2.9.1 defaults docusaurusVersion to V3, whose docusaurusPublishGhpages runs `yarn deploy` instead of `yarn publish-gh-pages`; rename the website publish script to `deploy` to match (still `docusaurus deploy`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation tooling to version 2.9.1.
  * Improved version consistency for documentation builds.
  * Renamed the website publishing command to `deploy` while retaining its deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->