### PR TITLE
feature: navigate to Java files materialized from .proto files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -999,6 +999,7 @@ lazy val mtest = project
       "kindProjector" -> V.kindProjector,
       "betterMonadicFor" -> V.betterMonadicFor,
       "lastSupportedSemanticdb" -> SemanticDbSupport.last,
+      "protobufVersion" -> V.protobuf,
     ),
     crossScalaVersions := V.nonDeprecatedScalaVersions,
     Compile / unmanagedSourceDirectories ++= multiScalaDirectories(

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -33,6 +33,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.decompile.DecompileBytecode
 import scala.meta.internal.metals.mbt.MbtBuild
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
+import scala.meta.internal.metals.mbt.ProtoGeneratedJavaFiles
 import scala.meta.internal.mtags.MD5
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.parsing.Trees
@@ -1649,6 +1650,7 @@ class Compilers(
     def fromBuildTarget: Option[PresentationCompiler] = {
       val target = buildTargets
         .inverseSources(path)
+        .orElse(protoGeneratedJavaTarget(path))
 
       target match {
         case None =>
@@ -1683,6 +1685,34 @@ class Compilers(
     else if (path.isWorksheet)
       loadWorksheetCompiler(path).orElse(fromBuildTarget)
     else fromBuildTarget
+  }
+
+  /**
+   * A Java file materialized from a proto outline belongs to no build target;
+   * route it to the target that owns the `.proto` file it was generated from,
+   * so that code navigation inside it uses a presentation compiler that can
+   * resolve the other proto-generated classes instead of the bare fallback
+   * compiler.
+   */
+  private def protoGeneratedJavaTarget(
+      path: AbsolutePath
+  ): Option[BuildTargetIdentifier] = {
+    if (!path.isJavaFilename) None
+    else {
+      ProtoGeneratedJavaFiles.protoPathFor(workspace, path).flatMap {
+        protoPath =>
+          // The materialized outline may have been deleted since it was first
+          // generated (`.metals` clean, `git clean`, editor reload); recreate
+          // it so code intelligence inside it keeps working.
+          ProtoGeneratedJavaFiles.regenerateIfMissing(
+            workspace,
+            path,
+            protoPath,
+            mbtWorkspaceSymbolProvider.protoJavaOutlines(protoPath),
+          )
+          buildTargets.inverseSources(protoPath)
+      }
+    }
   }
 
   def loadWorksheetCompiler(

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -78,6 +78,7 @@ final class DefinitionProvider(
     mbt,
     definitionProviders,
     protobufLspConfig,
+    mtags,
   )
   val destinationProvider = new DestinationProvider(
     index,

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProviderProtobufSupport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProviderProtobufSupport.scala
@@ -2,15 +2,21 @@ package scala.meta.internal.metals
 
 import java.{util => ju}
 
+import scala.util.Try
 import scala.util.control.NonFatal
 
+import scala.meta.dialects
 import scala.meta.internal.jmbt.Mbt
 import scala.meta.internal.metals.Configs.DefinitionProviderConfig
 import scala.meta.internal.metals.Configs.ProtobufLspConfig
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
+import scala.meta.internal.metals.mbt.ProtoGeneratedJavaFiles
+import scala.meta.internal.metals.mbt.ProtoJavaSymbolMapper
 import scala.meta.internal.metals.mbt.ProtoJavaVirtualFile
+import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.Symbol
+import scala.meta.internal.semanticdb.SymbolOccurrence
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 
@@ -22,6 +28,7 @@ final class DefinitionProviderProtobufSupport(
     mbt: MbtWorkspaceSymbolProvider,
     definitionProviders: () => DefinitionProviderConfig,
     protobufLspConfig: () => ProtobufLspConfig,
+    mtags: () => Mtags,
 ) {
 
   def hasProtoJavaLocation(res: DefinitionResult): Boolean =
@@ -88,10 +95,16 @@ final class DefinitionProviderProtobufSupport(
   def handleProtoJavaDefinition(
       res: DefinitionResult
   ): Option[DefinitionResult] = {
-    val mbtResult = mbt.definition(res.symbol)
-    if (mbtResult.nonEmpty) {
-      val locations = new ju.ArrayList[Location](mbtResult.size)
-      mbtResult.foreach(locations.add)
+    // When the proto file declares no java_package option, the proto package
+    // matches the generated Java package, so the MBT index resolves the Java
+    // symbol straight to the proto document. Those proto-file hits are ignored
+    // here so the generated Java outline lookup still runs; the proto file
+    // stays reachable through the fallback below.
+    val mbtJavaResult =
+      mbt.definition(res.symbol).filterNot(_.getUri.isProtoFilename)
+    if (mbtJavaResult.nonEmpty) {
+      val locations = new ju.ArrayList[Location](mbtJavaResult.size)
+      mbtJavaResult.foreach(locations.add)
       return Some(
         DefinitionResult(
           locations,
@@ -103,45 +116,155 @@ final class DefinitionProviderProtobufSupport(
       )
     }
 
-    val protoUri =
-      if (res.locations.isEmpty) None
-      else ProtoJavaVirtualFile.extractProtoPath(res.locations.get(0).getUri())
+    val generatedJavaFileUri =
+      Try(res.locations.get(0)).toOption.map(_.getUri())
+    val protoFilePath =
+      generatedJavaFileUri.flatMap(ProtoJavaVirtualFile.extractProtoPath)
 
-    val protoClassLocation = protoUri.flatMap { protoPath =>
+    val generatedJavaLocation = for {
+      javaPath <- generatedJavaFileUri
+      protoPath <- protoFilePath
+      location <- findSymbolInGeneratedJavaFile(protoPath, res.symbol, javaPath)
+    } yield location
+
+    val protoClassLocation = protoFilePath.flatMap { protoPath =>
       findProtoClassFromJavaSymbol(protoPath, res.symbol)
     }
 
     val protoFieldLocation = protoClassLocation.orElse {
-      protoUri.flatMap { protoPath =>
+      protoFilePath.flatMap { protoPath =>
         findProtoFieldFromJavaMethod(protoPath, res.symbol)
       }
     }
 
     val protoRpcLocation = protoFieldLocation.orElse {
-      protoUri.flatMap { protoPath =>
+      protoFilePath.flatMap { protoPath =>
         findProtoRpcFromJavaMethod(protoPath, res.symbol)
       }
     }
 
-    protoRpcLocation match {
-      case Some(loc) =>
-        Some(
-          DefinitionResult(
-            ju.Collections.singletonList(loc),
-            res.symbol,
-            None,
-            None,
-            res.querySymbol,
-          )
+    val allLocations = (generatedJavaLocation ++ protoRpcLocation).toList
+    if (allLocations.nonEmpty) {
+      Some(
+        DefinitionResult(
+          allLocations.asJava,
+          res.symbol,
+          // Recording the materialized file as the definition destination lets
+          // Metals remember which build target the user jumped from
+          // (InteractiveSemanticdbs.didDefinition), so later requests inside
+          // the materialized file use that target's classpath, which includes
+          // the protobuf runtime.
+          definition = generatedJavaLocation.map(_.getUri().toAbsolutePath),
+          semanticdb = None,
+          res.querySymbol,
         )
-      case None =>
-        scribe.debug(
-          s"proto-java: could not resolve symbol ${res.symbol} to proto"
-        )
-        Some(DefinitionResult.empty)
+      )
+    } else {
+      scribe.debug(
+        s"proto-java: could not resolve symbol ${res.symbol} to proto"
+      )
+      Some(DefinitionResult.empty)
     }
   }
 
+  /**
+   * Finds the definition of `javaSymbol` in the Java source that Metals
+   * synthesizes from the proto file. The outline is derived purely from the
+   * `.proto`, so this works for any build tool without a build or any
+   * configuration; it is materialized to a read-only file on disk so the
+   * client can open it.
+   */
+  private def findSymbolInGeneratedJavaFile(
+      protoPath: AbsolutePath,
+      javaSymbol: String,
+      virtualUri: String,
+  ): Option[Location] = try {
+    for {
+      className <- ProtoJavaVirtualFile.extractClassName(virtualUri)
+      outline <- mbt
+        .protoJavaOutlines(protoPath)
+        .find(outline =>
+          ProtoJavaVirtualFile
+            .extractClassName(outline.uri().toString())
+            .contains(className)
+        )
+      javaFile <- ProtoGeneratedJavaFiles.materialize(
+        workspace,
+        protoPath,
+        className,
+        outline.text,
+      )
+      range <- findJavaSymbolRange(javaFile, javaSymbol)
+    } yield new Location(javaFile.toURI.toString(), range.toLsp)
+  } catch {
+    case NonFatal(e) =>
+      scribe.debug(
+        s"proto-java: failed to resolve generated Java outline for $javaSymbol",
+        e,
+      )
+      None
+  }
+
+  /**
+   * Locates the definition range of `javaSymbol` in the given Java file,
+   * falling back to enclosing classes when the exact symbol is absent, for
+   * example when method overload disambiguators computed from the generated
+   * outline don't line up with the real generated source.
+   */
+  private def findJavaSymbolRange(
+      javaFile: AbsolutePath,
+      javaSymbol: String,
+  ): Option[s.Range] = {
+    val input = javaFile.toInputFromBuffers(buffers)
+    val doc = mtags().allToplevels(input, dialects.Scala213)
+    val definitions =
+      doc.occurrences.filter(_.role == s.SymbolOccurrence.Role.DEFINITION)
+
+    def loop(sym: Symbol): Option[s.Range] = {
+      if (sym.isNone || sym.isPackage) None
+      else findRange(sym.value, definitions).orElse(loop(sym.owner))
+    }
+
+    val querySym = Symbol(javaSymbol)
+    // For type symbols, require the type itself to be present: a message or
+    // enum missing from the generated source means the synthesized outline
+    // is stale or belongs to a different proto, and the proto fallback is
+    // more precise than an approximate enclosing-class location. Members may
+    // still fall back to their enclosing classes, since accessor overloads
+    // in the real generated source don't always line up with the
+    // synthesized outline.
+    if (querySym.isType) findRange(querySym.value, definitions)
+    else loop(querySym)
+  }
+
+  private def findRange(
+      symbol: String,
+      definitions: Iterable[SymbolOccurrence],
+  ): Option[s.Range] = {
+    val exact = definitions.find(_.symbol == symbol)
+    exact
+      .orElse {
+        val normalized = stripDisambiguators(symbol)
+        definitions.find(occ => stripDisambiguators(occ.symbol) == normalized)
+      }
+      .flatMap(_.range)
+  }
+
+  /**
+   * Strips SemanticDB overload disambiguators, which are appended to
+   * overloaded method symbols to keep them unique, for example:
+   *   - `getFoo(+1).` -> `getFoo().`
+   *   - `setBar(+3).` -> `setBar().`
+   */
+  private def stripDisambiguators(symbol: String): String =
+    symbol.replaceAll("""\(\+\d+\)""", "()")
+
+  /**
+   * The lowercased chain of owner names between `sym` and its enclosing
+   * package, for example the SemanticDB symbol
+   * `com/example/Foo#Bar#baz().` with package `com.example` becomes
+   * `List("foo", "bar", "baz")`.
+   */
   private def symbolSuffixAfterPackage(sym: Symbol): List[String] = {
     val pkg = sym.enclosingPackage
     def loop(s: Symbol, acc: List[String]): List[String] = {
@@ -305,16 +428,14 @@ final class DefinitionProviderProtobufSupport(
     import scala.meta.internal.mtags.proto.ProtoMtagsV2
 
     try {
-      val isGrpcClass = javaSymbol.contains("ImplBase#") ||
-        javaSymbol.contains("Stub#") ||
-        javaSymbol.contains("BlockingStub#") ||
-        javaSymbol.contains("FutureStub#")
-
-      if (!isGrpcClass) return None
+      if (!ProtoJavaSymbolMapper.isGrpcStubMethodSymbol(javaSymbol)) return None
 
       val methodNameOpt = extractMethodName(javaSymbol)
 
       methodNameOpt.flatMap { methodName =>
+        // Java stub methods use the lowerCamel RPC name (e.g. `doSomething`),
+        // while the proto symbol uses the UpperCamel RPC name declared in the
+        // service (e.g. `DoSomething`).
         val rpcName = capitalize(methodName)
 
         val input = protoPath.toInputFromBuffers(buffers)
@@ -356,6 +477,10 @@ final class DefinitionProviderProtobufSupport(
     else s.head.toUpper + s.tail
   }
 
+  /**
+   * The top-level class name owning `symbol`, for example the SemanticDB
+   * symbol `com/example/Foo#Bar#baz().` becomes `Foo`.
+   */
   private def extractClassName(symbol: String): Option[String] = {
     val sym = Symbol(symbol)
     def findTopLevelClass(s: Symbol): Option[String] = {
@@ -366,6 +491,10 @@ final class DefinitionProviderProtobufSupport(
     findTopLevelClass(sym)
   }
 
+  /**
+   * The method name of `symbol`, for example the SemanticDB symbol
+   * `com/example/Foo#bar(+1).` becomes `bar`.
+   */
   private def extractMethodName(symbol: String): Option[String] = {
     val hashIndex = symbol.lastIndexOf('#')
     if (hashIndex < 0) return None
@@ -379,6 +508,17 @@ final class DefinitionProviderProtobufSupport(
     }
   }
 
+  /**
+   * The proto field name accessed by a generated Java accessor method, for
+   * example:
+   *   - `getFooBar` -> `foo_bar`
+   *   - `setFooBarList` -> `foo_bar` (repeated field)
+   *   - `hasFooBar` / `clearFooBar` -> `foo_bar`
+   *   - `getHTTPCode` -> `HTTP_CODE` (already-uppercase names, e.g. proto
+   *     enum-like fields, are kept as-is instead of snake-cased)
+   *
+   * Inverse of [[scala.meta.internal.metals.mbt.ProtoJavaSymbolMapper#protoFieldToJavaMethods]].
+   */
   private def javaMethodToProtoField(methodName: String): Option[String] = {
     val fieldName =
       if (methodName.startsWith("set") && methodName.length > 3)

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProviderProtobufSupport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProviderProtobufSupport.scala
@@ -208,8 +208,8 @@ final class DefinitionProviderProtobufSupport(
   /**
    * Locates the definition range of `javaSymbol` in the given Java file,
    * falling back to enclosing classes when the exact symbol is absent, for
-   * example when method overload disambiguators computed from the generated
-   * outline don't line up with the real generated source.
+   * example when it refers to an inherited member not present in the
+   * synthesized outline.
    */
   private def findJavaSymbolRange(
       javaFile: AbsolutePath,
@@ -230,9 +230,8 @@ final class DefinitionProviderProtobufSupport(
     // enum missing from the generated source means the synthesized outline
     // is stale or belongs to a different proto, and the proto fallback is
     // more precise than an approximate enclosing-class location. Members may
-    // still fall back to their enclosing classes, since accessor overloads
-    // in the real generated source don't always line up with the
-    // synthesized outline.
+    // still fall back to their enclosing classes, since inherited members
+    // aren't always present in the synthesized outline.
     if (querySym.isType) findRange(querySym.value, definitions)
     else loop(querySym)
   }
@@ -240,24 +239,8 @@ final class DefinitionProviderProtobufSupport(
   private def findRange(
       symbol: String,
       definitions: Iterable[SymbolOccurrence],
-  ): Option[s.Range] = {
-    val exact = definitions.find(_.symbol == symbol)
-    exact
-      .orElse {
-        val normalized = stripDisambiguators(symbol)
-        definitions.find(occ => stripDisambiguators(occ.symbol) == normalized)
-      }
-      .flatMap(_.range)
-  }
-
-  /**
-   * Strips SemanticDB overload disambiguators, which are appended to
-   * overloaded method symbols to keep them unique, for example:
-   *   - `getFoo(+1).` -> `getFoo().`
-   *   - `setBar(+3).` -> `setBar().`
-   */
-  private def stripDisambiguators(symbol: String): String =
-    symbol.replaceAll("""\(\+\d+\)""", "()")
+  ): Option[s.Range] =
+    definitions.find(_.symbol == symbol).flatMap(_.range)
 
   /**
    * The lowercased chain of owner names between `sym` and its enclosing

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/IndexedDocument.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/IndexedDocument.scala
@@ -61,6 +61,16 @@ case class IndexedDocument(
     cachedProtobufJavaOutlines.set(null)
   }
 
+  /**
+   * The generated Java outlines cached by a previous
+   * [[getOrComputeJavaOutlines]] call, without computing them. Reading the
+   * cache matters when the proto file has changed on disk or in buffers:
+   * recomputing would produce outlines for the new content, while the cache
+   * still describes what earlier consumers (like the turbine classpath) saw.
+   */
+  def cachedJavaOutlines: Seq[VirtualTextDocument] =
+    Option(cachedProtobufJavaOutlines.get()).getOrElse(Seq.empty)
+
   def toSemanticdbCompilationUnit(
       input: Input.VirtualFile
   ): SemanticdbCompilationUnit with JavaFileObject = {

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtProtobufWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtProtobufWorkspaceSymbolProvider.scala
@@ -87,7 +87,19 @@ final class MbtProtobufWorkspaceSymbolProvider(
   ): Iterator[VirtualTextDocument] = {
     val packagePath = requestedPackage.stripSuffix("/").replace('/', '.')
 
-    val allOutlines = doc.getOrComputeJavaOutlines(() =>
+    allJavaOutlines(doc).iterator.filter { outline =>
+      outline.packages.headOption
+        .map(_.stripSuffix("/").replace('/', '.'))
+        .contains(packagePath)
+    }
+  }
+
+  /**
+   * All Java outlines generated from the given proto document, regardless of
+   * package.
+   */
+  def allJavaOutlines(doc: IndexedDocument): Seq[VirtualTextDocument] = {
+    doc.getOrComputeJavaOutlines(() =>
       try {
         val input = doc.file.toInputFromBuffers(buffers)
         val source = new ProtoSourceFile(input.path, input.text)
@@ -136,12 +148,6 @@ final class MbtProtobufWorkspaceSymbolProvider(
           Seq.empty
       }
     )
-
-    allOutlines.iterator.filter { outline =>
-      outline.packages.headOption
-        .map(_.stripSuffix("/").replace('/', '.'))
-        .contains(packagePath)
-    }
   }
 
   def findProtoRpcDefinition(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -140,25 +140,6 @@ class MbtWorkspaceSymbolProvider(
   def protoJavaOutlines(file: AbsolutePath): Seq[VirtualTextDocument] =
     documents.get(file).toSeq.flatMap(protobufWorkspace.allJavaOutlines)
 
-  /**
-   * The synthesized Java outline declaring `classSymbol` (a SemanticDB
-   * symbol, e.g. `com/example/Example#` or a nested
-   * `com/example/Outer#Inner#`), if any. Lets
-   * navigation recover the supertypes of a proto-generated class that the
-   * presentation compiler can't see, so it can follow inherited members into
-   * compiled base classes.
-   *
-   * An outline records only its outer class in `toplevelSymbols`, so a
-   * nested message is matched by prefix (safe since the outer symbol always
-   * ends in `#`).
-   */
-  def protoJavaOutlineFor(classSymbol: String): Option[VirtualTextDocument] =
-    documents.keysIterator
-      .filter(_.isProtoFilename)
-      .flatMap(protoJavaOutlines)
-      .find(
-        _.toplevelSymbols().asScala.exists(top => classSymbol.startsWith(top))
-      )
   private val turbineCompiler: TurbineCompiler[AbsolutePath] =
     new TurbineCompiler[AbsolutePath](
       () => documentsKeys,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -131,14 +131,59 @@ class MbtWorkspaceSymbolProvider(
     protobufLspConfig,
     clearAllProtobufCaches,
   )
+
+  /**
+   * The Java outlines synthesized from the given `.proto` file (one per
+   * generated top-level class). Empty when the file isn't an indexed proto or
+   * proto Java-package indexing is disabled.
+   */
+  def protoJavaOutlines(file: AbsolutePath): Seq[VirtualTextDocument] =
+    documents.get(file).toSeq.flatMap(protobufWorkspace.allJavaOutlines)
+
+  /**
+   * The synthesized Java outline declaring `classSymbol` (a SemanticDB
+   * symbol, e.g. `com/example/Example#` or a nested
+   * `com/example/Outer#Inner#`), if any. Lets
+   * navigation recover the supertypes of a proto-generated class that the
+   * presentation compiler can't see, so it can follow inherited members into
+   * compiled base classes.
+   *
+   * An outline records only its outer class in `toplevelSymbols`, so a
+   * nested message is matched by prefix (safe since the outer symbol always
+   * ends in `#`).
+   */
+  def protoJavaOutlineFor(classSymbol: String): Option[VirtualTextDocument] =
+    documents.keysIterator
+      .filter(_.isProtoFilename)
+      .flatMap(protoJavaOutlines)
+      .find(
+        _.toplevelSymbols().asScala.exists(top => classSymbol.startsWith(top))
+      )
   private val turbineCompiler: TurbineCompiler[AbsolutePath] =
     new TurbineCompiler[AbsolutePath](
       () => documentsKeys,
       file =>
-        if (!file.toLanguage.isJava) None
-        else
+        if (file.toLanguage.isJava) {
           toInput(file)
-            .map(input => new SourceFile(file.toString(), input.text)),
+            .map(input => new SourceFile(file.toString(), input.text))
+            .toList
+        } else if (
+          file.isProtoFilename &&
+          protobufWorkspace.isJavaPackageIndexingEnabled
+        ) {
+          // Include the Java outlines generated from proto files so that
+          // turbine can resolve references to proto-generated classes when it
+          // header-compiles the workspace. Without these, a Java method
+          // returning a proto-generated class gets its signature erased to
+          // java.lang.Object in the compiled classfile, breaking hover and
+          // completion in files that use that method.
+          for {
+            doc <- documents.get(file).toList
+            outline <- protobufWorkspace.allJavaOutlines(doc)
+          } yield new SourceFile(outline.getName(), outline.text)
+        } else {
+          Nil
+        },
       () => fallbackClasspaths().javaCompilerClasspath(),
       progress,
       // We don't need to re-compile the workspace super regularly because we can
@@ -174,7 +219,32 @@ class MbtWorkspaceSymbolProvider(
    */
   def didSave(path: AbsolutePath): Unit = {
     if (path.isProtoFilename) {
-      documents.get(path).foreach(_.clearProtobufJavaOutlinesCache())
+      documents.get(path).foreach { doc =>
+        invalidateCompiledProtoJavaOutlines(path, doc)
+        doc.clearProtobufJavaOutlinesCache()
+      }
+    }
+  }
+
+  /**
+   * Excludes proto-generated classes that were compiled into the turbine
+   * classpath from a previous version of the given proto file. Javac keeps
+   * resolving the current classes from fresh SOURCE_PATH outlines; without
+   * this, classes removed from the proto file would remain resolvable from
+   * stale classfiles until the next turbine recompile.
+   */
+  private def invalidateCompiledProtoJavaOutlines(
+      file: AbsolutePath,
+      doc: IndexedDocument,
+  ): Unit = {
+    if (javaSymbolLoader().isTurbineClasspath) {
+      val binaryNames = doc.cachedJavaOutlines
+        .flatMap(_.toplevelSymbols().asScala)
+        .map(_.stripSuffix("#").stripSuffix("."))
+      if (binaryNames.nonEmpty) {
+        turbineCompiler.onDidDelete(binaryNames, file.toURI.toString())
+        turbineCompiler.scheduleCompile().ignoreValue
+      }
     }
   }
   private def clearAllProtobufCaches(): Unit = {
@@ -417,6 +487,9 @@ class MbtWorkspaceSymbolProvider(
             case None =>
               Future.unit
           }
+        } else if (doc.language.isProtobuf) {
+          invalidateCompiledProtoJavaOutlines(file, doc)
+          Future.unit
         } else {
           Future.unit
         }
@@ -926,6 +999,16 @@ class MbtWorkspaceSymbolProvider(
           case None =>
             Future.unit
         }
+      } else if (
+        updateDocumentKeys &&
+        doc.language.isProtobuf &&
+        javaSymbolLoader().isTurbineClasspath
+      ) {
+        // Covers proto files changed outside the editor (e.g. git checkout);
+        // for editor saves, didSave already invalidated before the outline
+        // cache was cleared.
+        old.foreach(invalidateCompiledProtoJavaOutlines(file, _))
+        Future.unit
       } else {
         Future.unit
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/ProtoGeneratedJavaFiles.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/ProtoGeneratedJavaFiles.scala
@@ -5,9 +5,9 @@ import java.nio.file.Files
 
 import scala.util.control.NonFatal
 
-import scala.meta.internal.io.FileIO
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.mtags.MD5
 import scala.meta.io.AbsolutePath
 
 /**
@@ -110,10 +110,9 @@ object ProtoGeneratedJavaFiles {
     }
 
   private def writeIfChanged(file: AbsolutePath, content: String): Unit = {
-    val current =
-      if (file.exists) Some(FileIO.slurp(file, StandardCharsets.UTF_8))
-      else None
-    if (!current.contains(content)) {
+    val changed =
+      !file.exists || MD5.compute(file.toNIO) != MD5.compute(content)
+    if (changed) {
       Files.createDirectories(file.toNIO.getParent)
       Files.write(file.toNIO, content.getBytes(StandardCharsets.UTF_8))
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/ProtoGeneratedJavaFiles.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/ProtoGeneratedJavaFiles.scala
@@ -1,0 +1,121 @@
+package scala.meta.internal.metals.mbt
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import scala.util.control.NonFatal
+
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.metals.Directories
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+/**
+ * Materializes the Java source that Metals synthesizes from a `.proto` file
+ * (via [[MbtProtobufWorkspaceSymbolProvider]]) into a read-only file on disk,
+ * so that goto-definition on a proto-generated class can open it.
+ *
+ * The outline is derived purely from the `.proto` file, so this needs no build
+ * output and no configuration and works for every build tool. Files live under
+ * `.metals/readonly/` so clients treat them as read-only dependency sources.
+ */
+object ProtoGeneratedJavaFiles {
+
+  /** Subdirectory of `.metals/readonly/dependencies` for generated outlines. */
+  private val rootDirName = "proto-generated"
+
+  /**
+   * Writes `content` for `className.java` generated from `protoPath` to a
+   * stable on-disk location and returns it.
+   *
+   * The Java package is intentionally not reflected in the directory layout:
+   * it is already declared inside the file, no consumer derives it from the
+   * path, and class names are unique within a single `.proto`.
+   */
+  def materialize(
+      workspace: AbsolutePath,
+      protoPath: AbsolutePath,
+      className: String,
+      content: String,
+  ): Option[AbsolutePath] =
+    try {
+      protoPath.toRelativeInside(workspace).map { protoRelative =>
+        val javaFile = workspace
+          .resolve(Directories.dependencies)
+          .resolve(rootDirName)
+          .resolveZipPath(protoRelative.toNIO)
+          .resolve(s"$className.java")
+        writeIfChanged(javaFile, content)
+        javaFile
+      }
+    } catch {
+      case NonFatal(e) =>
+        scribe.debug(
+          s"proto-java: failed to materialize generated outline for $className",
+          e,
+        )
+        None
+    }
+
+  /**
+   * Inverse of [[materialize]]: recovers the `.proto` file that the given
+   * materialized Java file was generated from, or `None` when the path is not
+   * a materialized proto outline. The proto path is the leading segments of
+   * the path relative to the `proto-generated` root, up to and including the
+   * first segment with a `.proto` extension.
+   */
+  def protoPathFor(
+      workspace: AbsolutePath,
+      path: AbsolutePath,
+  ): Option[AbsolutePath] = {
+    val root = workspace
+      .resolve(Directories.dependencies)
+      .resolve(rootDirName)
+    for {
+      relative <- path.toRelativeInside(root)
+      segments = relative.toNIO.iterator().asScala.map(_.toString).toList
+      protoIndex = segments.indexWhere(_.endsWith(".proto"))
+      if protoIndex >= 0
+    } yield segments
+      .take(protoIndex + 1)
+      .foldLeft(workspace)(_.resolve(_))
+  }
+
+  /**
+   * Recreates the materialized outline for `outlineFile` when it has been
+   * deleted (for example after a `.metals` clean, a `git clean`, or an editor
+   * reload), so navigation, hover, and completion inside it keep working.
+   *
+   * `outlines` supplies the synthesized outlines for the proto `outlineFile`
+   * was generated from; it is evaluated only when the file is actually missing.
+   * No-op when the file still exists or no matching outline is found.
+   */
+  def regenerateIfMissing(
+      workspace: AbsolutePath,
+      outlineFile: AbsolutePath,
+      protoPath: AbsolutePath,
+      outlines: => Seq[VirtualTextDocument],
+  ): Unit =
+    if (!outlineFile.exists) {
+      val className = outlineFile.filename.stripSuffix(".java")
+      outlines
+        .find(outline =>
+          ProtoJavaVirtualFile
+            .extractClassName(outline.uri().toString())
+            .contains(className)
+        )
+        .foreach(outline =>
+          materialize(workspace, protoPath, className, outline.text)
+        )
+    }
+
+  private def writeIfChanged(file: AbsolutePath, content: String): Unit = {
+    val current =
+      if (file.exists) Some(FileIO.slurp(file, StandardCharsets.UTF_8))
+      else None
+    if (!current.contains(content)) {
+      Files.createDirectories(file.toNIO.getParent)
+      Files.write(file.toNIO, content.getBytes(StandardCharsets.UTF_8))
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
@@ -48,7 +48,7 @@ object TurbineCompiler {
 
   def compileClassfiles[T](
       toParse: ParArray[T],
-      toSourceFile: T => Option[SourceFile],
+      toSourceFile: T => Seq[SourceFile],
       classpath: Seq[Path],
       progressBars: ProgressBars,
   )(implicit rc: ReportContext): TurbineCompileResult = {
@@ -69,16 +69,14 @@ object TurbineCompiler {
 
   private def parseInputs[T](
       inputs: ParArray[T],
-      toSourceFile: T => Option[SourceFile],
+      toSourceFile: T => Seq[SourceFile],
   ): ImmutableList[Tree.CompUnit] = {
     val result = new ConcurrentLinkedQueue[Tree.CompUnit]()
     inputs.foreach { input =>
       try {
-        toSourceFile(input) match {
-          case None =>
-          // Silently ignore entries that may not exist
-          case Some(source) =>
-            result.add(Parser.parse(source))
+        // An empty result means the entry doesn't exist or isn't Java-related.
+        toSourceFile(input).foreach { source =>
+          result.add(Parser.parse(source))
         }
       } catch {
         case NonFatal(_) =>
@@ -128,7 +126,7 @@ private case class SourcepathJavaFileObject(
 
 class TurbineCompiler[T](
     allCompilationUnits: () => ParArray[T],
-    parseUnit: T => Option[SourceFile],
+    parseUnit: T => Seq[SourceFile],
     classpath: () => Seq[Path],
     progressBars: ProgressBars,
     turbineRecompileDelay: () => TurbineRecompileDelayConfig,

--- a/semanticdb-protoc/src/main/java/scala/meta/internal/proto/parse/Parser.java
+++ b/semanticdb-protoc/src/main/java/scala/meta/internal/proto/parse/Parser.java
@@ -62,7 +62,13 @@ public final class Parser {
           if (syntax.isPresent()) {
             error("Duplicate syntax declaration");
           }
-          syntax = Optional.of(parseSyntax());
+          syntax = Optional.of(parseSyntax("syntax"));
+          break;
+        case "edition":
+          if (syntax.isPresent()) {
+            error("Duplicate syntax declaration");
+          }
+          syntax = Optional.of(parseSyntax("edition"));
           break;
         case "package":
           if (pkg.isPresent()) {
@@ -104,9 +110,9 @@ public final class Parser {
         ImmutableList.copyOf(declarations));
   }
 
-  private SyntaxDecl parseSyntax() {
+  private SyntaxDecl parseSyntax(String keyword) {
     int startPos = currentPos();
-    expectIdentifier("syntax");
+    expectIdentifier(keyword);
     expectSymbol('=');
     String version = expectString();
     expectSymbol(';');

--- a/semanticdb-protoc/src/main/java/scala/meta/internal/proto/tree/Proto.java
+++ b/semanticdb-protoc/src/main/java/scala/meta/internal/proto/tree/Proto.java
@@ -145,9 +145,9 @@ public abstract class Proto {
     }
   }
 
-  /** syntax = "proto3"; */
+  /** syntax = "proto3"; or edition = "2023"; */
   public static final class SyntaxDecl extends Proto {
-    private final String version; // "proto2" or "proto3"
+    private final String version; // "proto2"/"proto3" for syntax, e.g. "2023" for edition
 
     public SyntaxDecl(int position, int endPosition, String version) {
       super(position, endPosition);

--- a/tests/protopc/src/test/scala/pc/ParserEdgeCasesSuite.scala
+++ b/tests/protopc/src/test/scala/pc/ParserEdgeCasesSuite.scala
@@ -1,5 +1,6 @@
 package pc
 
+import scala.meta.internal.proto.diag.ProtoError
 import scala.meta.internal.proto.diag.SourceFile
 import scala.meta.internal.proto.parse.Parser
 
@@ -17,6 +18,13 @@ class ParserEdgeCasesSuite extends FunSuite {
       val result = Parser.parse(source)
       // Just verify we can parse without exception
       assert(result != null, s"Parser returned null for: $name")
+    }
+  }
+
+  def parseError(name: String, code: String): Unit = {
+    test(name) {
+      val source = new SourceFile("test.proto", code)
+      intercept[ProtoError](Parser.parse(source))
     }
   }
 
@@ -156,6 +164,25 @@ class ParserEdgeCasesSuite extends FunSuite {
        |      "[hc4q8] [2023-01-10 19:12:58 +0000] [2] [INFO] Using worker: sync\n"
        |  ];
        |}
+       |""".stripMargin,
+  )
+
+  parseOk(
+    "edition-2023-basic",
+    """|edition = "2023";
+       |package devtools.skyframe;
+       |message FileInvalidationData {
+       |  string overflow_key = 1;
+       |  int64 parent_mtsv = 2;
+       |}
+       |""".stripMargin,
+  )
+
+  parseError(
+    "edition-then-syntax-is-duplicate-declaration",
+    """|edition = "2023";
+       |syntax = "proto3";
+       |message Foo {}
        |""".stripMargin,
   )
 }

--- a/tests/unit/src/test/scala/tests/mbt/ProtoGeneratedJavaFilesSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/ProtoGeneratedJavaFilesSuite.scala
@@ -1,8 +1,6 @@
 package tests.mbt
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.mbt.ProtoGeneratedJavaFiles
 import scala.meta.internal.metals.mbt.ProtoJavaVirtualFile
 import scala.meta.internal.metals.mbt.VirtualTextDocument
@@ -10,6 +8,7 @@ import scala.meta.io.AbsolutePath
 import scala.meta.pc
 
 import munit.AnyFixture
+import tests.MetalsTestEnrichments._
 
 class ProtoGeneratedJavaFilesSuite extends munit.FunSuite {
   val workspace = new tests.TemporaryDirectoryFixture()
@@ -19,8 +18,7 @@ class ProtoGeneratedJavaFilesSuite extends munit.FunSuite {
   private val className = "ClientProtos"
   private val content =
     """|package com.example.api.jproto;
-       |public final class ClientProtos {}
-       |""".stripMargin
+       |public final class ClientProtos {}""".stripMargin
 
   private def protoPath: AbsolutePath = workspace().resolve(protoRelative)
 
@@ -33,15 +31,11 @@ class ProtoGeneratedJavaFilesSuite extends munit.FunSuite {
       Nil,
     )
 
-  private def readText(file: AbsolutePath): String =
-    new String(Files.readAllBytes(file.toNIO), StandardCharsets.UTF_8)
-
   test("regenerates-when-missing") {
     val file = ProtoGeneratedJavaFiles
       .materialize(workspace(), protoPath, className, content)
       .getOrElse(fail("expected the outline to be materialized"))
-    Files.delete(file.toNIO)
-    assert(!Files.exists(file.toNIO))
+    file.delete()
 
     ProtoGeneratedJavaFiles.regenerateIfMissing(
       workspace(),
@@ -50,8 +44,8 @@ class ProtoGeneratedJavaFilesSuite extends munit.FunSuite {
       Seq(outline(className, content)),
     )
 
-    assert(Files.exists(file.toNIO), "expected the outline to be regenerated")
-    assertEquals(readText(file), content)
+    assert(file.exists, "expected the outline to be regenerated")
+    assertEquals(file.text, content)
   }
 
   test("no-op-when-present") {
@@ -67,14 +61,14 @@ class ProtoGeneratedJavaFilesSuite extends munit.FunSuite {
       fail("outlines should not be evaluated when the file exists"),
     )
 
-    assertEquals(readText(file), content)
+    assertEquals(file.text, content)
   }
 
   test("matches-outline-by-class-name") {
     val file = ProtoGeneratedJavaFiles
       .materialize(workspace(), protoPath, className, content)
       .getOrElse(fail("expected the outline to be materialized"))
-    Files.delete(file.toNIO)
+    file.delete()
 
     ProtoGeneratedJavaFiles.regenerateIfMissing(
       workspace(),
@@ -86,6 +80,6 @@ class ProtoGeneratedJavaFilesSuite extends munit.FunSuite {
       ),
     )
 
-    assertEquals(readText(file), content)
+    assertEquals(file.text, content)
   }
 }

--- a/tests/unit/src/test/scala/tests/mbt/ProtoGeneratedJavaFilesSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/ProtoGeneratedJavaFilesSuite.scala
@@ -1,0 +1,91 @@
+package tests.mbt
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import scala.meta.internal.metals.mbt.ProtoGeneratedJavaFiles
+import scala.meta.internal.metals.mbt.ProtoJavaVirtualFile
+import scala.meta.internal.metals.mbt.VirtualTextDocument
+import scala.meta.io.AbsolutePath
+import scala.meta.pc
+
+import munit.AnyFixture
+
+class ProtoGeneratedJavaFilesSuite extends munit.FunSuite {
+  val workspace = new tests.TemporaryDirectoryFixture()
+  override def munitFixtures: Seq[AnyFixture[_]] = List(workspace)
+
+  private val protoRelative = "a/src/main/proto/client.proto"
+  private val className = "ClientProtos"
+  private val content =
+    """|package com.example.api.jproto;
+       |public final class ClientProtos {}
+       |""".stripMargin
+
+  private def protoPath: AbsolutePath = workspace().resolve(protoRelative)
+
+  private def outline(name: String, text: String): VirtualTextDocument =
+    VirtualTextDocument(
+      ProtoJavaVirtualFile.makeUri(protoPath, name),
+      pc.Language.JAVA,
+      text,
+      Seq("com/example/api/jproto"),
+      Nil,
+    )
+
+  private def readText(file: AbsolutePath): String =
+    new String(Files.readAllBytes(file.toNIO), StandardCharsets.UTF_8)
+
+  test("regenerates-when-missing") {
+    val file = ProtoGeneratedJavaFiles
+      .materialize(workspace(), protoPath, className, content)
+      .getOrElse(fail("expected the outline to be materialized"))
+    Files.delete(file.toNIO)
+    assert(!Files.exists(file.toNIO))
+
+    ProtoGeneratedJavaFiles.regenerateIfMissing(
+      workspace(),
+      file,
+      protoPath,
+      Seq(outline(className, content)),
+    )
+
+    assert(Files.exists(file.toNIO), "expected the outline to be regenerated")
+    assertEquals(readText(file), content)
+  }
+
+  test("no-op-when-present") {
+    val file = ProtoGeneratedJavaFiles
+      .materialize(workspace(), protoPath, className, content)
+      .getOrElse(fail("expected the outline to be materialized"))
+
+    // The outlines thunk must not be evaluated when the file already exists.
+    ProtoGeneratedJavaFiles.regenerateIfMissing(
+      workspace(),
+      file,
+      protoPath,
+      fail("outlines should not be evaluated when the file exists"),
+    )
+
+    assertEquals(readText(file), content)
+  }
+
+  test("matches-outline-by-class-name") {
+    val file = ProtoGeneratedJavaFiles
+      .materialize(workspace(), protoPath, className, content)
+      .getOrElse(fail("expected the outline to be materialized"))
+    Files.delete(file.toNIO)
+
+    ProtoGeneratedJavaFiles.regenerateIfMissing(
+      workspace(),
+      file,
+      protoPath,
+      Seq(
+        outline("Session", "package com.example.api.jproto; class Session {}"),
+        outline(className, content),
+      ),
+    )
+
+    assertEquals(readText(file), content)
+  }
+}

--- a/tests/unit/src/test/scala/tests/p/ProtoPCJavaSuite.scala
+++ b/tests/unit/src/test/scala/tests/p/ProtoPCJavaSuite.scala
@@ -1478,22 +1478,17 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didOpen("a/src/main/java/com/example/Client.java")
       _ <- server.didFocus("a/src/main/java/com/example/Client.java")
       _ = assertNoDiagnostics()
-      locations <- server.definitionSubstringQuery(
+      _ <- server.assertDefinition(
         "a/src/main/java/com/example/Client.java",
         "public void auth(ClientProtos.Authentic@@ation auth) {}",
-      )
-      uris = locations.map(_.getUri())
-      _ = assert(
-        uris.exists(
-          _.endsWith(
-            ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java"
-          )
-        ),
-        s"expected a generated-outline location, got:\n${uris.mkString("\n")}",
-      )
-      _ = assert(
-        uris.exists(_.endsWith("a/src/main/proto/client.proto")),
-        s"expected the proto location, got:\n${uris.mkString("\n")}",
+        """|.metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java:LINE:COLUMN: definition
+           |  public static final class Authentication extends com.google.protobuf.GeneratedMessageV3 implements AuthenticationOrBuilder {
+           |                            ^^^^^^^^^^^^^^
+           |a/src/main/proto/client.proto:LINE:COLUMN: definition
+           |message Authentication {
+           |        ^^^^^^^^^^^^^^
+           |""".stripMargin,
+        redactLineNumbers = true,
       )
     } yield ()
   }
@@ -1526,22 +1521,17 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didOpen("a/src/main/java/com/example/Client.java")
       _ <- server.didFocus("a/src/main/java/com/example/Client.java")
       _ = assertNoDiagnostics()
-      locations <- server.definitionSubstringQuery(
+      _ <- server.assertDefinition(
         "a/src/main/java/com/example/Client.java",
         "public void auth(Authentic@@ation auth) {}",
-      )
-      uris = locations.map(_.getUri())
-      _ = assert(
-        uris.exists(
-          _.endsWith(
-            ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/Authentication.java"
-          )
-        ),
-        s"expected a generated-outline location, got:\n${uris.mkString("\n")}",
-      )
-      _ = assert(
-        uris.exists(_.endsWith("a/src/main/proto/client.proto")),
-        s"expected the proto location, got:\n${uris.mkString("\n")}",
+        """|.metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/Authentication.java:LINE:COLUMN: definition
+           |public final class Authentication extends com.google.protobuf.GeneratedMessageV3 implements AuthenticationOrBuilder {
+           |                   ^^^^^^^^^^^^^^
+           |a/src/main/proto/client.proto:LINE:COLUMN: definition
+           |message Authentication {
+           |        ^^^^^^^^^^^^^^
+           |""".stripMargin,
+        redactLineNumbers = true,
       )
     } yield ()
   }
@@ -1587,33 +1577,32 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/Client.java")
       _ = assertNoDiagnostics()
       // Navigating to Session materializes its generated outline on disk.
-      locations <- server.definitionSubstringQuery(
+      _ <- server.assertDefinition(
         "a/src/main/java/com/example/Client.java",
         "public void open(Sess@@ion session) {}",
-      )
-      _ = assert(
-        locations.exists(_.getUri().endsWith(sessionOutline)),
-        s"expected the Session outline, got:\n${locations.map(_.getUri()).mkString("\n")}",
+        """|.metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/Session.java:LINE:COLUMN: definition
+           |public final class Session extends com.google.protobuf.GeneratedMessageV3 implements SessionOrBuilder {
+           |                   ^^^^^^^
+           |a/src/main/proto/client.proto:LINE:COLUMN: definition
+           |message Session {
+           |        ^^^^^^^
+           |""".stripMargin,
+        redactLineNumbers = true,
       )
       // Inside the materialized outline, goto-definition on the field type
       // Authentication resolves to its own outline and proto declaration.
       _ <- server.didOpen(sessionOutline)
-      innerLocations <- server.definitionSubstringQuery(
+      _ <- server.assertDefinition(
         sessionOutline,
         "Authentic@@ation getAuth()",
-      )
-      innerUris = innerLocations.map(_.getUri())
-      _ = assert(
-        innerUris.exists(
-          _.endsWith(
-            ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/Authentication.java"
-          )
-        ),
-        s"expected the Authentication outline, got:\n${innerUris.mkString("\n")}",
-      )
-      _ = assert(
-        innerUris.exists(_.endsWith("a/src/main/proto/client.proto")),
-        s"expected the proto location, got:\n${innerUris.mkString("\n")}",
+        """|.metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/Authentication.java:LINE:COLUMN: definition
+           |public final class Authentication extends com.google.protobuf.GeneratedMessageV3 implements AuthenticationOrBuilder {
+           |                   ^^^^^^^^^^^^^^
+           |a/src/main/proto/client.proto:LINE:COLUMN: definition
+           |message Authentication {
+           |        ^^^^^^^^^^^^^^
+           |""".stripMargin,
+        redactLineNumbers = true,
       )
       // The jump recorded the origin's build target for the materialized file
       // (InteractiveSemanticdbs.didDefinition), so its presentation compiler
@@ -1666,25 +1655,29 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/Client.java")
       _ = assertNoDiagnostics()
       // Navigating to Session materializes the outer-class outline on disk.
-      locations <- server.definitionSubstringQuery(
+      _ <- server.assertDefinition(
         "a/src/main/java/com/example/Client.java",
         "public void open(ClientProtos.Sess@@ion session) {}",
-      )
-      _ = assert(
-        locations.exists(_.getUri().endsWith(outline)),
-        s"expected the ClientProtos outline, got:\n${locations.map(_.getUri()).mkString("\n")}",
+        """|.metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java:LINE:COLUMN: definition
+           |  public static final class Session extends com.google.protobuf.GeneratedMessageV3 implements SessionOrBuilder {
+           |                            ^^^^^^^
+           |a/src/main/proto/client.proto:LINE:COLUMN: definition
+           |message Session {
+           |        ^^^^^^^
+           |""".stripMargin,
+        redactLineNumbers = true,
       )
       // Inside the materialized outline, goto-definition on the sibling nested
       // type Authentication resolves.
       _ <- server.didOpen(outline)
-      innerLocations <- server.definitionSubstringQuery(
+      _ <- server.assertDefinition(
         outline,
         "Authentic@@ation getAuth()",
-      )
-      innerUris = innerLocations.map(_.getUri())
-      _ = assert(
-        innerUris.nonEmpty,
-        "expected goto-definition inside the outline to resolve, got no locations",
+        """|.metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java:LINE:COLUMN: definition
+           |  public static final class Authentication extends com.google.protobuf.GeneratedMessageV3 implements AuthenticationOrBuilder {
+           |                            ^^^^^^^^^^^^^^
+           |""".stripMargin,
+        redactLineNumbers = true,
       )
     } yield ()
   }
@@ -1698,8 +1691,14 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java"
     val source = "a/src/main/java/com/example/Client.java"
     val query = "public void open(ClientProtos.Sess@@ion session) {}"
-    def outlineLocation(locations: List[Location]) =
-      locations.find(_.getUri().endsWith(outline))
+    val expectedLocations =
+      """|.metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java:LINE:COLUMN: definition
+         |  public static final class Session extends com.google.protobuf.GeneratedMessageV3 implements SessionOrBuilder {
+         |                            ^^^^^^^
+         |a/src/main/proto/client.proto:LINE:COLUMN: definition
+         |message Session {
+         |        ^^^^^^^
+         |""".stripMargin
     for {
       _ <- initialize(
         """|/metals.json
@@ -1728,11 +1727,11 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus(source)
       _ = assertNoDiagnostics()
       // First navigation materializes the outline on disk.
-      first <- server.definitionSubstringQuery(source, query)
-      firstOutline = outlineLocation(first)
-      _ = assert(
-        firstOutline.isDefined,
-        s"expected a generated-outline location, got:\n${first.map(_.getUri()).mkString("\n")}",
+      _ <- server.assertDefinition(
+        source,
+        query,
+        expectedLocations,
+        redactLineNumbers = true,
       )
       outlinePath = server.toPath(outline)
       // Delete the materialized outline behind Metals' back.
@@ -1742,14 +1741,15 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
         "expected the outline to be deleted",
       )
       // Navigating again must regenerate it instead of returning a dead target.
-      second <- server.definitionSubstringQuery(source, query)
+      _ <- server.assertDefinition(
+        source,
+        query,
+        expectedLocations,
+        redactLineNumbers = true,
+      )
       _ = assert(
         Files.exists(outlinePath.toNIO),
         "expected the deleted outline to be regenerated",
-      )
-      _ = assert(
-        outlineLocation(second).isDefined,
-        s"expected the regenerated outline location, got:\n${second.map(_.getUri()).mkString("\n")}",
       )
     } yield ()
   }
@@ -1820,6 +1820,131 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ = assert(
         completions.contains("getToken"),
         s"expected getToken in completions:\n$completions",
+      )
+    } yield ()
+  }
+
+  // Builder setters for message-type fields are generated as overloads
+  // sharing one name (`setToken(Token)` / `setToken(Token.Builder)`);
+  // goto-definition on each call site must resolve to its own overload.
+  test("java-navigates-to-overloaded-builder-setter") {
+    cleanWorkspace()
+    val outline =
+      ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java"
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/client.proto
+           |syntax = "proto3";
+           |package com.example.api;
+           |option java_package = "com.example.api.jproto";
+           |option java_outer_classname = "ClientProtos";
+           |message Token {
+           |  string value = 1;
+           |}
+           |message Session {
+           |  Token token = 1;
+           |}
+           |/a/src/main/java/com/example/Client.java
+           |package com.example;
+           |import com.example.api.jproto.ClientProtos;
+           |public class Client {
+           |  ClientProtos.Session withValue(ClientProtos.Token token) {
+           |    return ClientProtos.Session.newBuilder().setToken(token).build();
+           |  }
+           |  ClientProtos.Session withBuilder() {
+           |    return ClientProtos.Session.newBuilder()
+           |      .setToken(ClientProtos.Token.newBuilder())
+           |      .build();
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/Client.java")
+      _ <- server.didFocus("a/src/main/java/com/example/Client.java")
+      _ = assertNoDiagnostics()
+      _ <- server.assertDefinition(
+        "a/src/main/java/com/example/Client.java",
+        ".setTo@@ken(token)",
+        s"""|$outline:LINE:COLUMN: definition
+            |      public Builder setToken(Token value) {
+            |                     ^^^^^^^^
+            |""".stripMargin,
+        redactLineNumbers = true,
+        includeLocation = _.getUri().endsWith(outline),
+      )
+      _ <- server.assertDefinition(
+        "a/src/main/java/com/example/Client.java",
+        ".setTo@@ken(ClientProtos.Token.newBuilder())",
+        s"""|$outline:LINE:COLUMN: definition
+            |      public Builder setToken(Token.Builder builderForValue) {
+            |                     ^^^^^^^^
+            |""".stripMargin,
+        redactLineNumbers = true,
+        includeLocation = _.getUri().endsWith(outline),
+      )
+    } yield ()
+  }
+
+  test("java-navigates-to-overloaded-repeated-field-adder") {
+    cleanWorkspace()
+    val outline =
+      ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java"
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/client.proto
+           |syntax = "proto3";
+           |package com.example.api;
+           |option java_package = "com.example.api.jproto";
+           |option java_outer_classname = "ClientProtos";
+           |message Token {
+           |  string value = 1;
+           |}
+           |message Session {
+           |  repeated Token tokens = 1;
+           |}
+           |/a/src/main/java/com/example/Client.java
+           |package com.example;
+           |import com.example.api.jproto.ClientProtos;
+           |public class Client {
+           |  ClientProtos.Session withValue(ClientProtos.Token token) {
+           |    return ClientProtos.Session.newBuilder().addTokens(token).build();
+           |  }
+           |  ClientProtos.Session withBuilder() {
+           |    return ClientProtos.Session.newBuilder()
+           |      .addTokens(ClientProtos.Token.newBuilder())
+           |      .build();
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/Client.java")
+      _ <- server.didFocus("a/src/main/java/com/example/Client.java")
+      _ = assertNoDiagnostics()
+      _ <- server.assertDefinition(
+        "a/src/main/java/com/example/Client.java",
+        ".addTok@@ens(token)",
+        s"""|$outline:LINE:COLUMN: definition
+            |      public Builder addTokens(Token value) {
+            |                     ^^^^^^^^^
+            |""".stripMargin,
+        redactLineNumbers = true,
+        includeLocation = _.getUri().endsWith(outline),
+      )
+      _ <- server.assertDefinition(
+        "a/src/main/java/com/example/Client.java",
+        ".addTok@@ens(ClientProtos.Token.newBuilder())",
+        s"""|$outline:LINE:COLUMN: definition
+            |      public Builder addTokens(Token.Builder builderForValue) {
+            |                     ^^^^^^^^^
+            |""".stripMargin,
+        redactLineNumbers = true,
+        includeLocation = _.getUri().endsWith(outline),
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/p/ProtoPCJavaSuite.scala
+++ b/tests/unit/src/test/scala/tests/p/ProtoPCJavaSuite.scala
@@ -1,5 +1,12 @@
 package tests.p
 
+import java.nio.file.Files
+
+import scala.concurrent.Future
+
+import org.eclipse.lsp4j.Location
+import tests.BuildInfoVersions
+
 /**
  * Tests for Java-to-proto code navigation.
  *
@@ -7,6 +14,22 @@ package tests.p
  * navigate to the original proto file definitions.
  */
 class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
+
+  // Goto-definition on a proto-generated Java symbol now also returns the
+  // synthesized Java outline; these tests assert the proto declaration only,
+  // so they filter to the `.proto` location. Navigation to the generated
+  // outline is covered by the `java-navigates-to-generated-outline` tests.
+  private def assertProtoDefinition(
+      filename: String,
+      query: String,
+      expected: String,
+  )(implicit loc: munit.Location): Future[List[Location]] =
+    server.assertDefinition(
+      filename,
+      query,
+      expected,
+      includeLocation = _.getUri().endsWith(".proto"),
+    )
 
   // Test multiple messages from the same proto file in the same package
   test("java-imports-multiple-proto-messages") {
@@ -42,7 +65,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       // No "package does not exist" diagnostic for proto-generated Java package
       _ = assertNoDiagnostics()
       // Navigate from Authentication import in Java to its definition in client.proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Client.java",
         "import com.example.api.jproto.Authentic@@ation;",
         """|a/src/main/proto/client.proto:5:9: definition
@@ -51,7 +74,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from Authorization import in Java to its definition in client.proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Client.java",
         "import com.example.api.jproto.Authoriz@@ation;",
         """|a/src/main/proto/client.proto:9:9: definition
@@ -92,7 +115,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       // No "package does not exist" diagnostic for enum import package
       _ = assertNoDiagnostics()
       // Navigate from Status import in Java to enum definition in status.proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Service.java",
         "import com.example.api.jproto.Sta@@tus;",
         """|a/src/main/proto/status.proto:5:6: definition
@@ -101,7 +124,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from return type Status to enum definition in status.proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Service.java",
         "public Sta@@tus getStatus() { return null; }",
         """|a/src/main/proto/status.proto:5:6: definition
@@ -143,7 +166,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       // No diagnostics for import of generated outer message class
       _ = assertNoDiagnostics()
       // Navigate from Container import in Java to message definition in nested.proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Handler.java",
         "import com.example.api.jproto.Contai@@ner;",
         """|a/src/main/proto/nested.proto:5:9: definition
@@ -152,7 +175,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from method parameter type Container to proto definition
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Handler.java",
         "public void handle(Contai@@ner container) {}",
         """|a/src/main/proto/nested.proto:5:9: definition
@@ -190,7 +213,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/api/Consumer.java")
       _ = assertNoDiagnostics()
       // Navigate from unqualified Java type to proto message via package fallback
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/api/Consumer.java",
         "public void consume(SimpleMess@@age msg) {}",
         """|a/src/main/proto/simple.proto:4:9: definition
@@ -239,7 +262,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       // All three imports should resolve to the same proto file
       _ <- server.didFocus("a/src/main/java/com/example/Api.java")
       _ = assertNoDiagnostics()
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Api.java",
         "import com.example.api.jproto.Requ@@est;",
         """|a/src/main/proto/multi.proto:5:9: definition
@@ -247,7 +270,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |        ^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Api.java",
         "import com.example.api.jproto.Respo@@nse;",
         """|a/src/main/proto/multi.proto:8:9: definition
@@ -255,7 +278,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |        ^^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/Api.java",
         "import com.example.api.jproto.ErrorCo@@de;",
         """|a/src/main/proto/multi.proto:11:6: definition
@@ -306,7 +329,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/UserBuilder.java")
       _ = assertNoDiagnostics()
       // Navigate from setName to the name field in proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/UserBuilder.java",
         ".setNa@@me(\"Alice\")",
         """|a/src/main/proto/user.proto:6:10: definition
@@ -315,7 +338,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from setAge to the age field in proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/UserBuilder.java",
         ".setA@@ge(30)",
         """|a/src/main/proto/user.proto:7:9: definition
@@ -367,7 +390,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/ContextBuilder.java")
       _ = assertNoDiagnostics()
       // Navigate from setAuthorizingPrincipal to authorizing_principal field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ContextBuilder.java",
         ".setAuthorizingPrinci@@pal(",
         """|a/src/main/proto/principal.proto:10:13: definition
@@ -376,7 +399,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from setId on nested builder to id field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ContextBuilder.java",
         ".setI@@d(123L)",
         """|a/src/main/proto/principal.proto:6:9: definition
@@ -422,7 +445,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/PersonReader.java")
       _ = assertNoDiagnostics()
       // Navigate from getFirstName to first_name field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/PersonReader.java",
         "p.getFirstNa@@me()",
         """|a/src/main/proto/person.proto:6:10: definition
@@ -431,7 +454,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from getLastName to last_name field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/PersonReader.java",
         "p.getLastNa@@me()",
         """|a/src/main/proto/person.proto:7:10: definition
@@ -484,7 +507,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/OrderHandler.java")
       _ = assertNoDiagnostics()
       // Navigate from addItems to items field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/OrderHandler.java",
         ".addIte@@ms(\"apple\")",
         """|a/src/main/proto/order.proto:6:19: definition
@@ -493,7 +516,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from getItemsList to items field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/OrderHandler.java",
         "o.getItemsLi@@st()",
         """|a/src/main/proto/order.proto:6:19: definition
@@ -502,7 +525,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from getItemsCount to items field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/OrderHandler.java",
         "o.getItemsCou@@nt()",
         """|a/src/main/proto/order.proto:6:19: definition
@@ -554,7 +577,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/ConfigHandler.java")
       _ = assertNoDiagnostics()
       // Navigate from putProperties to properties field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ConfigHandler.java",
         ".putProperti@@es(\"key\", \"value\")",
         """|a/src/main/proto/config.proto:6:23: definition
@@ -563,7 +586,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from getPropertiesMap to properties field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ConfigHandler.java",
         "c.getPropertiesMa@@p()",
         """|a/src/main/proto/config.proto:6:23: definition
@@ -572,7 +595,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from containsProperties to properties field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ConfigHandler.java",
         "c.containsProperti@@es(key)",
         """|a/src/main/proto/config.proto:6:23: definition
@@ -619,7 +642,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/StatusChecker.java")
       _ = assertNoDiagnostics()
       // Navigate from Status.PENDING to PENDING enum value
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/StatusChecker.java",
         "Status.PENDI@@NG",
         """|a/src/main/proto/status.proto:7:3: definition
@@ -628,7 +651,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from Status.APPROVED to APPROVED enum value
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/StatusChecker.java",
         "Status.APPROV@@ED",
         """|a/src/main/proto/status.proto:8:3: definition
@@ -679,7 +702,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/ContactHandler.java")
       _ = assertNoDiagnostics()
       // Navigate from hasEmail to email field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ContactHandler.java",
         "c.hasEma@@il()",
         """|a/src/main/proto/optional.proto:9:19: definition
@@ -688,7 +711,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from hasAddress to address field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ContactHandler.java",
         "c.hasAddre@@ss()",
         """|a/src/main/proto/optional.proto:10:11: definition
@@ -697,7 +720,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from clearEmail to email field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/ContactHandler.java",
         ".clearEma@@il()",
         """|a/src/main/proto/optional.proto:9:19: definition
@@ -749,7 +772,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/EchoClient.java")
       _ = assertNoDiagnostics()
       // setMessage on EchoRequest.Builder should go to EchoRequest.message
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/EchoClient.java",
         "EchoRequest.newBuilder().setMess@@age(text)",
         """|a/src/main/proto/echo.proto:9:19: definition
@@ -758,7 +781,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // setMessage on ForwardDelayedEchoRequest.Builder should go to ForwardDelayedEchoRequest.message
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/EchoClient.java",
         "ForwardDelayedEchoRequest.newBuilder().setMess@@age(text)",
         """|a/src/main/proto/echo.proto:6:19: definition
@@ -816,7 +839,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/EventHandler.java")
       _ = assertNoDiagnostics()
       // Navigate from hasTextPayload to text_payload field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/EventHandler.java",
         "e.hasTextPaylo@@ad()",
         """|a/src/main/proto/event.proto:8:12: definition
@@ -825,7 +848,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from getTextPayload to text_payload field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/EventHandler.java",
         "e.getTextPaylo@@ad()",
         """|a/src/main/proto/event.proto:8:12: definition
@@ -834,7 +857,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Navigate from setTextPayload to text_payload field
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/EventHandler.java",
         ".setTextPaylo@@ad(text)",
         """|a/src/main/proto/event.proto:8:12: definition
@@ -939,7 +962,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/AllFieldTypes.java")
       _ = assertNoDiagnostics()
       // -- scalar (line 13) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getTitl@@e()",
         """|a/src/main/proto/comprehensive.proto:13:10: definition
@@ -947,7 +970,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |         ^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.setTitl@@e(\"x\")",
         """|a/src/main/proto/comprehensive.proto:13:10: definition
@@ -955,7 +978,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |         ^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.clearTitl@@e()",
         """|a/src/main/proto/comprehensive.proto:13:10: definition
@@ -964,7 +987,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- message field (line 15) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getAddre@@ss()",
         """|a/src/main/proto/comprehensive.proto:15:11: definition
@@ -972,7 +995,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |          ^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.hasAddre@@ss()",
         """|a/src/main/proto/comprehensive.proto:15:11: definition
@@ -980,7 +1003,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |          ^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.setAddre@@ss(",
         """|a/src/main/proto/comprehensive.proto:15:11: definition
@@ -989,7 +1012,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- repeated scalar (line 17) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getTagsLi@@st()",
         """|a/src/main/proto/comprehensive.proto:17:19: definition
@@ -997,7 +1020,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                  ^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getTagsCou@@nt()",
         """|a/src/main/proto/comprehensive.proto:17:19: definition
@@ -1005,7 +1028,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                  ^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.addTa@@gs(\"t\")",
         """|a/src/main/proto/comprehensive.proto:17:19: definition
@@ -1014,7 +1037,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- repeated message (line 19) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getItemsLi@@st()",
         """|a/src/main/proto/comprehensive.proto:19:17: definition
@@ -1022,7 +1045,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                ^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.addIte@@ms(",
         """|a/src/main/proto/comprehensive.proto:19:17: definition
@@ -1031,7 +1054,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- map (line 21) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getCountsMa@@p()",
         """|a/src/main/proto/comprehensive.proto:21:22: definition
@@ -1039,7 +1062,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                     ^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.containsCoun@@ts(k)",
         """|a/src/main/proto/comprehensive.proto:21:22: definition
@@ -1047,7 +1070,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                     ^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.putCoun@@ts(\"k\",1)",
         """|a/src/main/proto/comprehensive.proto:21:22: definition
@@ -1056,7 +1079,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- oneof scalar (line 24, PLAT-154011) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getTextPaylo@@ad()",
         """|a/src/main/proto/comprehensive.proto:24:12: definition
@@ -1064,7 +1087,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |           ^^^^^^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.hasTextPaylo@@ad()",
         """|a/src/main/proto/comprehensive.proto:24:12: definition
@@ -1072,7 +1095,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |           ^^^^^^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.setTextPaylo@@ad(\"t\")",
         """|a/src/main/proto/comprehensive.proto:24:12: definition
@@ -1081,7 +1104,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- oneof message (line 25, PLAT-154011) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getLocationPaylo@@ad()",
         """|a/src/main/proto/comprehensive.proto:25:13: definition
@@ -1089,7 +1112,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |            ^^^^^^^^^^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.hasLocationPaylo@@ad()",
         """|a/src/main/proto/comprehensive.proto:25:13: definition
@@ -1097,7 +1120,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |            ^^^^^^^^^^^^^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.setLocationPaylo@@ad(",
         """|a/src/main/proto/comprehensive.proto:25:13: definition
@@ -1106,7 +1129,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // -- optional (line 28) --
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.getNot@@e()",
         """|a/src/main/proto/comprehensive.proto:28:19: definition
@@ -1114,7 +1137,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                  ^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "m.hasNot@@e()",
         """|a/src/main/proto/comprehensive.proto:28:19: definition
@@ -1122,7 +1145,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |                  ^^^^
            |""".stripMargin,
       )
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/AllFieldTypes.java",
         "b.setNot@@e(\"n\")",
         """|a/src/main/proto/comprehensive.proto:28:19: definition
@@ -1176,7 +1199,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/GreeterService.java")
       _ = assertNoDiagnostics()
       // Navigate from the GreeterGrpc import to the Greeter service in the proto
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/GreeterService.java",
         "import com.example.api.jproto.GreeterGr@@pc;",
         """|a/src/main/proto/greeter.proto:11:9: definition
@@ -1185,7 +1208,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
            |""".stripMargin,
       )
       // Also navigate from GreeterGrpc used as a qualifier in a method body
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/GreeterService.java",
         "return GreeterGr@@pc.class;",
         """|a/src/main/proto/greeter.proto:11:9: definition
@@ -1280,7 +1303,7 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       _ <- server.didFocus("a/src/main/java/com/example/GreeterClient.java")
       _ = assertNoDiagnostics()
       // Navigate from stub.sayHello to rpc SayHello definition (line 12 is 0-based, so line 13 in 1-based)
-      _ <- server.assertDefinition(
+      _ <- assertProtoDefinition(
         "a/src/main/java/com/example/GreeterClient.java",
         "stub.sayHel@@lo(request)",
         """|a/src/main/proto/greeter.proto:12:7: definition
@@ -1424,4 +1447,381 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       )
     } yield ()
   }
+
+  // Goto-definition on a proto-generated class navigates to the Java source
+  // that Metals synthesizes from the proto file (materialized read-only under
+  // .metals/readonly), alongside the proto declaration. This needs no build
+  // output and no configuration.
+  test("java-navigates-to-generated-outline") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/client.proto
+           |syntax = "proto3";
+           |package com.example.api;
+           |option java_package = "com.example.api.jproto";
+           |option java_outer_classname = "ClientProtos";
+           |message Authentication {
+           |  string token = 1;
+           |}
+           |/a/src/main/java/com/example/Client.java
+           |package com.example;
+           |import com.example.api.jproto.ClientProtos;
+           |public class Client {
+           |  public void auth(ClientProtos.Authentication auth) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/Client.java")
+      _ <- server.didFocus("a/src/main/java/com/example/Client.java")
+      _ = assertNoDiagnostics()
+      locations <- server.definitionSubstringQuery(
+        "a/src/main/java/com/example/Client.java",
+        "public void auth(ClientProtos.Authentic@@ation auth) {}",
+      )
+      uris = locations.map(_.getUri())
+      _ = assert(
+        uris.exists(
+          _.endsWith(
+            ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java"
+          )
+        ),
+        s"expected a generated-outline location, got:\n${uris.mkString("\n")}",
+      )
+      _ = assert(
+        uris.exists(_.endsWith("a/src/main/proto/client.proto")),
+        s"expected the proto location, got:\n${uris.mkString("\n")}",
+      )
+    } yield ()
+  }
+
+  // Same as above but the proto declares no java_package option (proto package
+  // equals the generated Java package, java_multiple_files), so the class is
+  // generated as a top-level Java file rather than nested in an outer class.
+  test("java-navigates-to-generated-outline-without-java-package-option") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/client.proto
+           |syntax = "proto3";
+           |package com.example.api.jproto;
+           |option java_multiple_files = true;
+           |message Authentication {
+           |  string token = 1;
+           |}
+           |/a/src/main/java/com/example/Client.java
+           |package com.example;
+           |import com.example.api.jproto.Authentication;
+           |public class Client {
+           |  public void auth(Authentication auth) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/Client.java")
+      _ <- server.didFocus("a/src/main/java/com/example/Client.java")
+      _ = assertNoDiagnostics()
+      locations <- server.definitionSubstringQuery(
+        "a/src/main/java/com/example/Client.java",
+        "public void auth(Authentic@@ation auth) {}",
+      )
+      uris = locations.map(_.getUri())
+      _ = assert(
+        uris.exists(
+          _.endsWith(
+            ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/Authentication.java"
+          )
+        ),
+        s"expected a generated-outline location, got:\n${uris.mkString("\n")}",
+      )
+      _ = assert(
+        uris.exists(_.endsWith("a/src/main/proto/client.proto")),
+        s"expected the proto location, got:\n${uris.mkString("\n")}",
+      )
+    } yield ()
+  }
+
+  // Code navigation works inside a materialized generated-outline file: the
+  // file belongs to no build target, so it is routed to the build target that
+  // owns the proto it was generated from.
+  test("java-navigates-within-generated-outline") {
+    cleanWorkspace()
+    val sessionOutline =
+      ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/Session.java"
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {
+            |    "libraryDependencies": [
+            |      "com.google.protobuf:protobuf-java:${BuildInfoVersions.protobufVersion}"
+            |    ]
+            |  }
+            |}
+            |/a/src/main/proto/client.proto
+            |syntax = "proto3";
+            |package com.example.api;
+            |option java_package = "com.example.api.jproto";
+            |option java_multiple_files = true;
+            |message Authentication {
+            |  string token = 1;
+            |}
+            |message Session {
+            |  Authentication auth = 1;
+            |}
+            |/a/src/main/java/com/example/Client.java
+            |package com.example;
+            |import com.example.api.jproto.Session;
+            |public class Client {
+            |  public void open(Session session) {}
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/Client.java")
+      _ <- server.didFocus("a/src/main/java/com/example/Client.java")
+      _ = assertNoDiagnostics()
+      // Navigating to Session materializes its generated outline on disk.
+      locations <- server.definitionSubstringQuery(
+        "a/src/main/java/com/example/Client.java",
+        "public void open(Sess@@ion session) {}",
+      )
+      _ = assert(
+        locations.exists(_.getUri().endsWith(sessionOutline)),
+        s"expected the Session outline, got:\n${locations.map(_.getUri()).mkString("\n")}",
+      )
+      // Inside the materialized outline, goto-definition on the field type
+      // Authentication resolves to its own outline and proto declaration.
+      _ <- server.didOpen(sessionOutline)
+      innerLocations <- server.definitionSubstringQuery(
+        sessionOutline,
+        "Authentic@@ation getAuth()",
+      )
+      innerUris = innerLocations.map(_.getUri())
+      _ = assert(
+        innerUris.exists(
+          _.endsWith(
+            ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/Authentication.java"
+          )
+        ),
+        s"expected the Authentication outline, got:\n${innerUris.mkString("\n")}",
+      )
+      _ = assert(
+        innerUris.exists(_.endsWith("a/src/main/proto/client.proto")),
+        s"expected the proto location, got:\n${innerUris.mkString("\n")}",
+      )
+      // The jump recorded the origin's build target for the materialized file
+      // (InteractiveSemanticdbs.didDefinition), so its presentation compiler
+      // has the origin's classpath and resolves the protobuf runtime too.
+      runtimeLocations <- server.definitionSubstringQuery(
+        sessionOutline,
+        "extends com.google.protobuf.GeneratedMessag@@eV3",
+      )
+      _ = assert(
+        runtimeLocations.exists(
+          _.getUri().contains("protobuf-java")
+        ),
+        s"expected GeneratedMessageV3 to resolve into protobuf-java, got:\n${runtimeLocations.map(_.getUri()).mkString("\n")}",
+      )
+    } yield ()
+  }
+
+  // Same as above but with the outer-class layout (no java_multiple_files),
+  // all messages are nested in one generated file, so type references
+  // inside the materialized outline resolve within the same file.
+  test("java-navigates-within-generated-outline-outer-class") {
+    cleanWorkspace()
+    val outline =
+      ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java"
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/client.proto
+           |syntax = "proto3";
+           |package com.example.api;
+           |option java_package = "com.example.api.jproto";
+           |option java_outer_classname = "ClientProtos";
+           |message Authentication {
+           |  string token = 1;
+           |}
+           |message Session {
+           |  Authentication auth = 1;
+           |}
+           |/a/src/main/java/com/example/Client.java
+           |package com.example;
+           |import com.example.api.jproto.ClientProtos;
+           |public class Client {
+           |  public void open(ClientProtos.Session session) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/Client.java")
+      _ <- server.didFocus("a/src/main/java/com/example/Client.java")
+      _ = assertNoDiagnostics()
+      // Navigating to Session materializes the outer-class outline on disk.
+      locations <- server.definitionSubstringQuery(
+        "a/src/main/java/com/example/Client.java",
+        "public void open(ClientProtos.Sess@@ion session) {}",
+      )
+      _ = assert(
+        locations.exists(_.getUri().endsWith(outline)),
+        s"expected the ClientProtos outline, got:\n${locations.map(_.getUri()).mkString("\n")}",
+      )
+      // Inside the materialized outline, goto-definition on the sibling nested
+      // type Authentication resolves.
+      _ <- server.didOpen(outline)
+      innerLocations <- server.definitionSubstringQuery(
+        outline,
+        "Authentic@@ation getAuth()",
+      )
+      innerUris = innerLocations.map(_.getUri())
+      _ = assert(
+        innerUris.nonEmpty,
+        "expected goto-definition inside the outline to resolve, got no locations",
+      )
+    } yield ()
+  }
+
+  // The materialized outline may be deleted after it was first generated (a
+  // `.metals` clean, `git clean`, or an editor reload). Navigating to it again
+  // must recreate the file rather than land on a missing target.
+  test("java-regenerates-deleted-generated-outline") {
+    cleanWorkspace()
+    val outline =
+      ".metals/readonly/dependencies/proto-generated/a/src/main/proto/client.proto/ClientProtos.java"
+    val source = "a/src/main/java/com/example/Client.java"
+    val query = "public void open(ClientProtos.Sess@@ion session) {}"
+    def outlineLocation(locations: List[Location]) =
+      locations.find(_.getUri().endsWith(outline))
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/client.proto
+           |syntax = "proto3";
+           |package com.example.api;
+           |option java_package = "com.example.api.jproto";
+           |option java_outer_classname = "ClientProtos";
+           |message Authentication {
+           |  string token = 1;
+           |}
+           |message Session {
+           |  Authentication auth = 1;
+           |}
+           |/a/src/main/java/com/example/Client.java
+           |package com.example;
+           |import com.example.api.jproto.ClientProtos;
+           |public class Client {
+           |  public void open(ClientProtos.Session session) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen(source)
+      _ <- server.didFocus(source)
+      _ = assertNoDiagnostics()
+      // First navigation materializes the outline on disk.
+      first <- server.definitionSubstringQuery(source, query)
+      firstOutline = outlineLocation(first)
+      _ = assert(
+        firstOutline.isDefined,
+        s"expected a generated-outline location, got:\n${first.map(_.getUri()).mkString("\n")}",
+      )
+      outlinePath = server.toPath(outline)
+      // Delete the materialized outline behind Metals' back.
+      _ = Files.delete(outlinePath.toNIO)
+      _ = assert(
+        !Files.exists(outlinePath.toNIO),
+        "expected the outline to be deleted",
+      )
+      // Navigating again must regenerate it instead of returning a dead target.
+      second <- server.definitionSubstringQuery(source, query)
+      _ = assert(
+        Files.exists(outlinePath.toNIO),
+        "expected the deleted outline to be regenerated",
+      )
+      _ = assert(
+        outlineLocation(second).isDefined,
+        s"expected the regenerated outline location, got:\n${second.map(_.getUri()).mkString("\n")}",
+      )
+    } yield ()
+  }
+
+  // Hover and completion on a method whose return type is a proto-generated
+  // class, accessed transitively from another Java file.
+  test("java-transitive-proto-return-type") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/client.proto
+           |syntax = "proto3";
+           |package com.example.api;
+           |option java_package = "com.example.api.jproto";
+           |option java_multiple_files = true;
+           |message Authentication {
+           |  string token = 1;
+           |}
+           |/a/src/main/java/com/example/AuthProvider.java
+           |package com.example;
+           |import com.example.api.jproto.Authentication;
+           |public class AuthProvider {
+           |  public Authentication readAuthentication() { return null; }
+           |}
+           |/a/src/main/java/com/example/AuthConsumer.java
+           |package com.example;
+           |public class AuthConsumer {
+           |  void consume(AuthProvider provider) {
+           |    provider.readAuthentication();
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/client.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/AuthConsumer.java")
+      _ <- server.didFocus("a/src/main/java/com/example/AuthConsumer.java")
+      _ = assertNoDiagnostics()
+      _ <- server.assertHover(
+        "a/src/main/java/com/example/AuthConsumer.java",
+        """|package com.example;
+           |public class AuthConsumer {
+           |  void consume(AuthProvider provider) {
+           |    provider.readAuthenticat@@ion();
+           |  }
+           |}
+           |""".stripMargin,
+        """|```java
+           |public com.example.api.jproto.Authentication readAuthentication()
+           |```
+           |""".stripMargin,
+      )
+      _ <- server.didChange("a/src/main/java/com/example/AuthConsumer.java") {
+        _ =>
+          """|package com.example;
+             |public class AuthConsumer {
+             |  void consume(AuthProvider provider) {
+             |    provider.readAuthentication().
+             |  }
+             |}
+             |""".stripMargin
+      }
+      completions <- server.completion(
+        "a/src/main/java/com/example/AuthConsumer.java",
+        "provider.readAuthentication().@@",
+      )
+      _ = assert(
+        completions.contains("getToken"),
+        s"expected getToken in completions:\n$completions",
+      )
+    } yield ()
+  }
+
 }


### PR DESCRIPTION
Generate read-only Javas file from .proto files and materialize them under .metals/readonly, so go-to-definition on a proto-generated class (message, enum, gRPC stub) lands in the generated Java source alongside the .proto declaration. Route the materialized file to the proto's build target and feed the outlines through the turbine classpath so hover and completion resolve proto-generated types too.

# DEMO
An example based on issue #8651 - https://github.com/buildfarm/buildfarm
* go to persistentworkers/examples/src/test/java/adder/AdderTest.java
* hover over waitAndRead in line 44
* check the return type in the tooltip
* go to the definition of waitAndRead
* go to the definition of the return type (WorkResponse)

## Before
The return value of waitAndRead is treated as Object
The definition of WorkResponse points to the .proto file
https://github.com/user-attachments/assets/386ddd4f-db38-40dd-8505-c3904d62612d

## After
The return value of waitAndRead if a WorkResponse
The definition of WorkResponse points to both the .proto file and the generated Java file
https://github.com/user-attachments/assets/0853b964-c20b-4af9-a803-925dc6ff012f