### PR TITLE
Bazel-mbt: Make the imported genSources paths configuration independent and add logs 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
@@ -96,7 +96,12 @@ class CompilerConfiguration(
         uncheckedSources.partition(_.endsWith(".srcjar"))
       val genDirs = genDirStrs.map(workspace.resolve)
       val srcJars =
-        genSrcJarStrs.map(workspace.resolve).filter(p => p.exists && p.isFile)
+        genSrcJarStrs.map(workspace.resolve).filter { p =>
+          val ok = p.exists && p.isFile
+          if (!ok)
+            scribe.warn(s"mbt-v2: uncheckedSources srcjar does not exist: $p")
+          ok
+        }
       val dirFiles =
         GitVCS
           .lsFilesFromDirs(genDirs)

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/GitVCS.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/GitVCS.scala
@@ -187,7 +187,11 @@ object GitVCS {
                     )
                   }
                 } catch {
-                  case NonFatal(_) =>
+                  case NonFatal(e) =>
+                    scribe.warn(
+                      s"mbt-v2: failed to extract ${path.toNIO} from srcjar $srcJar",
+                      e,
+                    )
                 }
               }
             }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
@@ -286,7 +286,12 @@ final class MbtBuildServer(
       .flatMap(_.uncheckedSources)
       .filter(_.endsWith(".srcjar"))
       .map(workspace.resolve)
-      .filter(p => p.exists && p.isFile)
+      .filter { p =>
+        val ok = p.exists && p.isFile
+        if (!ok)
+          scribe.warn(s"mbt-v2: uncheckedSources srcjar does not exist: $p")
+        ok
+      }
     if (srcJars.nonEmpty)
       GitVCS.lsFilesFromSrcJars(srcJars, workspace, extractOnly = true)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -239,7 +239,12 @@ class MbtWorkspaceSymbolProvider(
       uncheckedSources.partition(_.endsWith(".srcjar"))
     val genDirs = genDirStrs.map(workspace.resolve)
     val srcJars =
-      genSrcJarStrs.map(workspace.resolve).filter(p => p.exists && p.isFile)
+      genSrcJarStrs.map(workspace.resolve).filter { p =>
+        val ok = p.exists && p.isFile
+        if (!ok)
+          scribe.warn(s"mbt-v2: uncheckedSources srcjar does not exist: $p")
+        ok
+      }
     val files = gitFiles ++ GitVCS.lsFilesFromDirs(genDirs) ++ GitVCS
       .lsFilesFromSrcJars(srcJars, workspace)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
@@ -440,7 +440,26 @@ abstract class BazelMbtImporter(
       val genPaths = srcs
         .filter(ruleLabels)
         .flatMap(outputsByGenLabel.getOrElse(_, Nil))
+      genPaths.foreach { genPath =>
+        if (!Files.exists(projectRoot.resolve(genPath).toNIO))
+          scribe.warn(
+            s"bazel-mbt: generated source output for target $target does not exist on disk: $genPath"
+          )
+      }
       Option.when(genPaths.nonEmpty)(target -> genPaths)
+    }
+
+  /**
+   * Reanchor `bazel-out/<mnemonic>/bin/<file>` directory paths to `bazel-bin/<file>`.
+   * That current configuration mnemonic can differ after changes to bazel config.
+   * `bazel-bin` convenience symlink points to whichever configuration was
+   * most recently built.
+   */
+  private def anchorUnderBazelBin(path: String): String =
+    path.split("/").toList match {
+      case "bazel-out" :: _ :: "bin" :: rest =>
+        ("bazel-bin" :: rest).mkString("/")
+      case _ => path
     }
 
   /** bazel cquery that returns output file paths grouped by label. */
@@ -465,7 +484,7 @@ abstract class BazelMbtImporter(
                 val label =
                   if (rawLabel.startsWith("@@//")) rawLabel.substring(2)
                   else rawLabel
-                Some(label -> paths.toList)
+                Some(label -> paths.map(anchorUnderBazelBin).toList)
               case _ =>
                 scribe.warn(
                   s"bazel-mbt: unexpected cquery starlark line: $line"


### PR DESCRIPTION
We got a report from a user about an issue with missing symbols from generated sources, that we are not able to reproduce ourselves. After investigating the mbt.json, the paths were there, which led me to wonder what the issue could be. 
In the project it might be beneficial to semi-frequently change the --config, leading to different bazel-out directories being used at different times. Even though these directories should not be cleaned without `bazel clean`, they won't be updated when users re-build the directory, and metals won't know when to ask for reimport (since we don't track .bazelrc.user etc.). We try to accommodate this here by anchoring to `bazel-bin`, which should be automatically bound by bazel to use the most current configuration mnemonic.

Since we don't know for sure whether this is the cause of the issue, we also add more logs to the related parts of metals.