### PR TITLE
bugfix: Remove the problematic type annotation

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/InlineValueProvider.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/InlineValueProvider.scala
@@ -54,7 +54,7 @@ trait InlineValueProvider {
       endOffset: Int,
       range: l.Range
   ): l.Range = {
-    val (startWithSpace, endWithSpace): (Int, Int) =
+    val (startWithSpace, endWithSpace) =
       extendRangeToIncludeWhiteCharsAndTheFollowingNewLine(
         text
       )(startOffset, endOffset)


### PR DESCRIPTION
They cause a warning and thus an error in the scala 3 presentation compiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified an internal type declaration without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->