### PR TITLE
chore: Update sbt 2 to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,12 +25,12 @@ def crossSetting[A](
     if211: List[A] = Nil,
     if213: List[A] = Nil,
     if3: List[A] = Nil,
-    if2: List[A] = Nil,
+    if212: List[A] = Nil,
 ): List[A] =
   CrossVersion.partialVersion(scalaVersion) match {
-    case partialVersion if isScala211(partialVersion) => if211 ::: if2
-    case partialVersion if isScala212(partialVersion) => if2
-    case partialVersion if isScala213(partialVersion) => if2 ::: if213
+    case partialVersion if isScala211(partialVersion) => if211 ::: if212
+    case partialVersion if isScala212(partialVersion) => if212
+    case partialVersion if isScala213(partialVersion) => if212 ::: if213
     case partialVersion if isScala3(partialVersion) => if3
     case _ => Nil
   }
@@ -226,7 +226,7 @@ val sharedSettings = sharedJavacOptions ++ sharedScalacOptions ++ List(
   Compile / doc / sources := Seq.empty,
   libraryDependencies ++= crossSetting(
     scalaVersion.value,
-    if2 = List(
+    if212 = List(
       compilerPlugin(
         ("org.scalameta" % "semanticdb-scalac" % V.semanticdb(
           scalaVersion.value
@@ -356,7 +356,7 @@ val mtagsSettings = List(
   libraryDependencies ++= {
     crossSetting(
       scalaVersion.value,
-      if2 = List(
+      if212 = List(
         // for token edit-distance used by goto definition
         "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
         ("org.scalameta" % "semanticdb-scalac-core" % V.semanticdb(
@@ -549,7 +549,10 @@ lazy val `sbt-metals` = project
     ),
     scalaVersion := V.scala212,
     crossScalaVersions := Seq(V.scala212, V.scala3ForSBT2),
-    scalacOptions := Seq("-release", "8"),
+    scalacOptions ++= crossSetting(
+      scalaVersion.value,
+      if212 = List("-release", "8"),
+    ),
     scriptedLaunchOpts ++= Seq(s"-Dplugin.version=${version.value}"),
     (pluginCrossBuild / sbtVersion) := {
       scalaBinaryVersion.value match {

--- a/project/V.scala
+++ b/project/V.scala
@@ -9,7 +9,7 @@ object V {
 
   val scala3 = "3.3.8"
 
-  val scala3ForSBT2 = "3.7.4"
+  val scala3ForSBT2 = "3.8.4"
 
   val latestScala3Next = "3.8.4"
 
@@ -80,7 +80,7 @@ object V {
 
   val scribe = "3.19.0"
 
-  val sbt2Version = "2.0.0-RC8"
+  val sbt2Version = "2.0.3"
 
   val guava = "com.google.guava" % "guava" % "33.6.0-jre"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Scala version used for the SBT 2 toolchain (3.7.4 → 3.8.4).
  * Updated the SBT 2 tooling version (2.0.0-RC8 → 2.0.3).
* **Build Configuration**
  * Improved cross-build Scala 2 handling so version-specific settings are applied correctly.
  * Made the `-release 8` compiler option conditional for the Scala 2.12 branch (instead of always applying it).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->