### PR TITLE
bugfix: Plugin has been compiled by a more recent version of the Java Runtime

### DIFF
--- a/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPruneCompiler.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/jpc/JavaPruneCompiler.scala
@@ -83,7 +83,6 @@ class JavaPruneCompiler(
       classpath: Seq[Path] = Nil,
       extraOptions: List[String] = Nil
   ): List[String] = {
-    val finalClasspath = classpath :+ headerCompiler
     val options = List.newBuilder[String]
     options ++= List(
       "-Xprefer:source",
@@ -98,10 +97,12 @@ class JavaPruneCompiler(
       "-proc:none"
     )
     val processedExtraOptions = processExtraOptions(extraOptions, files)
-    if (finalClasspath.nonEmpty) {
-      options += "-classpath"
-      options += finalClasspath.mkString(File.pathSeparator)
-    }
+    // Always pass -classpath explicitly, even when empty: an absent
+    // -classpath makes javac fall back to the host JVM's own
+    // java.class.path, leaking our own runtime dependencies into the
+    // compiled target's classpath.
+    options += "-classpath"
+    options += classpath.mkString(File.pathSeparator)
     options ++= processedExtraOptions
     // Add --patch-module option if we're compiling sources from the JDK.
     for {
@@ -348,10 +349,12 @@ class JavaPruneCompiler(
       .mkString("-Xplugin:MetalsHeaderCompiler ", " ", "")
     options += headerCompilerOption
     var isAnnotationPath = false
+    var processorPathPresent = false
     extraOptions.foreach { extraOption =>
       val nextOption: String =
         if (extraOption == "-processorpath") {
           isAnnotationPath = true
+          processorPathPresent = true
           extraOption
         } else if (isAnnotationPath) {
           // Processing the option following "-processorpath"
@@ -361,11 +364,24 @@ class JavaPruneCompiler(
               .mkString(File.pathSeparator)
           processorPath
         } else if (extraOption.startsWith("-processorpath=")) {
+          processorPathPresent = true
           s"${extraOption}${File.pathSeparator}${headerCompiler}"
         } else {
           extraOption
         }
       options += nextOption
+    }
+    if (!processorPathPresent) {
+      // Without an explicit -processorpath, javac's Plugin/Processor
+      // ServiceLoader lookup falls back to scanning the entire -classpath
+      // (JavacProcessingEnvironment.getProcessorClassLoader). That classpath
+      // can contain a jar built for a newer JDK than the one running this
+      // presentation compiler, and merely loading such a jar's Plugin
+      // crashes the whole lookup before MetalsHeaderCompiler is ever found.
+      // Always setting -processorpath scopes plugin discovery to a
+      // classpath we control instead.
+      options += "-processorpath"
+      options += headerCompiler.toString()
     }
     options.result()
   }

--- a/tests/unit/src/test/scala/tests/j/BaseJavaPruneCompilerSuite.scala
+++ b/tests/unit/src/test/scala/tests/j/BaseJavaPruneCompilerSuite.scala
@@ -1,5 +1,6 @@
 package tests.j
 
+import java.nio.file.Path
 import java.nio.file.Paths
 
 import scala.meta.inputs.Input
@@ -34,8 +35,9 @@ abstract class BaseJavaPruneCompilerSuite extends munit.FunSuite {
       layout: String,
       mainPath: String,
       options: List[String] = Nil,
+      classpath: List[Path] = Nil,
   ): String = {
-    val result = compileFiles(layout, mainPath, options)
+    val result = compileFiles(layout, mainPath, options, classpath)
     result.diagnostics
       .map(d => d.formatMessage(result.input))
       .mkString("\n")
@@ -51,6 +53,7 @@ abstract class BaseJavaPruneCompilerSuite extends munit.FunSuite {
       layout: String,
       mainPath: String,
       options: List[String] = Nil,
+      classpath: List[Path] = Nil,
   ): CompileFilesResult = {
     val main = Paths.get(mainPath)
     if (main.isAbsolute) {
@@ -77,7 +80,7 @@ abstract class BaseJavaPruneCompilerSuite extends munit.FunSuite {
       embedded = embedded,
       javaFileManagerFactory = mbt,
       metalsConfig = PresentationCompilerConfigImpl(),
-      classpath = Nil,
+      classpath = classpath,
       options = options,
       progressBars = ProgressBars.EMPTY,
     )
@@ -92,10 +95,16 @@ abstract class BaseJavaPruneCompilerSuite extends munit.FunSuite {
       layout: String,
       mainPath: String,
       options: List[String] = Nil,
+      classpath: List[Path] = Nil,
   )(implicit loc: munit.Location): Unit = {
     test(name) {
       val withPlugin =
-        compileFilesWithFormattedDiagnostics(layout, mainPath, options)
+        compileFilesWithFormattedDiagnostics(
+          layout,
+          mainPath,
+          options,
+          classpath,
+        )
       assertNoDiff(withPlugin, "")
     }
   }

--- a/tests/unit/src/test/scala/tests/j/PluginClasspathJavaVersionMismatchSuite.scala
+++ b/tests/unit/src/test/scala/tests/j/PluginClasspathJavaVersionMismatchSuite.scala
@@ -1,0 +1,60 @@
+package tests.j
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Regression test for a crash where the presentation compiler's own
+ * `-Xplugin:MetalsHeaderCompiler` plugin failed to load whenever the build
+ * target's classpath contained a jar registering an unrelated
+ * `com.sun.source.util.Plugin` service provider compiled for a newer JDK.
+ *
+ * javac's Plugin ServiceLoader lookup must load every provider class on the
+ * relevant path to read its name, so a single incompatible jar anywhere on
+ * that path crashes plugin discovery before MetalsHeaderCompiler is ever
+ * found (see JavacProcessingEnvironment.getProcessorClassLoader, which falls
+ * back to scanning `-classpath` whenever `-processorpath` isn't set).
+ */
+class PluginClasspathJavaVersionMismatchSuite
+    extends BaseJavaPruneCompilerSuite {
+
+  private def incompatiblePluginJar(): Path = {
+    val jarPath = Files.createTempFile("incompatible-plugin", ".jar")
+    val out = new ZipOutputStream(Files.newOutputStream(jarPath))
+    out.putNextEntry(
+      new ZipEntry("META-INF/services/com.sun.source.util.Plugin")
+    )
+    out.write("com.example.IncompatiblePlugin".getBytes("UTF-8"))
+    out.closeEntry()
+    out.putNextEntry(new ZipEntry("com/example/IncompatiblePlugin.class"))
+    // 0xCAFEBABE identifies the file as a JVM class file (JVMS 4.1).
+    val classFileMagicNumber =
+      Array[Byte](0xca.toByte, 0xfe.toByte, 0xba.toByte, 0xbe.toByte)
+    val minorVersion: Short = 0
+    val majorVersionJava21: Short = 65
+    // Just enough of a class file for the JVM to reject it while reading the
+    // major version.
+    out.write(classFileMagicNumber)
+    out.write(Array[Byte]((minorVersion >> 8).toByte, minorVersion.toByte))
+    out.write(
+      Array[Byte]((majorVersionJava21 >> 8).toByte, majorVersionJava21.toByte)
+    )
+    out.closeEntry()
+    out.close()
+    jarPath
+  }
+
+  checkNoErrors(
+    "classpath-with-incompatible-plugin-jar",
+    """|/foo/Example.java
+       |package foo;
+       |public class Example {
+       |  public static final String greeting = "hello";
+       |}
+       |""".stripMargin,
+    "foo/Example.java",
+    classpath = List(incompatiblePluginJar()),
+  )
+}


### PR DESCRIPTION
## Background
Java editor features (semantic tokens, diagnostics, etc.) crashed for entire
build targets whenever the target's classpath contained a jar with a
registered `com.sun.source.util.Plugin` provider built for a newer JDK than
the one running Metals' presentation compiler:

```
compiler crashed due to an error in the Java compiler: java.lang.IllegalStateException: 
java.lang.UnsupportedClassVersionError: com/example/SomePlugin has been compiled by a more recent version of 
the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 
61.0, retrying with new compiler instance.
```

## Summary
- Metals' Java presentation compiler injects its own `-Xplugin:MetalsHeaderCompiler`, which javac's `Plugin` ServiceLoader can only discover via `-processorpath`, or, if that isn't set, by scanning the entire `-classpath`.
- Scanning the raw `-classpath` means loading every provider class there just to read its name — if any jar on that classpath was built for a newer JDK than the one running the presentation compiler, loading it throws `UnsupportedClassVersionError` and aborts plugin discovery before `MetalsHeaderCompiler` is ever found, breaking Java editor features for the whole build target.
- Always set `-processorpath` (to the self-contained header-compiler jar) when the target's javac options don't already supply one, so plugin discovery only ever scans a classpath Metals controls.

## Test plan
- Added `JavaPruneCompilerPluginClasspathSuite`, a regression test with a synthetic classpath jar registering an incompatible `com.sun.source.util.Plugin` provider, reproducing the crash and verifying it no longer occurs.

## Manual verification
* use JDK 17
* open https://github.com/bazelbuild/bazel
* go to some Java file, e.g. src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/ClassInfo.java
* import project by selecting Use MBT > Each build target
* check the Output tab (select Metals from the source dropdown, if it's not selected by default) 

### Before
<img width="1509" height="922" alt="Screenshot 2026-07-22 at 16 39 34" src="https://github.com/user-attachments/assets/81da294f-0771-4d75-bde2-e54ec6281d3f" />

### After
<img width="1509" height="922" alt="Screenshot 2026-07-22 at 16 41 25" src="https://github.com/user-attachments/assets/84f1c291-7000-49eb-bb3e-239c8da1cc53" />

