### PR TITLE
Wrap metals:default-shell command arguments in quotes

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -34,6 +34,9 @@ class ShellRunner(
 
   private val cancelables = new MutableCancelable()
 
+  private def shellQuote(arg: String): String =
+    "'" + arg.replace("'", "'\\''") + "'"
+
   override def cancel(): Unit = {
     cancelables.cancel()
   }
@@ -96,7 +99,8 @@ class ShellRunner(
 
     val shellArguments = userConfiguration().defaultShell match {
       case Some(shell) if shell.contains("fish") => shell :: args
-      case Some(shell) => List(shell, "-i", "-l", "-c", args.mkString(" "))
+      case Some(shell) =>
+        List(shell, "-i", "-l", "-c", args.map(shellQuote).mkString(" "))
       case None => args
     }
     scribe.info(s"Running command: ${shellArguments.mkString(" ")}")


### PR DESCRIPTION
The issue appeared when importing a bazel project for MBT while using the `metals:default-shell ` setting.
Without this, for any command that includes parentheses, these may be interpreted as e.g. glob qualifier syntax.

The issue was found and tested using zsh (and when that is set as metals:default-shell flag), but solution should work with other shells.

Before:
```scala
  2026.07.22 15:26:53 INFO  Running command: /bin/zsh -i -l -c bazel query --output=label --keep_going kind(scala_library, @//...:all) union kind(java_library, @//...:all) union kind(scala_binary, @//...:all) union kind(java_binary,     
  @//...:all) union kind(scala_test, @//...:all) union kind(java_test, @//...:all) union kind(scala_import, @//...:all) union kind(java_import, @//...:all)                                                                                                                 
  2026.07.22 15:26:54 WARN  zsh:1: number expected 
[the query itself would fail]             
```                                                                                                                                                                             
After:
```scala
2026.07.22 16:05:24 INFO  Running command: /bin/zsh -i -l -c 'bazel' 'query' '--output=label' '--keep_going' 'kind(scala_library, @//...:all) union kind(java_library, @//...:all) union kind(scala_binary, @//...:all) union kind(java_binary, @//...:all) union kind(scala_test, @//...:all) union kind(java_test, @//...:all) union kind(scala_import, @//...:all) union kind(java_import, @//...:all)'[0m
[no failure]
```