### PR TITLE
bugfix: Replace spaces by hyphens to mirror giter8 templating engine

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
@@ -98,15 +98,19 @@ class NewProjectProvider(
       }
   }
 
+  private def hyphenate(s: String) = s.replaceAll("""(\s+|\\|/)+""", "-")
+  private def normalize(s: String) = hyphenate(s.toLowerCase)
+
   private def createNewProject(
       inputPath: AbsolutePath,
       template: String,
       projectName: String,
       javaHome: Option[String],
   ): Future[Unit] = {
-    val projectPath = inputPath.resolve(projectName.toLowerCase())
+    val normalizedName = normalize(projectName.toLowerCase())
+    val projectPath = inputPath.resolve(normalizedName)
     val parent = projectPath.parent
-    projectPath.createDirectories()
+    parent.createDirectories()
     val command = List(
       template,
       s"--name=${projectPath.filename}",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * New projects now create directories using a consistent normalized name derived from the provided project title (lowercased; whitespace and path separators are replaced with hyphens).
  * Project directory setup has been adjusted to create only the necessary parent directories, improving reliability when setting up new project paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->