### PR TITLE
docs: Add release notes for Metals 1.6.8

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     id: version
     attributes:
       label: Version of Metals
-      placeholder: v1.6.7
+      placeholder: v1.6.8
     validations:
       required: true
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / resolvers += "scala-nightlies" at
   "https://repo.scala-lang.org/artifactory/maven-nightlies"
 
-def localSnapshotVersion = "1.6.8-SNAPSHOT"
-def latestReleaseVersion = "1.6.7"
+def localSnapshotVersion = "1.6.9-SNAPSHOT"
+def latestReleaseVersion = "1.6.8"
 def isCI = System.getenv("CI") != null
 def isTest = System.getenv("METALS_TEST") != null
 
@@ -255,6 +255,7 @@ lazy val interfaces = project
       "org.scalameta" % "mtags-interfaces" % "1.3.2",
       "org.scalameta" % "mtags-interfaces" % "1.4.2",
       "org.scalameta" % "mtags-interfaces" % "1.5.2",
+      "org.scalameta" % "mtags-interfaces" % "1.6.7",
     ),
     crossPaths := false,
     libraryDependencies ++= List(

--- a/website/blog/2026-07-23-osmium.md
+++ b/website/blog/2026-07-23-osmium.md
@@ -1,0 +1,528 @@
+---
+authors: tgodzik
+title: Metals v1.6.8 - Osmium
+---
+
+We're happy to announce the release of Metals v1.6.8, which includes a few
+long-awaited features. It's also worth mentioning that we are working on a new
+iteration of Metals (v2), which will change some important things about how
+Metals works. You can already try out the latest milestone `v2.0.0-M16`.
+
+<table>
+<tbody>
+  <tr>
+    <td>Commits since last release</td>
+    <td align="center">140</td>
+  </tr>
+  <tr>
+    <td>Merged PRs</td>
+    <td align="center">119</td>
+  </tr>
+    <tr>
+    <td>Contributors</td>
+    <td align="center">16</td>
+  </tr>
+  <tr>
+    <td>Closed issues</td>
+    <td align="center">21</td>
+  </tr>
+  <tr>
+    <td>New features</td>
+    <td align="center">3</td>
+  </tr>
+</tbody>
+</table>
+
+For full details:
+[https://github.com/scalameta/metals/milestone/87?closed=1](https://github.com/scalameta/metals/milestone/87?closed=1)
+
+Metals is a language server for Scala that works with VS Code, Vim, Emacs, Zed,
+Helix and Sublime Text. Metals is developed at the
+[Scala Center](https://scala.epfl.ch/) and [VirtusLab](https://virtuslab.com)
+with the help from contributors from the community.
+
+## TL;DR
+
+Check out [https://scalameta.org/metals/](https://scalameta.org/metals/), and
+give Metals a try!
+
+- [Add scalafix diagnostics](#add-scalafix-diagnostics)
+- [Use javac-based parser for Java source indexing](#use-javac-based-parser-for-java-source-indexing)
+- [Discover individual JUnit 5 tests](#support-for-junit-5-tests)
+- [Miscellaneous](#miscellaneous)
+
+## Add scalafix diagnostics
+
+Thanks to [warcholjakub](https://github.com/warcholjakub) it's now possible to
+see scalafix diagnostics in the editor from any linting rule. They are disabled
+by default, but you can enable them by setting `metals.scalafixLintEnabled` to
+`true` in your editor settings.
+
+## Use javac-based parser for Java source indexing
+
+For a long time, Metals used the QDox project to parse Java source code and
+provide some of the features when dealing with Java files and dependencies.
+These features could include providing javadocs or finding exact definition
+within a Java source file.
+
+However, QDox is no longer well maintained and thanks to
+[rkophs](https://github.com/rkophs) we now use the default javac parser to parse
+Java source code. This should make sure that we always support the latest Java
+syntax and will avoid any issues with incompatibilities between the different
+Java parsers.
+
+## Support for JUnit 5 tests
+
+JUnit 5 support has been a long-awaited feature for many users. It should
+finally be supported in all the build servers including Bloop using the Jupiter
+interface.
+
+Also, thanks to [Leon0402](https://github.com/Leon0402) it's now possible to
+discover individual JUnit 5 tests and run them.
+
+## Miscellaneous
+
+- improvement: Forward repository credentials to Bloop
+  [\#8297](https://github.com/scalameta/metals/pull/8297)
+  ([tgodzik](https://github.com/tgodzik))
+- bugfix: Java toplevel indexer support for multiline text blocks
+  [\#8296](https://github.com/scalameta/metals/pull/8296)
+  ([tgodzik](https://github.com/tgodzik))
+- bugfix: Include jvm properties from build server when running tests via MCP
+  [\#8308](https://github.com/scalameta/metals/pull/8308)
+  ([tgodzik](https://github.com/tgodzik))
+- bugfix: Always return MCP diagnostics even if compilation was cancelled
+  [\#8324](https://github.com/scalameta/metals/pull/8324)
+  ([tgodzik](https://github.com/tgodzik))
+- feature: Add support for Deder build tool
+  [\#8343](https://github.com/scalameta/metals/pull/8343)
+  ([sake92](https://github.com/sake92))
+- refactor: Update KiloCode configuration metadata
+  [\#8365](https://github.com/scalameta/metals/pull/8365)
+  ([cheleb](https://github.com/cheleb))
+- improvement: Expose go to log to be used in command palette
+  [\#8448](https://github.com/scalameta/metals/pull/8448)
+  ([tgodzik](https://github.com/tgodzik))
+- bugfix: Prefer a custom .bsp build server over a stray .bloop directory
+  [\#8465](https://github.com/scalameta/metals/pull/8465)
+  ([jozanek](https://github.com/jozanek))
+- bugfix: Expand implicit materializer macros in the presentation compiler
+  [\#8464](https://github.com/scalameta/metals/pull/8464)
+  ([jozanek](https://github.com/jozanek))
+- improvement: Send real document version in rename edits instead of null
+  [\#8456](https://github.com/scalameta/metals/pull/8456)
+  ([jozanek](https://github.com/jozanek))
+- bugfix: Don't truncate debug console output when the JVM exits
+  [\#8463](https://github.com/scalameta/metals/pull/8463)
+  ([jozanek](https://github.com/jozanek))
+- bugfix: Add into soft modifier
+  [\#8506](https://github.com/scalameta/metals/pull/8506)
+  ([tgodzik](https://github.com/tgodzik))
+- bugfix: let user-provided jvmOptions take precedence over build server ones in
+  shell command [\#8518](https://github.com/scalameta/metals/pull/8518)
+  ([jozanek](https://github.com/jozanek))
+- improvement: Only run bloopInstall on import when importing via Metals
+  [\#8538](https://github.com/scalameta/metals/pull/8538)
+  ([tgodzik](https://github.com/tgodzik))
+- feature: add support for Codex CLI MCP config
+  [\#8540](https://github.com/scalameta/metals/pull/8540)
+  ([greshny](https://github.com/greshny))
+- bugfix: Resolve double-encoded jar URIs for JDK sources when debugging on
+  Windows [\#8549](https://github.com/scalameta/metals/pull/8549)
+  ([jozanek](https://github.com/jozanek))
+- bugfix: retry completions when the qualifier loses its type to error recovery
+  [\#8514](https://github.com/scalameta/metals/pull/8514)
+  ([jozanek](https://github.com/jozanek))
+- improvement: parse scaladoc wiki links with a shared backtick/nesting-aware
+  parser [\#8676](https://github.com/scalameta/metals/pull/8676)
+  ([jozanek](https://github.com/jozanek))
+- bugfix: Handle Java raw types in override completions
+  [\#8489](https://github.com/scalameta/metals/pull/8489)
+  ([jozanek](https://github.com/jozanek))
+- bugfix: pass build server jvmOptions when running or debugging within the
+  Metals server [\#8556](https://github.com/scalameta/metals/pull/8556)
+  ([jozanek](https://github.com/jozanek))
+
+## Contributors
+
+Big thanks to everybody who contributed to this release or reported an issue!
+
+```console
+$ git shortlog -sn --no-merges v1.6.7..v1.6.8
+    43	Scala Steward
+    23	Tomasz Godzik
+    16	dependabot[bot]
+    10	Myroslav
+     9	Jozef Koval
+     3	Sakib Hadziavdic
+     2	Albert Meltzer
+     2	Olivier NOUGUIER
+     2	copilot-swe-agent[bot]
+     1	Jakub Warchoł
+     1	Leon De Andrade
+     1	Roman Greschni
+     1	Ryan Kophs
+     1	Simon Schenk
+     1	damiankus-vl
+     1	kenji yoshida
+```
+
+## [v1.6.8](https://github.com/scalameta/metals/tree/v1.6.8) (2026-07-21)
+
+[Full Changelog](https://github.com/scalameta/metals/compare/v1.6.7...v1.6.8)
+
+**Merged pull requests:**
+
+- build(deps): bump svgo from 3.3.3 to 3.3.4 in /website
+  [\#8711](https://github.com/scalameta/metals/pull/8711)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- chore: Update sbt 2 to latest
+  [\#8713](https://github.com/scalameta/metals/pull/8713)
+  ([tgodzik](https://github.com/tgodzik))
+- bugfix: Remove the problematic type annotation
+  [\#8712](https://github.com/scalameta/metals/pull/8712)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update scalafmt-core, scalafmt-dynamic from 3.11.1 to 3.11.4
+  [\#8698](https://github.com/scalameta/metals/pull/8698)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): bump webpack-dev-server from 5.2.5 to 5.2.6 in /website
+  [\#8706](https://github.com/scalameta/metals/pull/8706)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): bump body-parser from 1.20.5 to 1.20.6 in /website
+  [\#8705](https://github.com/scalameta/metals/pull/8705)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): bump brace-expansion from 1.1.13 to 1.1.16 in /website
+  [\#8708](https://github.com/scalameta/metals/pull/8708)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): bump shell-quote from 1.8.4 to 1.10.0 in /website
+  [\#8707](https://github.com/scalameta/metals/pull/8707)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- fix: pass build server jvmOptions to in-house debug adapter
+  [\#8556](https://github.com/scalameta/metals/pull/8556)
+  ([jozanek](https://github.com/jozanek))
+- bugfix: Handle Java raw types in override completions
+  [\#8489](https://github.com/scalameta/metals/pull/8489)
+  ([jozanek](https://github.com/jozanek))
+- parse scaladoc wiki links with a shared backtick/nesting-aware parser
+  [\#8676](https://github.com/scalameta/metals/pull/8676)
+  ([jozanek](https://github.com/jozanek))
+- build(deps): bump websocket-driver from 0.7.4 to 0.7.5 in /website
+  [\#8690](https://github.com/scalameta/metals/pull/8690)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update ipcsocket from 1.7.0 to 1.8.0
+  [\#8679](https://github.com/scalameta/metals/pull/8679)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): update mdoc to 2.9.1
+  [\#8693](https://github.com/scalameta/metals/pull/8693)
+  ([kitbellew](https://github.com/kitbellew))
+- feat(website): show GitHub as an icon in the navbar
+  [\#8692](https://github.com/scalameta/metals/pull/8692)
+  ([kitbellew](https://github.com/kitbellew))
+- build(deps): Update mdoc, mdoc-interfaces, sbt-mdoc from 2.9.0 to 2.9.1
+  [\#8696](https://github.com/scalameta/metals/pull/8696)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update metaconfig-core from 0.18.6 to 0.18.7
+  [\#8697](https://github.com/scalameta/metals/pull/8697)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update sbt-ci-release from 1.11.2 to 1.12.0
+  [\#8672](https://github.com/scalameta/metals/pull/8672)
+  ([scala-steward](https://github.com/scala-steward))
+- feat: discover individual JUnit 5 tests
+  [\#8457](https://github.com/scalameta/metals/pull/8457)
+  ([Leon0402](https://github.com/Leon0402))
+- chore: Update Bloop to 2.1.1
+  [\#8655](https://github.com/scalameta/metals/pull/8655)
+  ([tgodzik](https://github.com/tgodzik))
+- fix: retry completions when the qualifier loses its type to error recovery
+  [\#8514](https://github.com/scalameta/metals/pull/8514)
+  ([jozanek](https://github.com/jozanek))
+- Avoid infix and postfix syntax in build.sbt
+  [\#8643](https://github.com/scalameta/metals/pull/8643)
+  ([xuwei-k](https://github.com/xuwei-k))
+- Fixed the test failures summary
+  [\#8634](https://github.com/scalameta/metals/pull/8634)
+  ([odisseus](https://github.com/odisseus))
+- build(deps-dev): bump @types/node from 25.9.1 to 26.0.1 in /website in the
+  npm-dependencies group [\#8624](https://github.com/scalameta/metals/pull/8624)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): bump the github-actions group across 1 directory with 2 updates
+  [\#8623](https://github.com/scalameta/metals/pull/8623)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update flyway-core from 12.9.0 to 12.10.0
+  [\#8616](https://github.com/scalameta/metals/pull/8616)
+  ([scala-steward](https://github.com/scala-steward))
+- Select test reports by workflow run ID
+  [\#8621](https://github.com/scalameta/metals/pull/8621)
+  ([odisseus](https://github.com/odisseus))
+- Further improvements to the failure report
+  [\#8611](https://github.com/scalameta/metals/pull/8611)
+  ([odisseus](https://github.com/odisseus))
+- GitHub CI improvements [\#8608](https://github.com/scalameta/metals/pull/8608)
+  ([odisseus](https://github.com/odisseus))
+- Add the 'Test Failures Report' workflow to the main branch
+  [\#8606](https://github.com/scalameta/metals/pull/8606)
+  ([odisseus](https://github.com/odisseus))
+- build(deps): Update scala-debug-adapter from 4.2.8 to 4.2.9
+  [\#8596](https://github.com/scalameta/metals/pull/8596)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update bloop-maven-plugin from 2.0.4 to 2.0.5
+  [\#8595](https://github.com/scalameta/metals/pull/8595)
+  ([scala-steward](https://github.com/scala-steward))
+- Fix image links in docs
+  [\#8597](https://github.com/scalameta/metals/pull/8597)
+  ([damiankus-vl](https://github.com/damiankus-vl))
+- Improved grammar [\#8586](https://github.com/scalameta/metals/pull/8586)
+  ([odisseus](https://github.com/odisseus))
+- build(deps): bump http-proxy-middleware from 2.0.9 to 2.0.10 in /website
+  [\#8583](https://github.com/scalameta/metals/pull/8583)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update sbt-welcome from 0.5.0 to 0.6.0
+  [\#8576](https://github.com/scalameta/metals/pull/8576)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update geny from 1.0.0 to 1.1.1
+  [\#8577](https://github.com/scalameta/metals/pull/8577)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update mill-contrib-testng from 1.1.6 to 1.1.7
+  [\#8578](https://github.com/scalameta/metals/pull/8578)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update pprint from 0.7.3 to 0.9.6
+  [\#8579](https://github.com/scalameta/metals/pull/8579)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update sbt, scripted-plugin from 1.12.12 to 1.12.13
+  [\#8580](https://github.com/scalameta/metals/pull/8580)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update scalameta, semanticdb-metap, ... from 4.15.2 to 4.17.0
+  [\#8564](https://github.com/scalameta/metals/pull/8564)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update mcp, mcp-json-jackson2 from 1.1.3 to 2.0.0
+  [\#8552](https://github.com/scalameta/metals/pull/8552)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): bump undici from 6.24.1 to 6.27.0 in /website
+  [\#8571](https://github.com/scalameta/metals/pull/8571)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update cli_3, scala-cli-bsp from 1.12.5 to 1.14.0
+  [\#8569](https://github.com/scalameta/metals/pull/8569)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update coursier, ... from 2.1.25-M25 to 2.1.25-M26
+  [\#8567](https://github.com/scalameta/metals/pull/8567)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update ipcsocket from 1.6.3 to 1.7.0
+  [\#8568](https://github.com/scalameta/metals/pull/8568)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update flyway-core from 12.8.1 to 12.9.0
+  [\#8563](https://github.com/scalameta/metals/pull/8563)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update cli_3, scala-cli-bsp from 1.12.4 to 1.12.5
+  [\#8565](https://github.com/scalameta/metals/pull/8565)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): bump webpack-dev-server from 5.2.4 to 5.2.5 in /website
+  [\#8559](https://github.com/scalameta/metals/pull/8559)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update sbt-scalafix, scalafix-interfaces from 0.14.6 to 0.14.7
+  [\#8524](https://github.com/scalameta/metals/pull/8524)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update scalafmt-core, scalafmt-dynamic from 3.10.7 to 3.11.1
+  [\#8555](https://github.com/scalameta/metals/pull/8555)
+  ([scala-steward](https://github.com/scala-steward))
+- fix: Resolve double-encoded jar URIs for JDK sources when debugging on Windows
+  [\#8549](https://github.com/scalameta/metals/pull/8549)
+  ([jozanek](https://github.com/jozanek))
+- build(deps): Update sbt-mima-plugin from 1.1.5 to 1.1.6
+  [\#8551](https://github.com/scalameta/metals/pull/8551)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update mdoc, sbt-mdoc from 2.5.4 to 2.9.0
+  [\#8554](https://github.com/scalameta/metals/pull/8554)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): bump launch-editor from 2.11.1 to 2.14.1 in /website
+  [\#8544](https://github.com/scalameta/metals/pull/8544)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- feat: add support for Codex CLI MCP config
+  [\#8540](https://github.com/scalameta/metals/pull/8540)
+  ([greshny](https://github.com/greshny))
+- build(deps): bump @babel/core from 7.24.7 to 7.29.7 in /website
+  [\#8545](https://github.com/scalameta/metals/pull/8545)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- improvement: Run bloopInstall on import in the next BLoop version
+  [\#8538](https://github.com/scalameta/metals/pull/8538)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): bump joi from 17.12.3 to 17.13.4 in /website
+  [\#8523](https://github.com/scalameta/metals/pull/8523)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update mcp, mcp-json-jackson2 from 1.0.2 to 1.1.3
+  [\#8526](https://github.com/scalameta/metals/pull/8526)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update jsoup from 1.22.1 to 1.22.2
+  [\#8527](https://github.com/scalameta/metals/pull/8527)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update protobuf-java from 4.35.0 to 4.35.1
+  [\#8525](https://github.com/scalameta/metals/pull/8525)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update sbt, scripted-plugin from 1.12.5 to 1.12.12
+  [\#8530](https://github.com/scalameta/metals/pull/8530)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update mdoc, sbt-mdoc from 2.5.2 to 2.5.4
+  [\#8531](https://github.com/scalameta/metals/pull/8531)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update mdoc-interfaces from 2.8.2 to 2.9.0
+  [\#8532](https://github.com/scalameta/metals/pull/8532)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update metaconfig-core from 0.18.2 to 0.18.6
+  [\#8533](https://github.com/scalameta/metals/pull/8533)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update munit from 1.2.4 to 1.3.3
+  [\#8534](https://github.com/scalameta/metals/pull/8534)
+  ([scala-steward](https://github.com/scala-steward))
+- fix: let user-provided jvmOptions take precedence over build server ones in
+  shell command [\#8518](https://github.com/scalameta/metals/pull/8518)
+  ([jozanek](https://github.com/jozanek))
+- chore: Update Scala 3 LTS tests to 3.3.8
+  [\#8351](https://github.com/scalameta/metals/pull/8351)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update protobuf-java from 4.34.2 to 4.35.0
+  [\#8508](https://github.com/scalameta/metals/pull/8508)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update coursier, ... from 2.1.25-M23 to 2.1.25-M25
+  [\#8509](https://github.com/scalameta/metals/pull/8509)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update mcp, mcp-json-jackson2 from 1.0.0 to 1.0.2
+  [\#8511](https://github.com/scalameta/metals/pull/8511)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update flyway-core from 12.0.3 to 12.8.1
+  [\#8512](https://github.com/scalameta/metals/pull/8512)
+  ([scala-steward](https://github.com/scala-steward))
+- bugfix: Add into soft modifier
+  [\#8506](https://github.com/scalameta/metals/pull/8506)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): bump shell-quote from 1.8.3 to 1.8.4 in /website
+  [\#8487](https://github.com/scalameta/metals/pull/8487)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- bugfix: Don't truncate debug console output when the JVM exits
+  [\#8463](https://github.com/scalameta/metals/pull/8463)
+  ([jozanek](https://github.com/jozanek))
+- Send real document version in rename edits instead of null
+  [\#8456](https://github.com/scalameta/metals/pull/8456)
+  ([jozanek](https://github.com/jozanek))
+- build(deps): Update protobuf-java from 4.34.0 to 4.34.2
+  [\#8478](https://github.com/scalameta/metals/pull/8478)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update mill-contrib-testng from 1.1.3 to 1.1.6
+  [\#8479](https://github.com/scalameta/metals/pull/8479)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update scribe, scribe-file, scribe-slf4j2 from 3.18.0 to 3.19.0
+  [\#8480](https://github.com/scalameta/metals/pull/8480)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update semanticdb-java from 0.11.2 to 0.12.3
+  [\#8481](https://github.com/scalameta/metals/pull/8481)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update jackson-databind from 2.21.4 to 2.22.0
+  [\#8477](https://github.com/scalameta/metals/pull/8477)
+  ([scala-steward](https://github.com/scala-steward))
+- chore: Update Bloop to 2.1.0
+  [\#8475](https://github.com/scalameta/metals/pull/8475)
+  ([tgodzik](https://github.com/tgodzik))
+- bugfix: Expand implicit materializer macros in the presentation compiler
+  [\#8464](https://github.com/scalameta/metals/pull/8464)
+  ([jozanek](https://github.com/jozanek))
+- bugfix: Prefer a custom .bsp build server over a stray .bloop directory
+  [\#8465](https://github.com/scalameta/metals/pull/8465)
+  ([jozanek](https://github.com/jozanek))
+- build(deps): Update bloop-maven-plugin from 2.0.3 to 2.0.4
+  [\#8458](https://github.com/scalameta/metals/pull/8458)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update jackson-databind from 2.21.1 to 2.21.4
+  [\#8461](https://github.com/scalameta/metals/pull/8461)
+  ([scala-steward](https://github.com/scala-steward))
+- build(deps): Update guava from 33.5.0-jre to 33.6.0-jre
+  [\#8462](https://github.com/scalameta/metals/pull/8462)
+  ([scala-steward](https://github.com/scala-steward))
+- [main] Replace QDox with javac-based parser for Java source indexing
+  [\#8357](https://github.com/scalameta/metals/pull/8357)
+  ([rkophs](https://github.com/rkophs))
+- improvement: Expose go to log to be used in command palette
+  [\#8448](https://github.com/scalameta/metals/pull/8448)
+  ([tgodzik](https://github.com/tgodzik))
+- chore: Test with Scala 3.8.4
+  [\#8288](https://github.com/scalameta/metals/pull/8288)
+  ([tgodzik](https://github.com/tgodzik))
+- Fixed grammar [\#8433](https://github.com/scalameta/metals/pull/8433)
+  ([odisseus](https://github.com/odisseus))
+- build(deps): bump the npm-dependencies group in /website with 4 updates
+  [\#8434](https://github.com/scalameta/metals/pull/8434)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- Fixed typos and grammar
+  [\#8421](https://github.com/scalameta/metals/pull/8421)
+  ([odisseus](https://github.com/odisseus))
+- bugfix: Fix failing JDK 25 tests
+  [\#8420](https://github.com/scalameta/metals/pull/8420)
+  ([tgodzik](https://github.com/tgodzik))
+- fix: test execution over MCP
+  [\#8418](https://github.com/scalameta/metals/pull/8418)
+  ([runtologist](https://github.com/runtologist))
+- chore: Fix code rabbit config
+  [\#8419](https://github.com/scalameta/metals/pull/8419)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): bump webpack-dev-server from 5.2.2 to 5.2.4 in /website
+  [\#8398](https://github.com/scalameta/metals/pull/8398)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- improvement: Add main-v2 to be review as well
+  [\#8415](https://github.com/scalameta/metals/pull/8415)
+  ([tgodzik](https://github.com/tgodzik))
+- Fixed typos [\#8377](https://github.com/scalameta/metals/pull/8377)
+  ([odisseus](https://github.com/odisseus))
+- build(deps): bump @babel/plugin-transform-modules-systemjs from 7.24.7 to
+  7.29.4 in /website [\#8363](https://github.com/scalameta/metals/pull/8363)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- refactor(mcp): update KiloCode configuration metadata
+  [\#8365](https://github.com/scalameta/metals/pull/8365)
+  ([cheleb](https://github.com/cheleb))
+- Add support for Deder build tool
+  [\#8343](https://github.com/scalameta/metals/pull/8343)
+  ([sake92](https://github.com/sake92))
+- bugfix: Encode target uris for the doctor
+  [\#8355](https://github.com/scalameta/metals/pull/8355)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): bump the npm-dependencies group in /website with 7 updates
+  [\#8344](https://github.com/scalameta/metals/pull/8344)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- bugfix: Fix possible false positive prompt for BSP
+  [\#8325](https://github.com/scalameta/metals/pull/8325)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): bump postcss from 8.4.38 to 8.5.10 in /website
+  [\#8333](https://github.com/scalameta/metals/pull/8333)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- bugfix: Always return diagnostics even if cancelled
+  [\#8324](https://github.com/scalameta/metals/pull/8324)
+  ([tgodzik](https://github.com/tgodzik))
+- docs: Add MCP documentation
+  [\#8323](https://github.com/scalameta/metals/pull/8323)
+  ([tgodzik](https://github.com/tgodzik))
+- improvement: Fix issue with another out of bounds exception
+  [\#8322](https://github.com/scalameta/metals/pull/8322)
+  ([tgodzik](https://github.com/tgodzik))
+- improvement: Add guard in Fuzzy
+  [\#8321](https://github.com/scalameta/metals/pull/8321)
+  ([tgodzik](https://github.com/tgodzik))
+- Improved message for a missing dependency file
+  [\#8314](https://github.com/scalameta/metals/pull/8314)
+  ([odisseus](https://github.com/odisseus))
+- bugfix: Include jvm properties from build server when running from MCP
+  [\#8308](https://github.com/scalameta/metals/pull/8308)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): bump follow-redirects from 1.15.6 to 1.16.0 in /website
+  [\#8310](https://github.com/scalameta/metals/pull/8310)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- feat: add scalafix diagnostics
+  [\#8271](https://github.com/scalameta/metals/pull/8271)
+  ([warcholjakub](https://github.com/warcholjakub))
+- bugfix: Java toplevel indexer skips text blocks (JDK 25 HtmlConfiguration)
+  [\#8296](https://github.com/scalameta/metals/pull/8296)
+  ([tgodzik](https://github.com/tgodzik))
+- improvement: Forward credentials to Bloop
+  [\#8297](https://github.com/scalameta/metals/pull/8297)
+  ([tgodzik](https://github.com/tgodzik))
+- bugfix: Fix issue with uri is wrongly sent for watching
+  [\#8295](https://github.com/scalameta/metals/pull/8295)
+  ([tgodzik](https://github.com/tgodzik))
+- docs: Add release notes for 1.6.7
+  [\#8291](https://github.com/scalameta/metals/pull/8291)
+  ([tgodzik](https://github.com/tgodzik))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release announcement for Metals v1.6.8 (“Osmium”).
  * Included release activity stats, TL;DR quick highlights, and a link to the full change list.
  * Covered editor Scalafix diagnostics, improved Java source indexing, and enhanced JUnit 5 support (including individual test discovery).
  * Added “Miscellaneous” highlights and a contributors summary.
* **Chores / Release Management**
  * Updated the bug report template to reflect Metals v1.6.8 as the current version.
  * Bumped snapshot/latest release version values for the next release cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->