### PR TITLE
Moved some classes into separate packages

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,7 @@
+# https://github.com/scalameta/metals/pull/8726
+# Moved some classes into separate packages
+1b4ceebbb5a0529967387a37d9ead63867ca8305
+
 
 # https://github.com/scalameta/metals/pull/4050
 # add 'trailingCommas = multiple' in scalafmt

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -11,8 +11,6 @@ import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.builds.SbtBuildTool
 import scala.meta.internal.builds.ScalaCliBuildTool
 import scala.meta.internal.builds.ShellRunner
-import scala.meta.internal.metals.BloopServers
-import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.ConnectKind
 import scala.meta.internal.metals.ConnectionProvider
 import scala.meta.internal.metals.CreateSession
@@ -27,6 +25,8 @@ import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.TaskProgress
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.bloop.BloopServers
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.internal.semver.SemVer

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServerConnectionFactory.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServerConnectionFactory.scala
@@ -5,7 +5,6 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Properties
 
-import scala.meta.internal.metals.BuildServerConnectionFactory
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ClosableOutputStream
 import scala.meta.internal.metals.DismissedNotifications
@@ -14,9 +13,10 @@ import scala.meta.internal.metals.MetalsBuildClient
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.QuietInputStream
-import scala.meta.internal.metals.SocketConnection
 import scala.meta.internal.metals.TaskProgress
 import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.buildserver.BuildServerConnectionFactory
+import scala.meta.internal.metals.buildserver.SocketConnection
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.mtags.URIEncoderDecoder
 import scala.meta.internal.process.SystemProcess

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -11,7 +11,6 @@ import scala.util.Try
 
 import scala.meta.internal.bsp.BspServers.readInBspConfig
 import scala.meta.internal.io.FileIO
-import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsBuildClient
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -22,6 +21,7 @@ import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.TaskProgress
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.mbt.MbtBuild
 import scala.meta.internal.metals.mbt.MbtBuildServer

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
@@ -5,11 +5,11 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-import scala.meta.internal.metals.BloopServers
-import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ImportedBuild
 import scala.meta.internal.metals.TaskProgress
+import scala.meta.internal.metals.bloop.BloopServers
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 
 case class BspSession(
     main: BuildServerConnection,

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -11,13 +11,13 @@ import scala.concurrent.ExecutionContext
 import scala.meta.internal.bsp.BspServers
 import scala.meta.internal.bsp.ScalaCliBspScope
 import scala.meta.internal.io.PathIO
-import scala.meta.internal.metals.BloopServers
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.EmptyWorkDoneProgress
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.bloop.BloopServers
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.mbt.importer.MbtImportProvider
 import scala.meta.internal.metals.mbt.importer.ScriptMbtImporter

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -17,6 +17,7 @@ import scala.meta.internal.bsp.sync.WorkspaceSyncParams
 import scala.meta.internal.bsp.sync.WorkspaceSyncResult
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.internal.mtags.Symbol
 import scala.meta.internal.semver.SemVer.Version
 import scala.meta.io.AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -12,6 +12,7 @@ import scala.util.Success
 import scala.util.Try
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.mbt.MbtBuildServer

--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -33,6 +33,7 @@ import scala.meta.internal.builds.WorkspaceLoadedStatus
 import scala.meta.internal.metals.Interruptable._
 import scala.meta.internal.metals.Messages.IncompatibleBloopVersion
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.bloop.BloopServers
 import scala.meta.internal.metals.clients.language.MetalsSyncModesParams
 import scala.meta.internal.metals.doctor.Doctor
 import scala.meta.internal.metals.mbt.MbtBuild

--- a/metals/src/main/scala/scala/meta/internal/metals/ImportedBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ImportedBuild.scala
@@ -8,6 +8,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 
 import ch.epfl.scala.bsp4j._
 

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.metals
 
 import scala.meta.internal.builds.MillBuildTool
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -22,6 +22,7 @@ import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.builds.ScalaCliBuildTool
 import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.bloop.BloopServers
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.data.ResetWorkspaceState
 import scala.meta.internal.metals.doctor.HeadDoctor

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.io.PlatformFileIO
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaTarget.ExperimentalSyntaxRegex
 import scala.meta.internal.metals.ScalaTarget.KindProjectorRegex
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 
 import scala.meta.internal.bsp.ConnectionBspStatus
+import scala.meta.internal.metals.bloop.BloopServers
 import scala.meta.internal.metals.scalacli.ScalaCli
 
 import ch.epfl.scala.bsp4j.CompileParams

--- a/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
@@ -16,6 +16,7 @@ import scala.util.Properties
 
 import scala.meta.inputs.Input
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTarget

--- a/metals/src/main/scala/scala/meta/internal/metals/bloop/BloopServerConfigFactory.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/bloop/BloopServerConfigFactory.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.bloop
 
 import java.lang.management.ManagementFactory
 import java.nio.file.Files
@@ -8,6 +8,7 @@ import scala.collection.concurrent.TrieMap
 import scala.util.Properties
 import scala.util.control.NonFatal
 
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
 
 import bloop.rifle.BloopRifleConfig

--- a/metals/src/main/scala/scala/meta/internal/metals/bloop/BloopServerConnectionFactory.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/bloop/BloopServerConnectionFactory.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.bloop
 
 import java.io.IOException
 import java.net.ConnectException
@@ -17,9 +17,20 @@ import scala.util.control.NonFatal
 
 import scala.meta.internal.bsp.ConnectionBspStatus
 import scala.meta.internal.builds.ShellRunner
+import scala.meta.internal.metals.ClosableOutputStream
+import scala.meta.internal.metals.ConnectionProvider
+import scala.meta.internal.metals.DismissedNotifications
 import scala.meta.internal.metals.Interruptable.MetalsCancelException
+import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.Messages.OldBloopVersionRunning
+import scala.meta.internal.metals.MetalsBuildClient
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.QuietInputStream
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.buildserver.BuildServerConnectionFactory
+import scala.meta.internal.metals.buildserver.SocketConnection
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.io.AbsolutePath
 

--- a/metals/src/main/scala/scala/meta/internal/metals/bloop/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/bloop/BloopServers.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.bloop
 
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -17,7 +17,18 @@ import scala.util.control.NonFatal
 
 import scala.meta.internal.bsp.BuildChange
 import scala.meta.internal.bsp.ConnectionBspStatus
+import scala.meta.internal.metals.BloopJvmProperties
+import scala.meta.internal.metals.Embedded
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsBuildClient
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsProjectDirectories
+import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.Tables
+import scala.meta.internal.metals.TaskProgress
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.io.AbsolutePath
 

--- a/metals/src/main/scala/scala/meta/internal/metals/buildserver/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/buildserver/BuildServerConnection.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.buildserver
 
 import java.io.IOException
 import java.io.InputStream
@@ -28,7 +28,21 @@ import scala.meta.internal.bsp.sync.WorkspaceSyncResult
 import scala.meta.internal.builds.BazelBuildTool
 import scala.meta.internal.builds.MillBuildTool
 import scala.meta.internal.builds.SbtBuildTool
+import scala.meta.internal.metals.CancelTokens
+import scala.meta.internal.metals.Cancelable
+import scala.meta.internal.metals.CancelableFuture
+import scala.meta.internal.metals.ClosableOutputStream
+import scala.meta.internal.metals.ConnectionProvider
+import scala.meta.internal.metals.DismissedNotifications
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsBspException
+import scala.meta.internal.metals.MetalsBuildServer
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.MutableCancelable
+import scala.meta.internal.metals.ServerLivenessMonitor
+import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.bloop.BloopServers
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.logging.JvmRunEnvironmentNotSupported
 import scala.meta.internal.metals.logging.LogOnce

--- a/metals/src/main/scala/scala/meta/internal/metals/buildserver/BuildServerConnectionFactory.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/buildserver/BuildServerConnectionFactory.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.buildserver
 
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -12,9 +12,22 @@ import scala.meta.internal.bsp.ProtocolExtension
 import scala.meta.internal.bsp.sync.SyncExtension
 import scala.meta.internal.bsp.sync.SyncMode
 import scala.meta.internal.builds.BazelBuildTool
-import scala.meta.internal.metals.BuildServerConnection.BspExtraBuildParams
-import scala.meta.internal.metals.BuildServerConnection.InitializeBuildData
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.Cancelable
+import scala.meta.internal.metals.DismissedNotifications
+import scala.meta.internal.metals.LargeLauncher
+import scala.meta.internal.metals.MetalsBuildClient
+import scala.meta.internal.metals.MetalsBuildServer
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.RequestMonitorImpl
+import scala.meta.internal.metals.ServerLivenessMonitor
+import scala.meta.internal.metals.Trace
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.bloop.BloopServers
+import scala.meta.internal.metals.buildserver.BuildServerConnection.BspExtraBuildParams
+import scala.meta.internal.metals.buildserver.BuildServerConnection.InitializeBuildData
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.io.AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/metals/buildserver/BuildServerInitializeException.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/buildserver/BuildServerInitializeException.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.buildserver
 
 class BuildServerInitializeException(e: Throwable)
     extends Exception("Failed to connect to build server", e)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -18,7 +18,6 @@ import scala.util.Success
 import scala.util.Try
 import scala.util.control.NonFatal
 
-import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ClientConfiguration
@@ -42,6 +41,7 @@ import scala.meta.internal.metals.StacktraceAnalyzer
 import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.internal.metals.clients.language.LogForwarder
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.MetalsStatusParams

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
@@ -4,7 +4,6 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
 
 import scala.meta.internal.bsp.BspSession
-import scala.meta.internal.metals.BloopServers
 import scala.meta.internal.metals.JavaInfo
 import scala.meta.internal.metals.JavaTarget
 import scala.meta.internal.metals.JdkSources
@@ -14,6 +13,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MtagsResolver
 import scala.meta.internal.metals.ScalaTarget
 import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.bloop.BloopServers
 import scala.meta.internal.semver.SemVer
 
 class ProblemResolver(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServerConnectionFactory.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServerConnectionFactory.scala
@@ -8,7 +8,6 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 
 import scala.meta.internal.bsp.ConnectionBspStatus
-import scala.meta.internal.metals.BuildServerConnectionFactory
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ClosableOutputStream
 import scala.meta.internal.metals.DismissedNotifications
@@ -16,8 +15,9 @@ import scala.meta.internal.metals.MetalsBuildClient
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.QuietInputStream
 import scala.meta.internal.metals.ScalaVersionSelector
-import scala.meta.internal.metals.SocketConnection
 import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.buildserver.BuildServerConnectionFactory
+import scala.meta.internal.metals.buildserver.SocketConnection
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.io.AbsolutePath
 

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -19,7 +19,6 @@ import scala.util.control.NonFatal
 
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildInfo
-import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.Compilations
 import scala.meta.internal.metals.Compilers
@@ -33,6 +32,7 @@ import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.TargetData
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.scalacli.ScalaCli.ScalaCliCommand
 import scala.meta.io.AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCliConnectionFactory.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCliConnectionFactory.scala
@@ -4,15 +4,15 @@ import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 import scala.concurrent.Promise
 
-import scala.meta.internal.metals.BuildServerConnectionFactory
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ClosableOutputStream
 import scala.meta.internal.metals.DismissedNotifications
 import scala.meta.internal.metals.MetalsBuildClient
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsServerConfig
-import scala.meta.internal.metals.SocketConnection
 import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.buildserver.BuildServerConnectionFactory
+import scala.meta.internal.metals.buildserver.SocketConnection
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCliServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCliServers.scala
@@ -8,7 +8,6 @@ import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 
 import scala.meta.internal.metals.Buffers
-import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.Compilations
@@ -22,6 +21,7 @@ import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.TargetData
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.buildserver.BuildServerConnection
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.scalacli.ScalaCli.ScalaCliCommand
 import scala.meta.internal.process.SystemProcess

--- a/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
+++ b/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
@@ -8,11 +8,11 @@ import java.nio.file.Paths
 import scala.util.control.NonFatal
 
 import scala.meta.internal.builds.BazelBuildTool
-import scala.meta.internal.metals.BloopServers
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.Embedded
 import scala.meta.internal.metals.FormattingProvider
 import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.bloop.BloopServers
 import scala.meta.internal.metals.debug.server.MetalsDebugToolsResolver
 import scala.meta.internal.metals.debug.server.testing.TestInternals
 import scala.meta.internal.metals.logging.MetalsLogger


### PR DESCRIPTION
~Also, BloopJvmProperties (trait and companion object) has been moved from UserConfiguration.scala into a separate file.~

# DO NOT REBASE
(merge with a merge commit instead)