### PR TITLE
bugfix: Fix renaming protobuf-generated Java types

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -37,6 +37,7 @@ object Configs {
         (List(
           new FileSystemWatcher(JEither.forLeft(s"$root/**/*.scala")),
           new FileSystemWatcher(JEither.forLeft(s"$root/**/*.java")),
+          new FileSystemWatcher(JEither.forLeft(s"$root/**/*.proto")),
           new FileSystemWatcher(JEither.forLeft(s"$root/*.sbt")),
           new FileSystemWatcher(JEither.forLeft(s"$root/**/pom.xml")),
           new FileSystemWatcher(JEither.forLeft(s"$root/*.sc")),

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -153,8 +153,6 @@ abstract class MetalsLspService(
   protected val cancelables = new MutableCancelable()
   val isCancelled = new AtomicBoolean(false)
   val wasInitialized = new AtomicBoolean(false)
-  // Tracks whether proto files have been saved since the last Java PC restart.
-  private val protoFilesHaveChanged = new AtomicBoolean(false)
 
   override def cancel(): Unit = {
     if (isCancelled.compareAndSet(false, true)) {
@@ -998,11 +996,6 @@ abstract class MetalsLspService(
     scalaCli.didFocus(path)
     syncStatusReporter.didFocus(uri)
 
-    // Restart Java PCs if proto files have been saved since last Java file focus
-    if (path.isJavaFilename && protoFilesHaveChanged.getAndSet(false)) {
-      compilers.restartJavaCompilers()
-    }
-
     val future =
       if (isDependencySource(path)) {
         diagnostics.publishDiagnosticsNotAdjusted(path, Nil)
@@ -1130,9 +1123,10 @@ abstract class MetalsLspService(
     val path = params.getTextDocument.getUri.toAbsolutePath
     savedFiles.add(path)
     mbt2.didSave(path)
-    // Invalidate proto cache and track change so we restart Java PCs on next focus
+    // The Java presentation compiler caches resolved symbols from the
+    // synthesized proto outline and won't re-request them until restarted.
     if (path.isProtoFilename) {
-      protoFilesHaveChanged.set(true)
+      compilers.restartJavaCompilers()
     }
     Future
       .sequence(
@@ -1221,6 +1215,15 @@ abstract class MetalsLspService(
       case None =>
         Future.successful(())
     })
+    // A proto file can change on disk without ever going through didSave,
+    // for example when a rename's workspace edit is applied to a file that
+    // isn't open in an editor. Without this, the synthesized outline and
+    // the Java presentation compiler's cached symbols go stale until the
+    // next full restart.
+    if (paths.exists(_.isProtoFilename)) {
+      paths.filter(_.isProtoFilename).foreach(mbt2.didSave)
+      compilers.restartJavaCompilers()
+    }
     futures += onChange(paths)
     Future.sequence(futures.result()).ignoreValue
   }
@@ -1231,7 +1234,8 @@ abstract class MetalsLspService(
    */
   protected def fileWatchFilter(path: Path): Boolean = {
     val abs = AbsolutePath(path)
-    abs.isScalaOrJava || abs.isSemanticdb || abs.isInBspDirectory(folder)
+    abs.isScalaOrJava || abs.isProtoFilename || abs.isSemanticdb ||
+    abs.isInBspDirectory(folder)
   }
 
   protected def onChange(paths: Seq[AbsolutePath]): Future[Unit] = {

--- a/tests/unit/src/test/scala/tests/p/ProtoPCJavaSuite.scala
+++ b/tests/unit/src/test/scala/tests/p/ProtoPCJavaSuite.scala
@@ -1358,4 +1358,70 @@ class ProtoPCJavaSuite extends BaseProtoPCSuite("proto-pc-java") {
       )
     } yield ()
   }
+
+  // Regression test: same scenario as "proto-rename-invalidates-java" above,
+  // but WITHOUT the extra didFocus after the proto save. A live F2 rename in
+  // the editor never re-focuses the already-open Java file, so the Java PC
+  // restart that surfaces the "cannot find symbol" error must happen at
+  // didSave time for the .proto file, not be deferred until the next time the
+  // user happens to focus a Java file.
+  test("proto-rename-invalidates-java-without-refocus") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a": {}}
+           |/a/src/main/proto/model.proto
+           |syntax = "proto3";
+           |package com.example.api;
+           |option java_package = "com.example.api.jproto";
+           |option java_multiple_files = true;
+           |message User {
+           |  string name = 1;
+           |}
+           |/a/src/main/java/com/example/Service.java
+           |package com.example;
+           |import com.example.api.jproto.User;
+           |public class Service {
+           |  public void process(User user) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/proto/model.proto")
+      _ <- server.didOpen("a/src/main/java/com/example/Service.java")
+      _ <- server.didFocus("a/src/main/java/com/example/Service.java")
+      // Initially no errors - User class is found from proto
+      _ = assertNoDiagnostics()
+
+      // Rename User to Customer in the proto file and save. The Java file
+      // itself is neither edited nor refocused.
+      _ <- server.didChange("a/src/main/proto/model.proto") { _ =>
+        """|syntax = "proto3";
+           |package com.example.api;
+           |option java_package = "com.example.api.jproto";
+           |option java_multiple_files = true;
+           |message Customer {
+           |  string name = 1;
+           |}
+           |""".stripMargin
+      }
+      _ <- server.didSave("a/src/main/proto/model.proto")
+
+      // The save itself must be enough: User no longer exists.
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/java/com/example/Service.java:2:30: error: cannot find symbol
+           |  symbol:   class User
+           |  location: package com.example.api.jproto
+           |import com.example.api.jproto.User;
+           |                             ^^^^^
+           |a/src/main/java/com/example/Service.java:4:23: error: cannot find symbol
+           |  symbol:   class User
+           |  location: class com.example.Service
+           |  public void process(User user) {}
+           |                      ^^^^
+           |""".stripMargin,
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
Fixes issue #8653

## Summary

A live rename never refocuses the Java file it just edited, and proto files weren't watched at all, so the Java PC's cached symbols could go stale until a full restart. Now both didSave and didChangeWatchedFiles restart it immediately.

## Test steps
* open https://github.com/buildfarm/buildfarm.git
* go to buildfarm/persistentworkers/src/main/java/persistent/bazel/processes/WorkRequestHandler.java
* select WorkResponse
* press F2
* rename WorkResponse to WorkResponse2 (or something else)

**Expected behavior**
The type is renamed
Go-To definition works

**Actual behavior**
The selected type is renamed but is underscored. There's an error saying 
```
cannot find symbol
  symbol:   class WorkResponse2
  location: class com.google.devtools.build.lib.worker.WorkerProtocoljavac(compiler.err.cant.resolve.location)
```

## Before (2.0.0-M15)
https://github.com/user-attachments/assets/caad0cb5-12ea-478f-874c-0cb0467e68e5

## After (local snapshot)
https://github.com/user-attachments/assets/2ebc46ed-3a53-438d-979e-f17fea8ec01f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Java diagnostics now refresh immediately when Scala protobuf definitions are saved or changed.
  - Renaming or removing a protobuf message updates related Java errors without requiring the Java file to be refocused.
  - Protobuf files are now monitored for workspace changes to ensure dependent code stays current.

- **Tests**
  - Added regression coverage for Java diagnostics after protobuf message renames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->