### PR TITLE
Fix Bazel JUnit 6 tests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMavenJsonImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMavenJsonImporter.scala
@@ -199,7 +199,11 @@ object BazelMavenJsonImporter {
    * project hub, but it holds the ruleset's dependencies — not the project's —
    * so it must never be reported as the project's Maven repository.
    */
-  private val internalHubNames = Set(HubName("rules_jvm_external_deps"))
+  private val internalHubNames = Set(
+    HubName("rules_jvm_external_deps"),
+    HubName("contrib_rules_jvm_deps"),
+    HubName("rules_jvm_external"),
+  )
 
   /**
    * A rules_jvm_external hub's apparent repository name, already canonicalized


### PR DESCRIPTION
Fixes #8515 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bazel Maven dependency discovery by excluding additional internal rule hubs from project repositories.
  - Bazel workspace extraction now handles missing Maven lockfiles by attempting to generate them automatically before continuing.
  - If lockfile generation cannot be completed, extraction reports a warning instead of failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->