### PR TITLE
performance: Avoid repeated calls to StringOps#split in DocumentSymbolProvider#javaDocumentSymbols

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
@@ -59,10 +59,10 @@ final class DocumentSymbolProvider(
     val doc = mtags().index(input, dialects.Scala213)
     val occurrences =
       doc.occurrences.iterator.map(occ => occ.symbol -> occ).toMap
-    def lineContent(pos: Position): String = {
-      val lines = pos.input.text.split('\n')
-      if (pos.startLine >= 0 && pos.startLine < lines.length)
-        lines(pos.startLine)
+    val lines = input.text.split('\n')
+    def lineContent(startLine: Int): String = {
+      if (startLine >= 0 && startLine < lines.length)
+        lines(startLine)
       else ""
     }
     val symbols = (for {
@@ -76,7 +76,7 @@ final class DocumentSymbolProvider(
         None
       }
     } yield {
-      val detail = lineContent(pos)
+      val detail = lineContent(pos.startLine)
       val name =
         if (info.kind.isConstructor) Symbol(info.symbol).owner.displayName
         else info.displayName


### PR DESCRIPTION
## Summary

`DocumentSymbolProvider#javaDocumentSymbols` splits the content of the input file into lines.
In the version `main-v2` it's done multiple times (per symbol occurrence)
Since the input is shared between the resulting Position objects, we could split it once and reuse it

## Test steps
* install async-profiler https://github.com/async-profiler/async-profiler
* add a large Java file to the project currently opened in Metals - I used a file based on this Protobuf definition https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto 
[DescriptorProtos.java](https://github.com/user-attachments/files/30402974/DescriptorProtos.java)

* close VS Code
* open VS Code
* open some other Java file to trigger Metals initialization
* wait until Metals is initialized
* start async-profiler
* open the newly-added large Java file
* stop async-profiler
* check the flamegraph

I used this script for saving flamegraphs
[profile-metals.sh](https://github.com/user-attachments/files/30403041/profile-metals.sh)

### Before
<img width="1903" height="863" alt="Screenshot 2026-07-27 at 09 05 43" src="https://github.com/user-attachments/assets/0a16dc46-0c23-4b55-b594-2a662707c17e" />

[metals-9196-20260727-085721.html](https://github.com/user-attachments/files/30402895/metals-9196-20260727-085721.html)

### After
<img width="1903" height="863" alt="Screenshot 2026-07-27 at 09 13 34" src="https://github.com/user-attachments/assets/e4a6bf72-4b3e-4bcd-a1e6-2ea1ba402c82" />

[metals-9437-20260727-085808.html](https://github.com/user-attachments/files/30402890/metals-9437-20260727-085808.html)