### PR TITLE
bugfix: Use Scala 3 dialect for sbt 2.x *.sbt files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -337,7 +337,7 @@ object SbtBuildTool {
     val writtenPlugin =
       writePlugins(mainMeta, metalsPluginDetails, debugAdapterPluginDetails)
     val isSbt2 =
-      SbtBuildTool.loadVersion(projectRoot).exists(_.startsWith("2."))
+      SbtBuildTool.loadVersion(projectRoot).exists(ScalaVersions.isSbt2Version)
     if (isSbt2) {
       val writtenMeta = writePlugins(
         metaMeta,
@@ -465,6 +465,22 @@ object SbtBuildTool {
       finally in.close()
       Option(props.getProperty("sbt.version"))
     }
+  }
+
+  /** `sbt.version` from the nearest `project/build.properties` above `sbtFile`. */
+  def loadVersionForPath(sbtFile: AbsolutePath): Option[String] = {
+    @tailrec
+    def loop(dir: AbsolutePath): Option[String] = {
+      loadVersion(dir) match {
+        case some @ Some(_) => some
+        case None =>
+          dir.parentOpt match {
+            case Some(parent) => loop(parent)
+            case None => None
+          }
+      }
+    }
+    loop(sbtFile.parent)
   }
 
   def sbtInputPosAdjustment(

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -43,7 +43,8 @@ case class ScalaTarget(
     )
 
   def dialect(path: AbsolutePath): Dialect =
-    if (info.isSbtBuild && path.isSbt) Sbt
+    if (info.isSbtBuild && path.isSbt)
+      ScalaVersions.dialectForSbtVersion(sbtVersion)
     else scalaDialect
 
   private def scalaDialect: Dialect = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -44,7 +44,7 @@ case class ScalaTarget(
 
   def dialect(path: AbsolutePath): Dialect =
     if (info.isSbtBuild && path.isSbt)
-      ScalaVersions.dialectForSbtVersion(sbtVersion)
+      scalaDialect.withAllowToplevelTerms(true)
     else scalaDialect
 
   private def scalaDialect: Dialect = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals
 
 import scala.meta._
+import scala.meta.internal.builds.SbtBuildTool
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 
@@ -55,7 +56,12 @@ class ScalaVersionSelector(
         dialectFromBuildTarget(path).getOrElse(
           fallbackDialect()
         )
-      case Some("sbt") => dialects.Sbt
+      case Some("sbt") =>
+        dialectFromBuildTarget(path).getOrElse(
+          ScalaVersions.dialectForSbtVersion(
+            SbtBuildTool.loadVersionForPath(path)
+          )
+        )
       case Some("sc") =>
         val dialect = dialectFromBuildTarget(path).getOrElse(
           fallbackDialect()

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -138,6 +138,18 @@ class ScalaVersions(
     }
   }
 
+  /** Scalameta dialect for `*.sbt` files for the given sbt version. */
+  def dialectForSbtVersion(sbtVersion: Option[String]): Dialect =
+    sbtVersion match {
+      case Some(version) if isSbt2Version(version) =>
+        Scala3.withAllowToplevelTerms(true)
+      case _ =>
+        Sbt
+    }
+
+  def isSbt2Version(sbtVersion: String): Boolean =
+    sbtVersion.startsWith("2.")
+
   def fmtDialectForScalaVersion(
       scalaVersion: String,
       includeSource3: Boolean,

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -138,7 +138,7 @@ class ScalaVersions(
     }
   }
 
-  /** Scalameta dialect for `*.sbt` files for the given sbt version. */
+  /** Scalameta dialect for `*.sbt` from an sbt version string. */
   def dialectForSbtVersion(sbtVersion: Option[String]): Dialect =
     sbtVersion match {
       case Some(version) if isSbt2Version(version) =>

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -78,7 +78,7 @@ object TestGroups {
     "tests.digest.GradleDigestSuite", "tests.DetectionSuite",
     "tests.NewFileTemplateSuite", "tests.ScalaVersionsSuite",
     "tests.HttpServerSuite", "tests.BatchedFunctionSuite",
-    "tests.SbtVersionSuite", "tests.MessagesSuite",
+    "tests.SbtVersionSuite", "tests.SbtDialectSuite", "tests.MessagesSuite",
     "tests.TrigramSubstringsSuite", "tests.SelectBspServerSuite",
     "tests.InverseDependenciesSuite", "tests.TimerSuite",
     "tests.FoldingRangesSuite", "tests.SelectionRangeLspSuite",

--- a/tests/unit/src/test/scala/tests/SbtDialectSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtDialectSuite.scala
@@ -1,0 +1,174 @@
+package tests
+
+import java.nio.file.Paths
+
+import scala.meta._
+import scala.meta.dialects
+import scala.meta.internal.builds.SbtBuildTool
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaTarget
+import scala.meta.internal.metals.ScalaVersionSelector
+import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.{BuildInfo => V}
+import scala.meta.io.AbsolutePath
+
+import ch.epfl.scala.bsp4j.BuildTarget
+import ch.epfl.scala.bsp4j.BuildTargetCapabilities
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import ch.epfl.scala.bsp4j.ScalaBuildTarget
+import ch.epfl.scala.bsp4j.ScalaPlatform
+import ch.epfl.scala.bsp4j.ScalacOptionsItem
+
+class SbtDialectSuite extends BaseSuite {
+
+  private val significantIndentSbt =
+    """|val x = "3" match
+       |  case "3" => 1
+       |  case _   => 0
+       |""".stripMargin
+
+  private val bracedSbt =
+    """|val x = "3" match {
+       |  case "3" => 1
+       |  case _   => 0
+       |}
+       |""".stripMargin
+
+  private def parseOk(code: String, dialect: Dialect): Boolean =
+    Input.String(code).safeParse[Source](dialect).toOption.isDefined
+
+  private def emptySelector(): ScalaVersionSelector =
+    new ScalaVersionSelector(() => UserConfiguration(), BuildTargets.empty)
+
+  private def sbtMetaTarget(
+      scalaVersion: String,
+      sbtVersion: String,
+  ): ScalaTarget = {
+    val id = new BuildTargetIdentifier("sbt-meta")
+    val capabilities = new BuildTargetCapabilities()
+    val info = new BuildTarget(
+      id,
+      Nil.asJava,
+      Nil.asJava,
+      Nil.asJava,
+      capabilities,
+    )
+    info.setDisplayName("sbt-meta")
+    info.setDataKind("sbt")
+    val scalaInfo = new ScalaBuildTarget(
+      "org.scala-lang",
+      scalaVersion,
+      ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion),
+      ScalaPlatform.JVM,
+      Nil.asJava,
+    )
+    val scalac = new ScalacOptionsItem(id, Nil.asJava, Nil.asJava, "")
+    ScalaTarget(
+      info,
+      scalaInfo,
+      scalac,
+      autoImports = None,
+      sbtVersion = Some(sbtVersion),
+      bspConnection = None,
+    )
+  }
+
+  test("dialectForSbtVersion-fallback") {
+    assertEquals(
+      ScalaVersions.dialectForSbtVersion(Some("1.11.2")),
+      dialects.Sbt,
+    )
+    assertEquals(
+      ScalaVersions.dialectForSbtVersion(None),
+      dialects.Sbt,
+    )
+    val sbt2 = ScalaVersions.dialectForSbtVersion(Some("2.0.4"))
+    assert(sbt2.allowSignificantIndentation)
+    assert(sbt2.allowToplevelTerms)
+  }
+
+  test("fallback-getDialect-sbt2-parses-significant-indentation") {
+    val root = FileLayout.fromString(
+      s"""|/project/build.properties
+         |sbt.version=2.0.4
+         |/build.sbt
+         |$significantIndentSbt
+         |""".stripMargin
+    )
+    val path = root.resolve("build.sbt")
+    val dialect = emptySelector().getDialect(path)
+    assert(dialect.allowSignificantIndentation)
+    assert(dialect.allowToplevelTerms)
+    assert(parseOk(path.readText, dialect))
+  }
+
+  test("fallback-getDialect-sbt1-rejects-significant-indentation") {
+    val root = FileLayout.fromString(
+      s"""|/project/build.properties
+         |sbt.version=1.11.2
+         |/build.sbt
+         |$significantIndentSbt
+         |""".stripMargin
+    )
+    val path = root.resolve("build.sbt")
+    val dialect = emptySelector().getDialect(path)
+    assertEquals(dialect, dialects.Sbt)
+    assert(!dialect.allowSignificantIndentation)
+    assert(!parseOk(path.readText, dialect))
+    assert(parseOk(bracedSbt, dialect))
+  }
+
+  test("fallback-plugins.sbt-uses-workspace-sbt-version") {
+    val root = FileLayout.fromString(
+      """|/project/build.properties
+         |sbt.version=2.0.4
+         |/build.sbt
+         |val x = 1
+         |/project/plugins.sbt
+         |addSbtPlugin("com.example" % "example" % "1.0")
+         |""".stripMargin
+    )
+    assertEquals(
+      SbtBuildTool.loadVersionForPath(root.resolve("build.sbt")),
+      Some("2.0.4"),
+    )
+    assertEquals(
+      SbtBuildTool.loadVersionForPath(root.resolve("project/plugins.sbt")),
+      Some("2.0.4"),
+    )
+    val dialect =
+      emptySelector().getDialect(root.resolve("project/plugins.sbt"))
+    assert(dialect.allowSignificantIndentation)
+  }
+
+  test("build-target-sbt2-uses-scala-dialect-with-toplevel-terms") {
+    val target = sbtMetaTarget(V.scala3, "2.0.4")
+    val path = AbsolutePath(Paths.get("/workspace/build.sbt"))
+    val dialect = target.dialect(path)
+    assert(dialect.allowSignificantIndentation)
+    assert(dialect.allowToplevelTerms)
+    assert(parseOk(significantIndentSbt, dialect))
+    assert(parseOk(bracedSbt, dialect))
+  }
+
+  test("build-target-sbt1-uses-scala-dialect-with-toplevel-terms") {
+    val target = sbtMetaTarget(V.scala212, "1.11.2")
+    val path = AbsolutePath(Paths.get("/workspace/build.sbt"))
+    val dialect = target.dialect(path)
+    assert(dialect.allowToplevelTerms)
+    assert(!dialect.allowSignificantIndentation)
+    assert(!parseOk(significantIndentSbt, dialect))
+    assert(parseOk(bracedSbt, dialect))
+  }
+
+  test("build-target-non-sbt-path-keeps-scala-dialect") {
+    val target = sbtMetaTarget(V.scala3, "2.0.4")
+    val path = AbsolutePath(Paths.get("/workspace/project/Deps.scala"))
+    val dialect = target.dialect(path)
+    assert(dialect.allowSignificantIndentation)
+    assert(!dialect.allowToplevelTerms)
+  }
+
+}

--- a/tests/unit/src/test/scala/tests/SbtDialectSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtDialectSuite.scala
@@ -92,10 +92,10 @@ class SbtDialectSuite extends BaseSuite {
   test("fallback-getDialect-sbt2-parses-significant-indentation") {
     val root = FileLayout.fromString(
       s"""|/project/build.properties
-         |sbt.version=2.0.4
-         |/build.sbt
-         |$significantIndentSbt
-         |""".stripMargin
+          |sbt.version=2.0.4
+          |/build.sbt
+          |$significantIndentSbt
+          |""".stripMargin
     )
     val path = root.resolve("build.sbt")
     val dialect = emptySelector().getDialect(path)
@@ -107,10 +107,10 @@ class SbtDialectSuite extends BaseSuite {
   test("fallback-getDialect-sbt1-rejects-significant-indentation") {
     val root = FileLayout.fromString(
       s"""|/project/build.properties
-         |sbt.version=1.11.2
-         |/build.sbt
-         |$significantIndentSbt
-         |""".stripMargin
+          |sbt.version=1.11.2
+          |/build.sbt
+          |$significantIndentSbt
+          |""".stripMargin
     )
     val path = root.resolve("build.sbt")
     val dialect = emptySelector().getDialect(path)

--- a/tests/unit/src/test/scala/tests/SbtVersionSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtVersionSuite.scala
@@ -1,6 +1,10 @@
 package tests
 
+import scala.meta.dialects
 import scala.meta.internal.builds.SbtBuildTool
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.ScalaVersionSelector
+import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.UserConfiguration
 
 import munit.Location
@@ -35,5 +39,74 @@ class SbtVersionSuite extends BaseSuite {
     """.stripMargin,
     "1.1.3",
   )
+
+  test("loadVersionForPath") {
+    val root = FileLayout.fromString(
+      """|/project/build.properties
+         |sbt.version=2.0.4
+         |/build.sbt
+         |scalaVersion := "3.3.4"
+         |/project/plugins.sbt
+         |addSbtPlugin("com.example" % "example" % "1.0")
+         |""".stripMargin
+    )
+    assertEquals(
+      SbtBuildTool.loadVersionForPath(root.resolve("build.sbt")),
+      Some("2.0.4"),
+    )
+    assertEquals(
+      SbtBuildTool.loadVersionForPath(root.resolve("project/plugins.sbt")),
+      Some("2.0.4"),
+    )
+  }
+
+  test("dialectForSbtVersion") {
+    assertEquals(
+      ScalaVersions.dialectForSbtVersion(Some("1.11.2")),
+      dialects.Sbt,
+    )
+    assertEquals(
+      ScalaVersions.dialectForSbtVersion(None),
+      dialects.Sbt,
+    )
+    val sbt2 = ScalaVersions.dialectForSbtVersion(Some("2.0.4"))
+    assert(sbt2.allowSignificantIndentation)
+    assert(sbt2.allowToplevelTerms)
+  }
+
+  test("getDialect-sbt2") {
+    val root = FileLayout.fromString(
+      """|/project/build.properties
+         |sbt.version=2.0.4
+         |/build.sbt
+         |val x = 1
+         |""".stripMargin
+    )
+    val selector = new ScalaVersionSelector(
+      () => UserConfiguration(),
+      BuildTargets.empty,
+    )
+    val dialect = selector.getDialect(root.resolve("build.sbt"))
+    assert(dialect.allowSignificantIndentation)
+    assert(dialect.allowToplevelTerms)
+  }
+
+  test("getDialect-sbt1") {
+    val root = FileLayout.fromString(
+      """|/project/build.properties
+         |sbt.version=1.11.2
+         |/build.sbt
+         |val x = 1
+         |""".stripMargin
+    )
+    val selector = new ScalaVersionSelector(
+      () => UserConfiguration(),
+      BuildTargets.empty,
+    )
+    assertEquals(
+      selector.getDialect(root.resolve("build.sbt")),
+      dialects.Sbt,
+    )
+  }
 
 }

--- a/tests/unit/src/test/scala/tests/SbtVersionSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtVersionSuite.scala
@@ -1,10 +1,6 @@
 package tests
 
-import scala.meta.dialects
 import scala.meta.internal.builds.SbtBuildTool
-import scala.meta.internal.metals.BuildTargets
-import scala.meta.internal.metals.ScalaVersionSelector
-import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.UserConfiguration
 
 import munit.Location
@@ -57,55 +53,6 @@ class SbtVersionSuite extends BaseSuite {
     assertEquals(
       SbtBuildTool.loadVersionForPath(root.resolve("project/plugins.sbt")),
       Some("2.0.4"),
-    )
-  }
-
-  test("dialectForSbtVersion") {
-    assertEquals(
-      ScalaVersions.dialectForSbtVersion(Some("1.11.2")),
-      dialects.Sbt,
-    )
-    assertEquals(
-      ScalaVersions.dialectForSbtVersion(None),
-      dialects.Sbt,
-    )
-    val sbt2 = ScalaVersions.dialectForSbtVersion(Some("2.0.4"))
-    assert(sbt2.allowSignificantIndentation)
-    assert(sbt2.allowToplevelTerms)
-  }
-
-  test("getDialect-sbt2") {
-    val root = FileLayout.fromString(
-      """|/project/build.properties
-         |sbt.version=2.0.4
-         |/build.sbt
-         |val x = 1
-         |""".stripMargin
-    )
-    val selector = new ScalaVersionSelector(
-      () => UserConfiguration(),
-      BuildTargets.empty,
-    )
-    val dialect = selector.getDialect(root.resolve("build.sbt"))
-    assert(dialect.allowSignificantIndentation)
-    assert(dialect.allowToplevelTerms)
-  }
-
-  test("getDialect-sbt1") {
-    val root = FileLayout.fromString(
-      """|/project/build.properties
-         |sbt.version=1.11.2
-         |/build.sbt
-         |val x = 1
-         |""".stripMargin
-    )
-    val selector = new ScalaVersionSelector(
-      () => UserConfiguration(),
-      BuildTargets.empty,
-    )
-    assertEquals(
-      selector.getDialect(root.resolve("build.sbt")),
-      dialects.Sbt,
     )
   }
 


### PR DESCRIPTION
## Summary
- After build import, `*.sbt` dialects follow the Mill/worksheet pattern: reuse the meta-build `scalaDialect` with `allowToplevelTerms`
- Before import, fall back to `project/build.properties` (`dialectForSbtVersion`) so sbt 2.x still gets Scala 3 syntax
- Fixes false Scalameta parse errors on valid Scala 3 syntax such as significant-indentation `match` (see #8752)

## Test plan
- [x] `tests.SbtDialectSuite` (7 tests): pre-import fallback for sbt 1/2, `plugins.sbt` version walk, build-target dialect for sbt 1/2, non-`.sbt` meta sources, and actual parse of significant-indentation vs braced `match`
- [x] `tests.SbtVersionSuite` (`loadVersionForPath`)
- [ ] Open an sbt 2.x workspace with significant-indentation syntax in `build.sbt` and confirm no `'{' expected but 'case' found` diagnostic
- [ ] Confirm sbt 1.x workspaces still parse with the Scala 2 sbt dialect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for detecting the SBT version from project build files.
  - SBT 2 projects now use the appropriate Scala 3 dialect, including support for top-level terms.
  - Legacy and unknown SBT versions continue using the compatible SBT dialect.
  - Dialect selection now applies consistently across SBT files and build targets.

- **Tests**
  - Added coverage for SBT version discovery and dialect selection across supported SBT versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->