### PR TITLE
Bugfix: Handle the extensions keyword in proto files

### DIFF
--- a/semanticdb-protoc/src/main/java/scala/meta/internal/proto/parse/Parser.java
+++ b/semanticdb-protoc/src/main/java/scala/meta/internal/proto/parse/Parser.java
@@ -699,6 +699,7 @@ public final class Parser {
     int startPos = currentPos();
     expectIdentifier("extensions");
     ImmutableList<Proto.Range> ranges = parseRanges();
+    parseFieldOptions();
     expectSymbol(';');
     return new ExtensionsDecl(startPos, currentPos(), ranges);
   }

--- a/tests/protopc/src/test/scala/pc/ParserEdgeCasesSuite.scala
+++ b/tests/protopc/src/test/scala/pc/ParserEdgeCasesSuite.scala
@@ -125,6 +125,24 @@ class ParserEdgeCasesSuite extends FunSuite {
        |""".stripMargin,
   )
 
+  // Bracketed options on an extension range, as upstream `descriptor.proto` has.
+  // The message literal spans lines and separates fields with neither commas nor
+  // semicolons.
+  parseOk(
+    "extensions-range-with-declaration-options",
+    """|syntax = "proto2";
+       |message FileDescriptorSet {
+       |  optional string name = 1;
+       |  extensions 536000000 [declaration = {
+       |    number: 536000000
+       |    type: ".buf.descriptor.v1.FileDescriptorSetExtension"
+       |    full_name: ".buf.descriptor.v1.buf_file_descriptor_set_extension"
+       |  }];
+       |  extensions 1000 to max [verification = UNVERIFIED];
+       |}
+       |""".stripMargin,
+  )
+
   parseOk(
     "group-declaration",
     """|syntax = "proto2";


### PR DESCRIPTION
An extension range may carry bracketed options, for example:

    extensions 536000000 [declaration = {
      number: 536000000
      type: ".buf.descriptor.v1.FileDescriptorSetExtension"
    }];

The parser went straight from the range list to the terminating `;` and failed with `Expected ';', got: [`, which loses the outline for the whole file rather than just that declaration.

`parseFieldOptions` already handles the bracket list and brace-counts message literals, so consuming the options with it is enough. They are parsed and dropped: an extension range declares no symbol.

## Test steps
* create a .proto file with an extensions section
* import the file in a Java file
* create a message defined in the proto file
* go to the definition of the message type

## Actual behavior (main-v2)
The proto parser throws an exception like this one
```
scala.meta.internal.proto.diag.ProtoError: file:///Users/dkus/Documents/Projects/bytecode-protobuf-navigation/proto/extension_range.proto:24:18: Expected ';', got: [
	at scala.meta.internal.proto.parse.Parser.error(Parser.java:892)
	at scala.meta.internal.proto.parse.Parser.expectSymbol(Parser.java:807)
	at scala.meta.internal.proto.parse.Parser.parseExtensions(Parser.java:702)
	at scala.meta.internal.proto.parse.Parser.parseMessage(Parser.java:328)
	at scala.meta.internal.proto.parse.Parser.parseFile(Parser.java:86)
	at scala.meta.internal.proto.parse.Parser.parse(Parser.java:36)
	at scala.meta.internal.metals.mbt.MbtProtobufWorkspaceSymbolProvider.$anonfun$allJavaOutlines$1(MbtProtobufWorkspaceSymbolProvider.scala:106)
	at scala.meta.internal.metals.mbt.IndexedDocument.getOrComputeJavaOutlines(IndexedDocument.scala:53)
	at scala.meta.internal.metals.mbt.MbtProtobufWorkspaceSymbolProvider.allJavaOutlines(MbtProtobufWorkspaceSymbolProvider.scala:102)
	at scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider.$anonfun$turbineCompiler$4(MbtWorkspaceSymbolProvider.scala:163)
	at scala.collection.immutable.List.flatMap(List.scala:283)
	at scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider.$anonfun$turbineCompiler$2(MbtWorkspaceSymbolProvider.scala:162)
	at scala.meta.internal.metals.mbt.TurbineCompiler$.$anonfun$parseInputs$1(TurbineCompiler.scala:78)
	at scala.meta.internal.metals.mbt.TurbineCompiler$.$anonfun$parseInputs$1$adapted(TurbineCompiler.scala:75)
	at scala.collection.parallel.mutable.ParArray$ParArrayIterator.foreach_quick(ParArray.scala:149)
	at scala.collection.parallel.mutable.ParArray$ParArrayIterator.foreach(ParArray.scala:142)
	at scala.collection.parallel.ParIterableLike$Foreach.leaf(ParIterableLike.scala:938)
	at scala.collection.parallel.Task.$anonfun$tryLeaf$1(Tasks.scala:52)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at scala.util.control.Breaks$$anon$1.catchBreak(Breaks.scala:97)
	at scala.collection.parallel.Task.tryLeaf(Tasks.scala:55)
	at scala.collection.parallel.Task.tryLeaf$(Tasks.scala:49)
	at scala.collection.parallel.ParIterableLike$Foreach.tryLeaf(ParIterableLike.scala:935)
	at scala.collection.parallel.AdaptiveWorkStealingTasks$AWSTWrappedTask.compute(Tasks.scala:152)
	at scala.collection.parallel.AdaptiveWorkStealingTasks$AWSTWrappedTask.compute$(Tasks.scala:148)
	at scala.collection.parallel.AdaptiveWorkStealingForkJoinTasks$AWSFJTWrappedTask.compute(Tasks.scala:304)
	at java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

## Expected behavior (fix)
Parsing succeeds