### PR TITLE
Dependencies not showing up in Bazel-based mbt.json

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -146,7 +146,12 @@ class MbtWorkspaceSymbolProvider(
       file =>
         if (file.toLanguage.isJava) {
           toInput(file)
-            .map(input => new SourceFile(file.toString(), input.text))
+            .map(input =>
+              new SourceFile(
+                file.toNIO.toAbsolutePath.normalize().toString,
+                input.text,
+              )
+            )
             .toList
         } else if (
           file.isProtoFilename &&
@@ -161,7 +166,12 @@ class MbtWorkspaceSymbolProvider(
           for {
             doc <- documents.get(file).toList
             outline <- protobufWorkspace.allJavaOutlines(doc)
-          } yield new SourceFile(outline.getName(), outline.text)
+          } yield {
+            val name = outline.uri()
+            val path = java.nio.file.Path.of(name)
+            val cleanOutlinePath = path.toAbsolutePath().normalize().toString()
+            new SourceFile(cleanOutlinePath, outline.text)
+          }
         } else {
           Nil
         },


### PR DESCRIPTION
Fixes #8546 

Metals version: main-v2
OS: Windows

Steps to reproduce:
- clone [bazel ](https://github.com/bazelbuild/bazel) on Windows
- build the bazel project with 
```
bazel build //...
```
- start Cursor/VS Code
- open `TestCustomGreeting.java`

You will see eleven errors.
This issue has been introduced by the following commit: https://github.com/scalameta/metals/pull/8699/changes/69aaa6d32fb7b9bf82cedb9a9771167e082df410

When `TurbineCompiler` is created, this code adds the `parseUnit` variable as URL (file:///....) instead of adding it as a path which is the cause of `InvalidPathException` in `TurbineCompiler.compileClassfilesInternal`. 
Because of that, Metals V2 only recognizes JDK classes in `TestCustomGreeting.java`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace symbol indexing for Java source files and generated Protocol Buffer outlines.
  * Added support for Protocol Buffer outline names provided as filesystem paths or URI strings.
  * Improved reliability when processing URI-based outline paths.
  * Standardized path handling to provide more consistent symbol discovery across different workspace locations and path formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->