### PR TITLE
docs: Explain Corfu auto-completion in string interpolators

### DIFF
--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -261,6 +261,29 @@ not exist yet.
 
 ```
 
+#### Automatic completion inside string interpolators
+
+Metals completes identifiers and members inside `$name` and `${ }` splices
+of interpolated strings such as `s"..."` or `sql"""..."""`. Whether the
+completion popup appears while you type is up to the client, not Metals.
+
+With Eglot and [Corfu](https://github.com/minad/corfu), the popup does not
+appear inside an empty `${ }` splice: Corfu auto-completes only after
+`corfu-auto-prefix` typed characters, and at `${|}` the prefix is empty.
+Add Metals' completion trigger characters to `corfu-auto-trigger`:
+
+```elisp
+(setq corfu-auto-trigger ".${")
+```
+
+- `$` opens the popup the moment a splice starts, matching other editors.
+- `{` keeps the popup alive across the `${` opener. Drop it if popups on
+  plain `{` blocks bother you.
+- `.` completes members, as in `s"${foo.|}"`.
+
+Otherwise, type one character to trigger the popup, or call
+`completion-at-point` manually.
+
 ```scala mdoc:generic
 
 ```

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -270,11 +270,15 @@ completion popup appears while you type is up to the client, not Metals.
 With Eglot and [Corfu](https://github.com/minad/corfu), the popup does not
 appear inside an empty `${ }` splice: Corfu auto-completes only after
 `corfu-auto-prefix` typed characters, and at `${|}` the prefix is empty.
-Add Metals' completion trigger characters to `corfu-auto-trigger`:
+Teach Corfu the trigger characters for Scala buffers:
 
 ```elisp
-(setq corfu-auto-trigger ".${")
+(add-hook 'scala-mode-hook
+          (lambda () (setq-local corfu-auto-trigger ".${")))
 ```
+
+`corfu-auto-trigger` is a global variable, so scope the setting to
+`scala-mode` to avoid popups on every `{` in other major modes.
 
 - `$` opens the popup the moment a splice starts, matching other editors.
 - `{` keeps the popup alive across the `${` opener. Drop it if popups on


### PR DESCRIPTION
## Problem

Emacs users with Eglot + Corfu get no completion popup inside empty `${ }` splices of interpolated strings (`s"..."`, `sql"""..."""`). This is a recurring source of confusion (e.g. #1394, lsp-mode back then) and reads as "Metals does not complete inside interpolators."

The cause is client-side, a three-layer interaction:

1. At `${|}`, `bounds-of-thing-at-point (quote symbol)` is nil, so the Eglot Capf reports a zero-width completion prefix.
2. Corfu auto-completes only after `corfu-auto-prefix` typed characters, so the auto popup is suppressed.
3. Metals declares `$` as a completion trigger character, but Corfu does not consult server trigger characters.

Each layer is defensible; the composition is a silent dead window.

## Fix

Document the one-line client configuration that restores VS Code parity: add `$` and `{` to `corfu-auto-trigger`. Verified end-to-end against Metals 1.6.5 + Eglot + Corfu with a live server: popup at `s"$|"` (567 candidates), suppressed at `s"${|}"` without the setting, working after one typed character or manual `completion-at-point`.

Docs change only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Emacs guidance for automatic completion inside Scala string interpolator splices.
  * Documented Eglot and Corfu configuration, including automatic completion triggers and manual completion options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->