### PR TITLE
test: Cover completions inside ${ } splices of interpolated strings

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -823,4 +823,95 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
     filter = _.contains("[A]")
   )
 
+  check(
+    "brace-member",
+    """|object Main {
+       |  val foo = ""
+       |  s"Hello ${foo.toStr@@}!"
+       |}
+       |""".stripMargin,
+    """|toString(): String
+       |""".stripMargin,
+    filter = _.contains("toString")
+  )
+
+  check(
+    "brace-member-empty-query",
+    """|object Main {
+       |  val foo = ""
+       |  s"Hello ${foo.@@}!"
+       |}
+       |""".stripMargin,
+    """|toString(): String
+       |""".stripMargin,
+    filter = _.contains("toString")
+  )
+
+  check(
+    "brace-member-triple-quote",
+    """|object Main {
+       |  val foo = ""
+       |  s'''Hello ${foo.toStr@@}!'''
+       |}
+       |""".stripMargin.triplequoted,
+    """|toString(): String
+       |""".stripMargin,
+    filter = _.contains("toString")
+  )
+
+  check(
+    "brace-scope-mid-expression",
+    """|object Main {
+       |  val foo = 1
+       |  val bar = 2
+       |  s"Hello ${foo + ba@@}!"
+       |}
+       |""".stripMargin,
+    """|bar: Int
+       |""".stripMargin,
+    filter = _.contains("bar")
+  )
+
+  check(
+    "brace-member-nested-lambda",
+    """|object Main {
+       |  val xs = List("")
+       |  s"Hello ${xs.map(x => x.toStr@@)}!"
+       |}
+       |""".stripMargin,
+    """|toString(): String
+       |""".stripMargin,
+    filter = _.contains("toString")
+  )
+
+  check(
+    "brace-member-custom-interpolator",
+    """|object Main {
+       |  implicit class XtensionStringContext(c: StringContext) {
+       |    def sql(args: Any*): String = ""
+       |  }
+       |  val foo = ""
+       |  sql"SELECT ${foo.toStr@@}"
+       |}
+       |""".stripMargin,
+    """|toString(): String
+       |""".stripMargin,
+    filter = _.contains("toString")
+  )
+
+  check(
+    "brace-member-custom-interpolator-triple-quote",
+    """|object Main {
+       |  implicit class XtensionStringContext(c: StringContext) {
+       |    def sql(args: Any*): String = ""
+       |  }
+       |  val foo = ""
+       |  sql'''SELECT ${foo.toStr@@}'''
+       |}
+       |""".stripMargin.triplequoted,
+    """|toString(): String
+       |""".stripMargin,
+    filter = _.contains("toString")
+  )
+
 }


### PR DESCRIPTION
## Why

`CompletionInterpolatorSuite` covers `$name` and `$name.member` splices thoroughly, but the `${ }` form only had cases for bare identifiers (`"${myNa@@"`, `"${@@"`). Member selection and mid-expression scope completion inside braces — `s"${foo.toStr@@}"`, `s"${foo + ba@@}"` — had no coverage. These paths dispatch differently (the enclosing tree is the splice argument, not the string literal), so they merit their own cases. Prompted by user reports that completions inside `${ }` do not work (which turned out to be a client-side issue — see scalameta/metals#8765 for the Emacs/Corfu angle).

## What

Seven new cases in `CompletionInterpolatorSuite`:

- member selection with and without a query (`s"${foo.toStr@@}"`, `s"${foo.@@}"`)
- member selection in a triple-quoted string
- scope completion mid-expression (`s"${foo + ba@@}"`)
- member selection nested in a lambda (`s"${xs.map(x => x.toStr@@)}"`)
- custom interpolator (`sql"..."`), single- and triple-quoted

All pass on 2.13.18; `scalafmt --test` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for code completion within brace-enclosed interpolations.
  * Verified completion behavior for member access, empty queries, triple-quoted strings, mid-expression scopes, nested lambdas, and custom interpolators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->