### PR TITLE
Shortened query that selects Bazel targets for importing

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
@@ -54,11 +54,7 @@ object BazelQuery {
     val ps =
       if (patterns.isEmpty) BazelProjectViewTargets.defaultPatterns
       else patterns
-    val parts = for {
-      k <- ruleKinds
-      p <- ps
-    } yield s"kind($k, $p)"
-    val query = parts.mkString(" union ")
+    val query = s"kind('${ruleKinds mkString "|"}', set(${ps mkString " "}))"
     BazelQuery(query, outputMode = Label)
   }
 


### PR DESCRIPTION
Previously, the length of the query was growing like $O(k \cdot p)$, where $k$ is the number of target kinds and $p$ is the number of patterns. Now it grows like $O(k + p)$.

The execution time seems to be roughly the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bazel project importing by consolidating rule matching into a single query.
  * Preserved support for matching multiple rule types and patterns during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->