### PR TITLE
bugfix: stop a build tool restarting its daemon on every debug session

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -150,7 +150,11 @@ object ShellRunner {
   )(implicit ec: ExecutionContext): Option[String] = {
 
     val sbOut = new StringBuilder()
-    val env = additionalEnv ++ maybeJavaHome.map("JAVA_HOME" -> _).toMap
+    // Through `envVariables`, as in `run`: without it the command inherits
+    // whatever `JAVA_HOME` Metals was started with, `/jdk/Home/` here against
+    // the `/jdk/Home` every other command sends. A build tool compares the two
+    // as text and restarts its daemon.
+    val env = additionalEnv ++ JdkSources.envVariables(maybeJavaHome)
     val ps = SystemProcess.run(
       args,
       directory,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
@@ -1,7 +1,6 @@
 package scala.meta.internal.metals.mbt
 
 import java.net.URI
-import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.ExecutionContext
@@ -10,6 +9,7 @@ import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 
 import scala.meta.internal.metals.BaseWorkDoneProgress
+import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.debug.server.BuildToolDebugAdapter
 import scala.meta.internal.metals.debug.server.DebugLogger
 import scala.meta.internal.metals.debug.server.DebugeeParamsCreator
@@ -280,16 +280,13 @@ class MbtDebugSessionStarter(
     }
   }
 
+  /**
+   * Built by [[JdkSources.envVariables]] so that `JAVA_HOME` is spelled the way
+   * the importer's own commands spell it: `/jdk/Home/` against `/jdk/Home` is
+   * enough to restart a build tool's daemon.
+   */
   private def javaHomeEnv(target: MbtTarget): Map[String, String] =
-    target.javaHome
-      .orElse(userJavaHome())
-      .map { raw =>
-        val path =
-          if (raw.startsWith("file:")) Paths.get(URI.create(raw)).toString
-          else raw
-        Map("JAVA_HOME" -> path)
-      }
-      .getOrElse(Map.empty)
+    JdkSources.envVariables(target.javaHome.orElse(userJavaHome()))
 
   private def redactedCommand(command: List[String]): String =
     command.headOption.getOrElse("<empty>")

--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -1,6 +1,8 @@
 package scala.meta.internal.metals
 
+import java.net.URI
 import java.nio.file.Paths
+import java.util.Locale
 
 import scala.util.Failure
 import scala.util.Properties
@@ -33,9 +35,27 @@ object JdkSources {
     }
   }
 
+  /**
+   * Reads a java home written either way: `/jdk/Home` or `file:///jdk/Home`.
+   *
+   * The `file:` spelling reaches Metals two ways: from a build server, whose
+   * `javaHome` BSP types as a URI, and from the Gradle importer, which writes
+   * one into `MbtNamespace.javaHome`. `AbsolutePath` alone would read it as a
+   * relative path whose first element is the scheme, `file:`, so the JDK would
+   * go unnoticed.
+   */
   private def fromString(path: String): Option[AbsolutePath] = {
     Option(path).filter(_.nonEmpty).flatMap { str =>
-      Try(AbsolutePath(str)) match {
+      // Inside the `Try`, since `URI.create` rejects a `file:` URI that no path
+      // can hold: `file://host/jdk` names `/jdk` on a machine called `host`.
+      Try {
+        // `FILE:` as well: a URI scheme is case-insensitive, and `Paths.get`
+        // reads any case. `Locale.ROOT`, since a Turkish locale lowercases
+        // `FILE:` to `fıle:`.
+        if (str.toLowerCase(Locale.ROOT).startsWith("file:"))
+          AbsolutePath(Paths.get(URI.create(str)))
+        else AbsolutePath(str)
+      } match {
         case Failure(exception) =>
           logger.warn(
             s"Failed to parse java home path $str: ${exception.getMessage}"

--- a/tests/unit/src/test/scala/tests/JdkSourcesSuite.scala
+++ b/tests/unit/src/test/scala/tests/JdkSourcesSuite.scala
@@ -4,8 +4,183 @@ import scala.meta.dialects
 import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.mtags.Symbol
+import scala.meta.io.AbsolutePath
 
 class JdkSourcesSuite extends BaseSuite {
+
+  private val withoutUserJavaHome =
+    JdkSources.defaultJavaHome(userJavaHome = None)
+
+  /**
+   * The java home parsed from one spelling, or `None` if parsing failed.
+   *
+   * `defaultJavaHome` always adds the `JAVA_HOME` and `java.home` fallbacks
+   * after it, so a rejected spelling leaves just the fallbacks behind.
+   */
+  private def readJavaHome(javaHomeDirectorySpelling: String): Option[String] =
+    JdkSources.defaultJavaHome(Some(javaHomeDirectorySpelling)) match {
+      case javaHome :: fallbacks if fallbacks == withoutUserJavaHome =>
+        Some(javaHome.toString())
+      case _ => None
+    }
+
+  private def checkJavaHome(
+      name: String,
+      expected: String,
+      javaHomeDirectorySpellings: List[String],
+  ): Unit =
+    test(name) {
+      for (javaHomeDirectorySpelling <- javaHomeDirectorySpellings)
+        assertEquals(
+          obtained = readJavaHome(javaHomeDirectorySpelling),
+          expected = Some(expected),
+          clue = s"read from: $javaHomeDirectorySpelling",
+        )
+    }
+
+  /** Checks that none of the spellings parses into a java home. */
+  private def checkNoJavaHome(
+      name: String,
+      javaHomeDirectorySpellings: List[String],
+  ): Unit =
+    test(name) {
+      for (javaHomeDirectorySpelling <- javaHomeDirectorySpellings)
+        assertEquals(
+          obtained = readJavaHome(javaHomeDirectorySpelling),
+          expected = None,
+          clue = s"read from: $javaHomeDirectorySpelling",
+        )
+    }
+
+  checkNoJavaHome(
+    name = "empty-java-home-falls-back",
+    javaHomeDirectorySpellings = List(""),
+  )
+
+  // A space is not allowed in a URI, so `URI.create` rejects both spellings on
+  // every platform and Metals falls back to `JAVA_HOME`.
+  checkNoJavaHome(
+    name = "java-home-uri-holding-an-unencoded-space",
+    javaHomeDirectorySpellings = List(
+      "file:///opt/java home/jdk-17",
+      "file:///C:/Program Files/Java/jdk-17",
+    ),
+  )
+
+  if (isWindows) {
+    checkJavaHome(
+      name = "windows-java-home",
+      expected = """C:\Program Files\Java\jdk-17""",
+      javaHomeDirectorySpellings = List(
+        """C:\Program Files\Java\jdk-17""",
+        // The same directory with a trailing separator.
+        """C:\Program Files\Java\jdk-17\""",
+        "file:///C:/Program%20Files/Java/jdk-17",
+        "file:///C:/Program%20Files/Java/jdk-17/",
+        // A URI scheme is case-insensitive.
+        "FILE:///C:/Program%20Files/Java/jdk-17",
+      ),
+    )
+
+    // Windows reads a forward slash as a separator too.
+    checkJavaHome(
+      name = "windows-java-home-spelled-with-forward-slashes",
+      expected = """C:\Program Files\Java\jdk-17""",
+      javaHomeDirectorySpellings = List(
+        "C:/Program Files/Java/jdk-17",
+        "C:/Program Files/Java/jdk-17/",
+      ),
+    )
+
+    // A universal naming convention path points at a share on another machine
+    // instead of a local drive: `\\host\share\jdk-17`. Windows is the only
+    // platform that builds one from a URI authority like `file://host/share`.
+    checkJavaHome(
+      name = "windows-universal-naming-convention-java-home",
+      expected = """\\host\share\jdk-17""",
+      javaHomeDirectorySpellings = List(
+        """\\host\share\jdk-17""",
+        """\\host\share\jdk-17\""",
+        "file://host/share/jdk-17",
+        "file://host/share/jdk-17/",
+      ),
+    )
+  } else {
+    checkJavaHome(
+      name = "linux-java-home",
+      expected = "/usr/lib/jvm/java-17-openjdk-amd64",
+      javaHomeDirectorySpellings = List(
+        "/usr/lib/jvm/java-17-openjdk-amd64",
+        "/usr/lib/jvm/java-17-openjdk-amd64/",
+        "file:///usr/lib/jvm/java-17-openjdk-amd64",
+        "file:///usr/lib/jvm/java-17-openjdk-amd64/",
+        // JDK 8's `Path.toUri` writes a single slash after `file:`.
+        "file:/usr/lib/jvm/java-17-openjdk-amd64",
+        // A URI scheme is case-insensitive.
+        "FILE:///usr/lib/jvm/java-17-openjdk-amd64",
+        "File:///usr/lib/jvm/java-17-openjdk-amd64",
+      ),
+    )
+
+    checkJavaHome(
+      name = "macos-java-home",
+      expected = "/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home",
+      javaHomeDirectorySpellings = List(
+        "/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home",
+        "/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home/",
+        "file:///Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home",
+        "file:///Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home/",
+        "file:/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home",
+      ),
+    )
+
+    checkJavaHome(
+      name = "java-home-holding-a-space",
+      expected = "/opt/java home/jdk-17",
+      javaHomeDirectorySpellings = List(
+        "/opt/java home/jdk-17",
+        "/opt/java home/jdk-17/",
+        "file:///opt/java%20home/jdk-17",
+        "file:///opt/java%20home/jdk-17/",
+      ),
+    )
+
+    // Outside Windows a backslash is part of a file name, so `java\home` is a
+    // single directory and a URI has to encode it as `%5C`.
+    checkJavaHome(
+      name = "java-home-holding-a-backslash",
+      expected = """/opt/java\home/jdk-17""",
+      javaHomeDirectorySpellings = List(
+        """/opt/java\home/jdk-17""",
+        """/opt/java\home/jdk-17/""",
+        "file:///opt/java%5Chome/jdk-17",
+        "file:///opt/java%5Chome/jdk-17/",
+      ),
+    )
+
+    // A backslash separates nothing here, so a Windows path is a single
+    // relative file name that `AbsolutePath` resolves against the working
+    // directory.
+    val workingDirectory = AbsolutePath.workingDirectory
+    checkJavaHome(
+      name = "windows-java-home-holds-no-separator-here",
+      expected = raw"""$workingDirectory/C:\Program Files\Java\jdk-17""",
+      javaHomeDirectorySpellings = List("""C:\Program Files\Java\jdk-17"""),
+    )
+    checkJavaHome(
+      name = "windows-share-java-home-holds-no-separator-here",
+      expected = raw"""$workingDirectory/\\host\share\jdk-17""",
+      javaHomeDirectorySpellings = List("""\\host\share\jdk-17"""),
+    )
+
+    // `file://host/jdk` points at `/jdk` on a machine called `host`, which only
+    // Windows can express, so `URI.create` fails and Metals falls back.
+    checkNoJavaHome(
+      name = "java-home-no-path-can-hold",
+      javaHomeDirectorySpellings = List("file://host/jdk"),
+    )
+  }
+
   test("src.zip") {
     JdkSources().right.get
   }


### PR DESCRIPTION
## Reproduction steps
* run BazelDapMbtLspSuite
* check the last test case - bazel-mbt-test-multiple-test-targets-same-build-file

### Actual behavior (main-v2)
The test case fails due to differences in JAVA_HOME path spelling
If we add a client_debug parameter (apply this patch: [client_debug.patch](https://github.com/user-attachments/files/30782099/client_debug.patch)), we can observe this warning

Note the difference in the trailing slash
default_system_javabase=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
default_system_javabase=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/**Home/**

```
2026.08.06 10:07:04 ERROR [INFO 10:07:04.480 src/main/cpp/blaze.cc:1032] Args from the running server that are not included in the current request:
2026.08.06 10:07:04 ERROR [INFO 10:07:04.480 src/main/cpp/blaze.cc:1035]   --default_system_javabase=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
2026.08.06 10:07:04 ERROR [INFO 10:07:04.480 src/main/cpp/blaze.cc:1039] Args from the current request that were not included when creating the server:
2026.08.06 10:07:04 ERROR [INFO 10:07:04.480 src/main/cpp/blaze.cc:1042]   --default_system_javabase=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home/
2026.08.06 10:07:04 ERROR [WARNING 10:07:04.480 src/main/cpp/blaze.cc:1075] Running Bazel server needs to be killed, because the startup options are different.
2026.08.06 10:07:04 ERROR [INFO 10:07:04.480 src/main/cpp/blaze.cc:1833] Shutting running server with RPC request
```

<img width="1512" height="426" alt="Screenshot 2026-08-06 at 09 40 06" src="https://github.com/user-attachments/assets/dd7e5c2a-3ae6-490b-8924-39c1b574f5ab" />


## Expected behavior (fix)
BazelDapMbtLspSuite succeeds
<img width="1512" height="426" alt="Screenshot 2026-08-06 at 11 42 14" src="https://github.com/user-attachments/assets/4e0ee6bc-ef2f-486f-84ff-80c7ec56618c" />

___

## Description of changes

The MBT debug path exported no JAVA_HOME when neither the build target nor the user configured a java home, so the launched command inherited whatever the environment held. That value often ends with a separator, `/jdk/Home/`, while every command that goes through `ShellRunner` exports the same JDK as `/jdk/Home`. The build tool compares JAVA_HOME against the value its running daemon started with, sees two different JDKs, and shuts the daemon down. It did that between the importer's commands and the ones Metals launched, and the analysis cache went with it.

The debug path now goes through `JdkSources.envVariables`, like every other command, so all of them export the same spelling. `JdkSources` also accepts a `file:` URI, which is how a BSP `JvmBuildTarget` reports its java home; `AbsolutePath` alone reads `file:///jdk/Home` as a relative path whose first segment is `file:`.

`JdkSourcesSuite` covers the spellings a java home reaches Metals in, one case per platform: a trailing separator, a `file:` URI, a percent-encoded space, a Windows drive or share, and the spellings that no path can hold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Java home locations supplied as file URIs or filesystem paths.
  - Fixed parsing for Windows drive paths, UNC paths, Unix and macOS paths, and paths containing encoded spaces or backslashes.
  - Improved Java home environment setup for debugging and command execution.
  - Added safer handling for empty or invalid Java home values while preserving existing warnings.
- **Tests**
  - Expanded coverage for platform-specific Java home parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->