### PR TITLE
feat(mcp): glob-search over all modules

### DIFF
--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -132,12 +132,27 @@ Metals provides a comprehensive set of tools through MCP:
 
 | Tool                | Description                                                                                                                            |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `glob-search`       | Search for symbols by partial name matching. Find packages, classes, objects, methods, traits, and other symbols across the workspace. |
-| `typed-glob-search` | Search for symbols filtered by type (package, class, object, function, method, trait).                                                 |
+| `glob-search`       | Search symbols by one unqualified name. Returns each symbol's kind and fully qualified name, see the notes below.                      |
+| `typed-glob-search` | Same as `glob-search`, restricted to the given symbol kinds (package, class, object, function, method, trait).                         |
 | `inspect`           | Inspect a Scala symbol. Returns members for packages/objects/traits, members and constructors for classes, and signatures for methods. |
 | `get-docs`          | Get documentation (ScalaDoc) for a symbol.                                                                                             |
 | `get-usages`        | Find all references and usages of a symbol across the project.                                                                         |
 | `get-source`        | Get the source file contents for a symbol. Useful for understanding library code.                                                      |
+
+Notes on symbol search:
+
+- The query matches the last part of a fully qualified name, ignoring case:
+  `Probe` finds `com.example.MidWordProbe`, `com.example` does not.
+- Matching starts at name boundaries, so `idWordProbe` does not find
+  `MidWordProbe`.
+- Wildcards are not supported, `*` and `?` match literally.
+- `typed-glob-search` returns packages only when `package` is among the
+  requested kinds.
+- All modules are searched, together with every dependency on the workspace
+  classpath. Dependency matches are additionally limited to a handful of
+  non-exact hits per query.
+- Results are capped, see `metals.max-mcp-search-results` below. Whenever
+  matches were dropped, the response says so.
 
 ### Build and Dependencies
 
@@ -204,6 +219,13 @@ When using MCP with Metals in an editor:
 | ----------------------- | --------------------- | ------- |
 | `metals.startMcpServer` | Enable the MCP server | `false` |
 
+### Server Properties
+
+The result cap of `glob-search` and `typed-glob-search` is configurable through
+the `-Dmetals.max-mcp-search-results`
+[server property](../integrations/new-editor.md#metals-server-properties), which
+defaults to `100`.
+
 ## Tips for AI Agents
 
 When working with Metals MCP, AI agents should:
@@ -260,3 +282,6 @@ MCP support was introduced in Metals v1.5.3 and has been continuously improved:
 - **v1.6.5**: Switched to streamable HTTP transport (`/mcp` endpoint)
 - **v1.6.6**: Added standalone MCP server (`metals-mcp`)
 - **v1.6.7**: Added stdio transport support, `get-source` tool
+- **v1.6.9**: `glob-search` and `typed-glob-search` search every module instead
+  of the one owning the file in focus, dropped their `fileInFocus` parameter and
+  capped their results

--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -594,6 +594,12 @@ Possible values:
   compiler.
 - `on`: log verbose debugging information for the presentation compiler.
 
+### `-Dmetals.max-mcp-search-results`
+
+Maximum number of results a single MCP symbol search (`glob-search`,
+`typed-glob-search`) returns. Matches beyond the cap are dropped, and the
+response states that it is partial. Default value is `100`.
+
 ### `-Dbloop.sbt.version`
 
 Version number of the sbt-bloop plugin to use for the "Install build" command.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -4,7 +4,6 @@ import scala.concurrent.duration.Duration
 import scala.util.Try
 
 import scala.meta.internal.metals.Configs._
-import scala.meta.internal.metals.mcp.McpQueryEngine
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -147,7 +147,7 @@ final case class MetalsServerConfig(
     ),
     maxMcpSearchResults: Int = MetalsServerConfig.intProperty(
       "metals.max-mcp-search-results",
-      default = McpQueryEngine.MaxMcpSearchResults,
+      default = 100,
     ),
 ) {
   override def toString: String =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -4,6 +4,7 @@ import scala.concurrent.duration.Duration
 import scala.util.Try
 
 import scala.meta.internal.metals.Configs._
+import scala.meta.internal.metals.mcp.McpQueryEngine
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 
@@ -50,6 +51,7 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
  * @param metalsToIdleTime The time that needs to pass with no action to consider metals as idle.
  * @param pingInterval Interval in which we ping the build server.
  * @param debuggeeGracePeriod Grace period in seconds for the debuggee to start.
+ * @param maxMcpSearchResults The maximum number of results a single MCP symbol search returns.
  */
 final case class MetalsServerConfig(
     globSyntax: GlobSyntaxConfig = GlobSyntaxConfig.default,
@@ -97,21 +99,20 @@ final case class MetalsServerConfig(
       "metals.allow-multiline-string-formatting",
       default = true,
     ),
-    macOsMaxWatchRoots: Int =
-      Option(System.getProperty("metals.macos-max-watch-roots"))
-        .filter(_.forall(Character.isDigit(_)))
-        .map(_.toInt)
-        .getOrElse(32),
+    macOsMaxWatchRoots: Int = MetalsServerConfig.intProperty(
+      "metals.macos-max-watch-roots",
+      default = 32,
+    ),
     loglevel: String =
       sys.props.get("metals.loglevel").map(_.toLowerCase()).getOrElse("info"),
     maxLogFileSize: Long = Option(System.getProperty("metals.max-logfile-size"))
       .withFilter(_.forall(Character.isDigit(_)))
       .map(_.toLong)
       .getOrElse(3 << 20),
-    maxLogBackups: Int = Option(System.getProperty("metals.max-log-backups"))
-      .withFilter(_.forall(Character.isDigit(_)))
-      .map(_.toInt)
-      .getOrElse(10),
+    maxLogBackups: Int = MetalsServerConfig.intProperty(
+      "metals.max-log-backups",
+      default = 10,
+    ),
     metalsToIdleTime: Duration =
       Option(System.getProperty("metals.server-to-idle-time"))
         .flatMap(opt => Try(Duration(opt)).toOption)
@@ -120,33 +121,33 @@ final case class MetalsServerConfig(
       Option(System.getProperty("metals.build-server-ping-interval"))
         .flatMap(opt => Try(Duration(opt)).toOption)
         .getOrElse(Duration("1m")),
-    worksheetTimeout: Int =
-      Option(System.getProperty("metals.worksheet-timeout"))
-        .filter(_.forall(Character.isDigit(_)))
-        .map(_.toInt)
-        .getOrElse(30),
-    debugServerStartTimeout: Int =
-      Option(System.getProperty("metals.debug-server-start-timeout"))
-        .filter(_.forall(Character.isDigit(_)))
-        .map(_.toInt)
-        .getOrElse(60),
-    debuggeeGracePeriod: Int =
-      Option(System.getProperty("metals.debuggee-grace-period"))
-        .filter(_.forall(Character.isDigit(_)))
-        .map(_.toInt)
-        .getOrElse(60),
+    worksheetTimeout: Int = MetalsServerConfig.intProperty(
+      "metals.worksheet-timeout",
+      default = 30,
+    ),
+    debugServerStartTimeout: Int = MetalsServerConfig.intProperty(
+      "metals.debug-server-start-timeout",
+      default = 60,
+    ),
+    debuggeeGracePeriod: Int = MetalsServerConfig.intProperty(
+      "metals.debuggee-grace-period",
+      default = 60,
+    ),
     enableBestEffort: Boolean = MetalsServerConfig.binaryOption(
       "metals.enable-best-effort",
       default = false,
     ),
-    foldingRageMinimumSpan: Int =
-      Option(System.getProperty("metals.folding-range-minimum-span"))
-        .filter(_.forall(Character.isDigit(_)))
-        .map(_.toInt)
-        .getOrElse(3),
+    foldingRageMinimumSpan: Int = MetalsServerConfig.intProperty(
+      "metals.folding-range-minimum-span",
+      default = 3,
+    ),
     disableShowMessageRequest: Boolean = MetalsServerConfig.binaryOption(
       "metals.disable-show-message-request",
       default = false,
+    ),
+    maxMcpSearchResults: Int = MetalsServerConfig.intProperty(
+      "metals.max-mcp-search-results",
+      default = McpQueryEngine.MaxMcpSearchResults,
     ),
 ) {
   override def toString: String =
@@ -176,6 +177,7 @@ final case class MetalsServerConfig(
       s"enable-best-effort=$enableBestEffort",
       s"folding-range-minimum-span=$foldingRageMinimumSpan",
       s"disable-show-message-request=$disableShowMessageRequest",
+      s"max-mcp-search-results=$maxMcpSearchResults",
     ).mkString("MetalsServerConfig(\n  ", ",\n  ", "\n)")
 }
 object MetalsServerConfig {
@@ -190,6 +192,12 @@ object MetalsServerConfig {
           .toSet
       )
       .getOrElse(Set.empty)
+  def intProperty(key: String, default: Int): Int =
+    sys.props
+      .get(key)
+      .filter(_.forall(Character.isDigit(_)))
+      .map(_.toInt)
+      .getOrElse(default)
   def binaryOption(key: String, default: Boolean): Boolean =
     sys.props.get(key) match {
       case Some("true" | "on") => true

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -254,6 +254,7 @@ class ProjectMetalsLspService(
       scalaVersionSelector,
       mcpSearch,
       folder,
+      initialServerConfig.maxMcpSearchResults,
     )
 
   lazy val mcpTestRunner =

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -126,6 +126,17 @@ final class WorkspaceSymbolProvider(
     SymbolSearch.Result.COMPLETE
   }
 
+  /**
+   * Visit workspace packages, either of a single build target and its
+   * transitive dependencies, or of every known build target when `target` is
+   * `None`.
+   *
+   * Iterates build targets rather than `packages` keys, because package entries
+   * outlive the build targets they came from, e.g. after a build reimport.
+   *
+   * Note that a package declared in several build targets is visited once per
+   * target, so callers that search all targets have to deduplicate.
+   */
   def searchWorkspacePackages(
       visitor: SymbolSearchVisitor,
       target: Option[BuildTargetIdentifier],
@@ -137,11 +148,16 @@ final class WorkspaceSymbolProvider(
         loop(node.children, pkg)
       }
     }
-    target.foreach { id =>
-      buildTargets
-        .buildTargetTransitiveDependencies(id)
-        .foreach { dep =>
-          packages.get(dep).foreach(loop(_, ""))
+    target match {
+      case Some(id) =>
+        buildTargets
+          .buildTargetTransitiveDependencies(id)
+          .foreach { dep =>
+            packages.get(dep).foreach(loop(_, ""))
+          }
+      case None =>
+        buildTargets.allBuildTargetIds.foreach { id =>
+          packages.get(id).foreach(loop(_, ""))
         }
     }
     SymbolSearch.Result.COMPLETE

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpPrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpPrinter.scala
@@ -44,6 +44,23 @@ object McpPrinter {
     def show: String = result.map(_.show).sorted.mkString("\n")
   }
 
+  implicit class XtensionGlobSearchResult(result: GlobSearchResult) {
+    def show: String = {
+      // `McpQueryEngine.normalize` guarantees dedupe, cap and display order
+      val body =
+        if (result.results.isEmpty) "No symbols found."
+        else result.results.map(_.show).mkString("\n")
+      // both flags mean the same to the caller: the answer is partial
+      if (!result.isPartial) body
+      else if (result.results.isEmpty)
+        body + "\n\n[The search stopped early, matches may exist beyond it. " +
+          "Use a longer or more specific query.]"
+      else
+        body + s"\n\n[Showing ${result.results.size} results; " +
+          "additional matches may exist. Narrow the query.]"
+    }
+  }
+
   implicit class XtensionSymbolDocumentation(
       result: SymbolDocumentationSearchResult
   ) {

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpPrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpPrinter.scala
@@ -50,14 +50,13 @@ object McpPrinter {
       val body =
         if (result.results.isEmpty) "No symbols found."
         else result.results.map(_.show).mkString("\n")
-      // both flags mean the same to the caller: the answer is partial
-      if (!result.isPartial) body
-      else if (result.results.isEmpty)
-        body + "\n\n[The search stopped early, matches may exist beyond it. " +
-          "Use a longer or more specific query.]"
-      else
+      if (result.cappedByResultLimit)
         body + s"\n\n[Showing ${result.results.size} results; " +
           "additional matches may exist. Narrow the query.]"
+      else if (result.searchBudgetExhausted)
+        body + "\n\n[The search stopped early, matches may exist beyond it. " +
+          "Use a longer or more specific query.]"
+      else body
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
@@ -580,12 +580,6 @@ object SymbolType {
 object McpQueryEngine {
 
   /**
-   * Default result cap of a single MCP symbol search, a budget that keeps tool
-   * output within an LLM context window.
-   */
-  val MaxMcpSearchResults = 100
-
-  /**
    * Deduplicate, rank, cap and finally display-sort search results.
    *
    * Capping raw order would be nondeterministic, as the indexes below are

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
@@ -24,9 +24,7 @@ import org.eclipse.lsp4j.SymbolKind
 
 /**
  * Query engine for searching symbols in the workspace and classpath.
- * Supports glob search, symbol inspection, and documentation retrieval.
- *
- * @param workspaceSearchProvider Provider for workspace symbol search
+ * Supports name search, symbol inspection, and documentation retrieval.
  */
 class McpQueryEngine(
     compilers: Compilers,
@@ -36,30 +34,40 @@ class McpQueryEngine(
     scalaVersionSelector: ScalaVersionSelector,
     mcpSearch: McpSymbolSearch,
     workspace: AbsolutePath,
+    maxSearchResults: Int,
 )(implicit ec: ExecutionContext) {
   private val mcpDefinitionProvider =
     new McpSymbolProvider(scalaVersionSelector, mcpSearch)
 
   /**
-   * Search for symbols matching a glob pattern.
+   * Search all modules and every dependency on the workspace classpath for
+   * symbols whose last name segment contains `query`, ignoring case.
    *
-   * @param query The search query (e.g., "matching" will search for "*matching*")
-   * @param symbolTypes Set of symbol types to filter results (empty means all types)
-   * @param path Path to the file in context
-   * @return Collection of matching symbols with their information
+   * `WorkspaceSymbolQuery` matches candidates at name boundaries, so mid-name
+   * matches can be missed; `searchWorkspacePackages` never applies it, so
+   * workspace packages match on plain substrings. Wildcards are literal.
+   *
+   * Results are deduplicated and capped at `maxSearchResults`, keeping the most
+   * relevant ones.
+   *
+   * @param symbolTypes Requested symbol types, empty means all types
+   * @return Matching symbols, with flags describing whether matches were dropped
    */
   def globSearch(
       query: String,
       symbolTypes: Set[SymbolType] = Set.empty,
-      path: AbsolutePath,
-  ): Future[Seq[SymbolSearchResult]] = Future {
-    mcpSearch
-      .nameSearch(
-        query,
-        symbolTypes,
-        Some(path),
-      )
-      .map(_.toMcpSymbolSearchResult)
+  ): Future[GlobSearchResult] = Future {
+    val searchResult = mcpSearch.nameSearch(query, symbolTypes)
+    val (results, cappedByResultLimit) = McpQueryEngine.normalize(
+      query,
+      searchResult.results.map(_.toMcpSymbolSearchResult),
+      maxSearchResults,
+    )
+    GlobSearchResult(
+      results = results,
+      searchBudgetExhausted = searchResult.searchBudgetExhausted,
+      cappedByResultLimit = cappedByResultLimit,
+    )
   }
 
   /**
@@ -449,6 +457,22 @@ case class SymbolSearchResult(
   def name: String = path.split('.').lastOption.getOrElse(path)
 }
 
+/**
+ * Result of a glob search.
+ *
+ * @param results deduplicated, relevance-capped and display-sorted matches
+ * @param searchBudgetExhausted a search layer below stopped early, which does
+ *                              not guarantee that more matches exist
+ * @param cappedByResultLimit `maxSearchResults` dropped matches
+ */
+case class GlobSearchResult(
+    results: Seq[SymbolSearchResult],
+    searchBudgetExhausted: Boolean,
+    cappedByResultLimit: Boolean,
+) {
+  def isPartial: Boolean = searchBudgetExhausted || cappedByResultLimit
+}
+
 case class MethodSignature(
     name: String
 )
@@ -556,6 +580,54 @@ object SymbolType {
 }
 
 object McpQueryEngine {
+
+  /**
+   * Default result cap of a single MCP symbol search, a budget that keeps tool
+   * output within an LLM context window.
+   */
+  val MaxMcpSearchResults = 100
+
+  /**
+   * Deduplicate, rank, cap and finally display-sort search results.
+   *
+   * Capping raw order would be nondeterministic, as the indexes below are
+   * iterated in an unspecified order. Capping display order would prefer
+   * whichever kind sorts first, because `show` starts with the kind. Hence rank
+   * by relevance, cap, then sort for display.
+   *
+   * @return the results to show and whether the cap dropped anything
+   */
+  private[mcp] def normalize(
+      query: String,
+      raw: Seq[SymbolSearchResult],
+      limit: Int,
+  ): (Seq[SymbolSearchResult], Boolean) = {
+    val lowerCaseQuery = query.toLowerCase
+    def relevance(
+        result: SymbolSearchResult
+    ): (Int, Int, Int, String, String, String) = {
+      val isExactName = if (result.name.toLowerCase == lowerCaseQuery) 0 else 1
+      (
+        isExactName,
+        result.name.length,
+        result.path.count(_ == '.'),
+        result.path,
+        // picks the same duplicate every time, overloads share kind and path
+        result.symbol,
+        // makes the order total across everything the dedupe keeps apart
+        result.symbolType.name,
+      )
+    }
+    // the rendered form is `kind + path`, so results sharing both would render
+    // as duplicate lines and would otherwise consume the cap; ranking first
+    // makes the surviving duplicate deterministic
+    val ranked = raw
+      .sortBy(relevance)
+      .distinctBy(result => (result.symbolType, result.path))
+    // a cap below 1 would report a partial result with nothing in it
+    val shown = ranked.take(limit.max(1))
+    (shown.sortBy(_.show), ranked.size > shown.size)
+  }
 
   /**
    * Check if a build target is a meta-target (e.g., SBT build definition).

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
@@ -469,9 +469,7 @@ case class GlobSearchResult(
     results: Seq[SymbolSearchResult],
     searchBudgetExhausted: Boolean,
     cappedByResultLimit: Boolean,
-) {
-  def isPartial: Boolean = searchBudgetExhausted || cappedByResultLimit
-}
+)
 
 case class MethodSignature(
     name: String

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpSymbolSearch.scala
@@ -18,8 +18,10 @@ import scala.meta.internal.mtags.Symbol
 import scala.meta.internal.semanticdb.Scala.Descriptor
 import scala.meta.internal.semanticdb.Scala.Symbols
 import scala.meta.io.AbsolutePath
+import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
 
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import org.eclipse.lsp4j
 import org.eclipse.lsp4j.SymbolKind
 
@@ -29,11 +31,14 @@ class McpSymbolSearch(
     workspaceSearchProvider: WorkspaceSymbolProvider,
 ) {
 
+  /**
+   * Search all build targets and every dependency on the workspace classpath
+   * for symbols whose last name segment contains the query, ignoring case.
+   */
   def nameSearch(
       query: String,
       symbolTypes: Set[SymbolType] = Set.empty,
-      path: Option[AbsolutePath],
-  ): Seq[SearchResult] = {
+  ): NameSearchResult = {
     val lowerCaseQuery = query.toLowerCase
     val matches: String => Boolean = { symbol =>
       val fqcn = symbol.fqcn
@@ -44,7 +49,7 @@ class McpSymbolSearch(
       WorkspaceSymbolQuery.fromTextQuery(query),
       matches,
       symbolTypes,
-      path,
+      target = None,
     )
   }
 
@@ -55,15 +60,39 @@ class McpSymbolSearch(
     val matches: String => Boolean = { symbol =>
       symbol.fqcn == query
     }
-    search(WorkspaceSymbolQuery.exact(query), matches, Set.empty, path)
+    search(
+      WorkspaceSymbolQuery.exact(query),
+      matches,
+      Set.empty,
+      target = singleBuildTarget(path),
+    ).results
   }
+
+  /**
+   * The build target to search from: the first one owning `path`, or, without a
+   * path, the first target that is not a build meta-target (e.g. `root-build`,
+   * which has no project dependencies).
+   *
+   * Both picks depend on target iteration order.
+   */
+  private def singleBuildTarget(
+      path: Option[AbsolutePath]
+  ): Option[BuildTargetIdentifier] =
+    path
+      .flatMap(buildTargets.sourceBuildTargets)
+      .flatMap(_.headOption)
+      .orElse {
+        buildTargets.allBuildTargetIds
+          .filterNot(McpQueryEngine.isBuildMetaTarget(buildTargets, _))
+          .headOption
+      }
 
   private def search(
       wsQuery: WorkspaceSymbolQuery,
       matches: String => Boolean,
       symbolTypes: Set[SymbolType],
-      path: Option[AbsolutePath],
-  ): Seq[SearchResult] = {
+      target: Option[BuildTargetIdentifier],
+  ): NameSearchResult = {
 
     val visitor = new McpSearchVisitor(
       index,
@@ -71,32 +100,41 @@ class McpSymbolSearch(
       matches,
     )
 
-    // Smart fallback: if no path provided, use first available build target
-    // Exclude build meta-targets (e.g., root-build) as they don't have project dependencies
-    val buildTarget =
-      path
-        .flatMap(buildTargets.sourceBuildTargets)
-        .flatMap(_.headOption)
-        .orElse {
-          buildTargets.allBuildTargetIds
-            .filterNot(McpQueryEngine.isBuildMetaTarget(buildTargets, _))
-            .headOption
-        }
-
-    // use focused document build target (or fallback)
-    workspaceSearchProvider.search(
+    // the returned result covers dependencies only, and
+    // `ClasspathSearch.maxNonExactMatches` caps them at 10 non-exact matches
+    val (dependencyResult, _) = workspaceSearchProvider.search(
       wsQuery,
       visitor,
-      buildTarget,
+      target,
     )
-    workspaceSearchProvider.searchWorkspacePackages(
+    // add separately indexed workspace packages to the visitor
+    val _ = workspaceSearchProvider.searchWorkspacePackages(
       visitor,
-      buildTarget,
+      target,
     )
 
-    visitor.getResults
+    NameSearchResult(
+      results = visitor.getResults,
+      // workspace sources are capped silently for queries under
+      // `Fuzzy.PrefixSearchLimit` chars, and the discarded count above mixes
+      // all layers, so flag every short query, as `ClasspathSearch` does
+      searchBudgetExhausted =
+        dependencyResult == SymbolSearch.Result.INCOMPLETE || wsQuery.isShortQuery,
+    )
   }
 }
+
+/**
+ * Results of a symbol name search.
+ *
+ * @param results the collected matches, neither deduplicated nor capped
+ * @param searchBudgetExhausted true when a search layer below stopped early,
+ *                              which does not guarantee that more matches exist
+ */
+private[mcp] case class NameSearchResult(
+    results: Seq[SearchResult],
+    searchBudgetExhausted: Boolean,
+)
 
 private[mcp] class McpSearchVisitor(
     index: GlobalSymbolIndex,
@@ -122,7 +160,10 @@ private[mcp] class McpSearchVisitor(
   }
 
   override def visitWorkspacePackage(pkg: String): Int = {
-    if (matches(pkg)) {
+    val shouldIncludePackages =
+      symbolTypes.isEmpty || symbolTypes.contains(SymbolType.Package)
+
+    if (shouldIncludePackages && matches(pkg)) {
       results += SearchResult(
         symbol = pkg,
         SymbolType.Package,

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpTools.scala
@@ -467,11 +467,7 @@ trait MetalsMcpTools extends Cancelable {
         "properties": {
           "query": {
             "type": "string",
-            "description": "Substring of the symbol to search for"
-          },
-          "fileInFocus": {
-            "type": "string",
-            "description": "The current file in focus for context, if empty we will try to detect it"
+            "description": "A single unqualified name, e.g. `Probe`, not `com.example.Probe`. Wildcards match literally."
           }
         },
         "required": ["query"]
@@ -481,10 +477,10 @@ trait MetalsMcpTools extends Cancelable {
       .builder()
       .name("glob-search")
       .description(
-        """|Search for symbols using glob pattern. Find packages, classes, objects, methods, traits,
-           |and other Scala symbols by partial name matching. Returns symbol locations
-           |and signatures from the entire project workspace.
-           |Use this if you encounter unknown API, for example proprietary libraries.""".stripMargin
+        """|Search symbols by name across all modules and their dependency classpaths.
+           |Matches the last part of a fully qualified name at name boundaries, ignoring
+           |case, so `idWordProbe` does not find `MidWordProbe`.
+           |Use `inspect` for details of a result.""".stripMargin
       )
       .inputSchema(jsonMapper, schema)
       .build()
@@ -492,14 +488,13 @@ trait MetalsMcpTools extends Cancelable {
       tool,
       withErrorHandling { (exchange, arguments) =>
         val query = arguments.getAs[String]("query")
-        val path = arguments.getFileInFocus
         indexingPromise.future.flatMap { _ =>
           queryEngine
-            .globSearch(query, Set.empty, path)
+            .globSearch(query, Set.empty)
             .map(result =>
               CallToolResult
                 .builder()
-                .content(createContent(result.map(_.show).mkString("\n")))
+                .content(createContent(result.show))
                 .isError(false)
                 .build()
             )
@@ -515,7 +510,7 @@ trait MetalsMcpTools extends Cancelable {
         "properties": {
           "query": {
             "type": "string",
-            "description": "Substring of the symbol to search for"
+            "description": "A single unqualified name, e.g. `Probe`, not `com.example.Probe`. Wildcards match literally."
           },
           "symbolType": {
             "type": "array",
@@ -523,11 +518,7 @@ trait MetalsMcpTools extends Cancelable {
               "type": "string",
               "enum": ["package", "class", "object", "function", "method", "trait"]
             },
-            "description": "The type of symbol to search for"
-          },
-          "fileInFocus": {
-            "type": "string",
-            "description": "The current file in focus for context, if empty we will try to detect it"
+            "description": "Symbol kinds to include in the results."
           }
         },
         "required": ["query", "symbolType"]
@@ -537,10 +528,8 @@ trait MetalsMcpTools extends Cancelable {
       .builder()
       .name("typed-glob-search")
       .description(
-        """|Search for symbols by type using glob pattern. Filter symbol search results
-           |by specific symbol types (package, class, object, function, method, trait).
-           |More precise than glob-search when you know the symbol type you're looking for.
-           |Use this if you encounter unknown API, for example proprietary libraries.""".stripMargin
+        """|Same as `glob-search`, restricted to the given symbol kinds. Note that packages are
+           |returned only when `package` is among them.""".stripMargin
       )
       .inputSchema(jsonMapper, schema)
       .build()
@@ -548,7 +537,6 @@ trait MetalsMcpTools extends Cancelable {
       tool,
       withErrorHandling { (exchange, arguments) =>
         val query = arguments.getAs[String]("query")
-        val path = arguments.getFileInFocus
         val symbolTypes = arguments.getAsList[String]("symbolType")
 
         val invalidSymbols =
@@ -563,11 +551,11 @@ trait MetalsMcpTools extends Cancelable {
 
         indexingPromise.future.flatMap { _ =>
           queryEngine
-            .globSearch(query, symbolTypesSet, path)
+            .globSearch(query, symbolTypesSet)
             .map(result =>
               CallToolResult
                 .builder()
-                .content(createContent(result.map(_.show).mkString("\n")))
+                .content(createContent(result.show))
                 .isError(false)
                 .build()
             )

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -139,6 +139,8 @@ object TestGroups {
     "tests.parsing.BloopDiagnosticsParserSuite",
     "tests.codeactions.RemoveInfixLspSuite",
     "scala.meta.internal.metals.debug.tests.DebugProxyTeardownSuite",
+    "tests.mcp.McpGlobSearchCapLspSuite",
+    "scala.meta.internal.metals.mcp.tests.McpGlobSearchNormalizeSuite",
   )
 
   val numberOfShards = 4

--- a/tests/slow/src/test/scala/tests/feature/McpStdioSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/McpStdioSuite.scala
@@ -40,9 +40,8 @@ class McpStdioSuite extends BaseSuite with StdioMcpTestHelper {
         typedGlobResult <- client.typedGlobSearch(
           "Hello",
           List("class", "object"),
-          Some(filePath),
         )
-        globSearchResult <- client.globSearch("Hello", Some(filePath))
+        globSearchResult <- client.globSearch("Hello")
         inspectResult <- client.inspect("com.example.Hello")
         docsResult <- client.getDocs("com.example.Hello")
         usagesResult <- client.getUsages("com.example.Hello.add")

--- a/tests/unit/src/main/scala/tests/mcp/TestMcpStdioClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/TestMcpStdioClient.scala
@@ -94,24 +94,18 @@ class TestMcpStdioClient(
   def typedGlobSearch(
       query: String,
       symbolTypes: List[String],
-      fileInFocus: Option[String] = None,
   ): Future[String] = {
     val params = objectMapper.createObjectNode()
     params.put("query", query)
     val symbolTypeArray = objectMapper.createArrayNode()
     symbolTypes.foreach(symbolTypeArray.add)
     params.set("symbolType", symbolTypeArray)
-    fileInFocus.foreach(f => params.put("fileInFocus", f))
     callTool("typed-glob-search", params).map(_.mkString)
   }
 
-  def globSearch(
-      query: String,
-      fileInFocus: Option[String] = None,
-  ): Future[String] = {
+  def globSearch(query: String): Future[String] = {
     val params = objectMapper.createObjectNode()
     params.put("query", query)
-    fileInFocus.foreach(f => params.put("fileInFocus", f))
     callTool("glob-search", params).map(_.mkString)
   }
 

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/mcp/tests/McpGlobSearchNormalizeSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/mcp/tests/McpGlobSearchNormalizeSuite.scala
@@ -1,0 +1,139 @@
+package scala.meta.internal.metals.mcp.tests
+
+import scala.util.Random
+
+import scala.meta.internal.metals.mcp.McpPrinter._
+import scala.meta.internal.metals.mcp.McpQueryEngine
+import scala.meta.internal.metals.mcp.SymbolSearchResult
+import scala.meta.internal.metals.mcp.SymbolType
+
+import tests.BaseSuite
+
+/**
+ * Tests for the pure part of glob search: deduplicating, ranking, capping and
+ * display sorting of results. The underlying indexes are iterated in an
+ * unspecified order, so all of it has to be independent of the input order.
+ *
+ * Ranking order: exact name match, then shortest name, then fewest path
+ * segments, then path alphabetically.
+ */
+class McpGlobSearchNormalizeSuite extends BaseSuite {
+
+  /** The symbol is only a tie-breaker here, so it needs no realistic shape. */
+  private def result(
+      path: String,
+      symbolType: SymbolType = SymbolType.Class,
+      symbol: String = "",
+  ): SymbolSearchResult =
+    SymbolSearchResult(
+      path,
+      symbolType,
+      if (symbol.isEmpty) path.replace('.', '/') + "#" else symbol,
+    )
+
+  private val mixed: Seq[SymbolSearchResult] = Seq(
+    result("com.example.ThingBuilder"),
+    result("com.example.Thing", SymbolType.Object),
+    result("com.example.Thing"),
+    result("com.example.deeper.Thing", SymbolType.Trait),
+    result("com.example.ThingFactoryProvider"),
+    result("org.other.Thing", SymbolType.Package, symbol = "org/other/Thing/"),
+  )
+
+  /** Seeded, so that a failure names a reproducible input order. */
+  private val orderings: Seq[(String, Seq[SymbolSearchResult])] =
+    Seq("original" -> mixed, "reversed" -> mixed.reverse) ++
+      Seq(1L, 2L, 3L).map(seed =>
+        s"shuffled with seed $seed" -> new Random(seed).shuffle(mixed)
+      )
+
+  private def checkEveryOrdering(
+      limit: Int,
+      expectedShow: String,
+      expectedTruncated: Boolean,
+  ): Unit =
+    orderings.foreach { case (ordering, input) =>
+      val (shown, truncated) = McpQueryEngine.normalize("Thing", input, limit)
+      assertNoDiff(shown.show, expectedShow, s"input order: $ordering")
+      assertEquals(truncated, expectedTruncated, s"input order: $ordering")
+    }
+
+  test("order-independent") {
+    checkEveryOrdering(
+      limit = 10,
+      """|class com.example.Thing
+         |class com.example.ThingBuilder
+         |class com.example.ThingFactoryProvider
+         |object com.example.Thing
+         |package org.other.Thing
+         |trait com.example.deeper.Thing
+         |""".stripMargin,
+      expectedTruncated = false,
+    )
+  }
+
+  test("order-independent-when-truncated") {
+    // exact name matches win, `com.example` before `org.other` alphabetically,
+    // `com.example.deeper` loses on path length
+    checkEveryOrdering(
+      limit = 3,
+      """|class com.example.Thing
+         |object com.example.Thing
+         |package org.other.Thing
+         |""".stripMargin,
+      expectedTruncated = true,
+    )
+  }
+
+  test("cap-below-one-still-shows-a-result") {
+    checkEveryOrdering(
+      limit = 0,
+      """|class com.example.Thing
+         |""".stripMargin,
+      expectedTruncated = true,
+    )
+  }
+
+  test("relevance-beats-alphabet") {
+    val results = Seq(
+      result("com.aaa.ThingBuilder"),
+      result("com.zzz.Thing"),
+    )
+    val (shown, truncated) = McpQueryEngine.normalize("thing", results, 1)
+
+    assert(truncated)
+    // an exact, case-insensitive name match survives a cap of 1, even though it
+    // sorts last alphabetically and came last in the input
+    assertNoDiff(
+      shown.show,
+      """|class com.zzz.Thing
+         |""".stripMargin,
+    )
+  }
+
+  test("duplicate-rows-collapse") {
+    val overloads = Seq(
+      result(
+        "com.example.Thing.overloaded",
+        SymbolType.Method,
+        symbol = "com/example/Thing#overloaded(+1).",
+      ),
+      result(
+        "com.example.Thing.overloaded",
+        SymbolType.Method,
+        symbol = "com/example/Thing#overloaded().",
+      ),
+    )
+    val (shown, truncated) =
+      McpQueryEngine.normalize("overloaded", overloads, 2)
+
+    assertEquals(shown.size, 1)
+    assertEquals(truncated, false)
+    // the surviving symbol does not depend on the input order
+    assertNoDiff(shown.head.symbol, "com/example/Thing#overloaded().")
+    assertNoDiff(
+      McpQueryEngine.normalize("overloaded", overloads.reverse, 2)._1.show,
+      shown.show,
+    )
+  }
+}

--- a/tests/unit/src/test/scala/tests/mcp/McpGlobSearchCapLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpGlobSearchCapLspSuite.scala
@@ -1,0 +1,64 @@
+package tests.mcp
+
+import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.mcp.McpPrinter._
+import scala.meta.internal.metals.mcp.SymbolType
+
+import tests.BaseLspSuite
+
+class McpGlobSearchCapLspSuite extends BaseLspSuite("mcp-glob-search-cap") {
+
+  override def serverConfig: MetalsServerConfig =
+    super.serverConfig.copy(maxMcpSearchResults = 2)
+
+  test("glob search result cap") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/a/src/main/scala/com/capped/CappedProbes.scala
+           |package com.capped
+           |
+           |class CappedProbe1
+           |class CappedProbe2
+           |class CappedProbe3
+           |class CappedProbe4
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/capped/CappedProbes.scala")
+      _ = assertNoDiagnostics()
+
+      truncated <- server.headServer.queryEngine.globSearch(
+        "CappedProbe",
+        Set(SymbolType.Class),
+      )
+      _ = assertEquals(truncated.results.size, 2)
+      _ = assertEquals(truncated.cappedByResultLimit, true)
+      _ = assertEquals(truncated.searchBudgetExhausted, false)
+      _ = assertNoDiff(
+        truncated.show,
+        """|class com.capped.CappedProbe1
+           |class com.capped.CappedProbe2
+           |
+           |[Showing 2 results; additional matches may exist. Narrow the query.]
+           |""".stripMargin,
+        "query: globSearch(\"CappedProbe\", Set(SymbolType.Class))",
+      )
+
+      // a result set below the cap has no notice at all
+      complete <- server.headServer.queryEngine.globSearch(
+        "CappedProbe3",
+        Set(SymbolType.Class),
+      )
+      _ = assertEquals(complete.cappedByResultLimit, false)
+      _ = assertNoDiff(
+        complete.show,
+        """|class com.capped.CappedProbe3
+           |""".stripMargin,
+        "query: globSearch(\"CappedProbe3\", Set(SymbolType.Class))",
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/mcp/McpQueryLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpQueryLspSuite.scala
@@ -518,8 +518,13 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
             |expected the classpath search to report incompleteness, but got:
             |${result.show}""".stripMargin,
       )
-      _ = assert(
-        result.show.contains("additional matches may exist"),
+      _ = assertEquals(result.cappedByResultLimit, false)
+      _ = assertEquals(
+        result.show.linesIterator.toList.lastOption,
+        Some(
+          "[The search stopped early, matches may exist beyond it. " +
+            "Use a longer or more specific query.]"
+        ),
         s"""|query: globSearch("String", Set.empty)
             |expected an incompleteness notice, but got:
             |${result.show}""".stripMargin,

--- a/tests/unit/src/test/scala/tests/mcp/McpQueryLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpQueryLspSuite.scala
@@ -2,9 +2,13 @@ package tests.mcp
 
 import java.nio.file.Path
 
+import scala.meta.internal.metals.WorkspaceSymbolInformation
 import scala.meta.internal.metals.mcp.McpPrinter._
 import scala.meta.internal.metals.mcp.SymbolType
+import scala.meta.internal.semanticdb.SymbolInformation.Kind
 
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import org.eclipse.lsp4j.Range
 import tests.BaseLspSuite
 
 class McpQueryLspSuite extends BaseLspSuite("query") {
@@ -72,12 +76,10 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
       )
       _ <- server.didOpen("a/src/main/scala/com/test/TestClass.scala")
       _ = assertNoDiagnostics()
-      path = server.toPath("a/src/main/scala/com/test/TestClass.scala")
       // Test searching for "test" - should find packages, classes, objects, trait
       result <- server.headServer.queryEngine.globSearch(
         "test",
         Set.empty,
-        path,
       )
       _ = assertNoDiff(
         result.show,
@@ -98,7 +100,6 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
       matching <- server.headServer.queryEngine.globSearch(
         "matching",
         Set.empty,
-        path,
       )
       _ = assertNoDiff(
         matching.show,
@@ -112,7 +113,6 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
       testClasses <- server.headServer.queryEngine.globSearch(
         "test",
         Set(SymbolType.Class),
-        path,
       )
       // Test searching for "test" with class filter
       _ = assertNoDiff(
@@ -120,7 +120,6 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
         """|class com.test.TestCaseClass
            |class com.test.TestClass
            |class java.awt.dnd.SerializationTester
-           |package com.test
            |""".stripMargin,
         "query: globSearch(\"test\", Set(SymbolType.Class))",
       )
@@ -129,7 +128,6 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
         .globSearch(
           "method",
           Set(SymbolType.Method, SymbolType.Function),
-          path,
         )
       // Test searching for methods
       _ = assertNoDiff(
@@ -138,7 +136,7 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
            |method com.test.TestClass.testMethod
            |method com.test.TestTrait.abstractMethod
            |""".stripMargin,
-        "query: globSearch(\"test\", Set(SymbolType.Class))",
+        "query: globSearch(\"method\", Set(SymbolType.Method, SymbolType.Function))",
       )
     } yield ()
   }
@@ -181,13 +179,11 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
       )
       _ <- server.didOpen("a/src/main/scala/com/test/CaseSensitivity.scala")
       _ = assertNoDiagnostics()
-      path = server.toPath("a/src/main/scala/com/test/CaseSensitivity.scala")
 
       // Case insensitive search for "camel"
       camel <- server.headServer.queryEngine.globSearch(
         "camel",
         Set.empty,
-        path,
       )
       _ = assertNoDiff(
         camel.show,
@@ -199,7 +195,6 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
       uppercase <- server.headServer.queryEngine.globSearch(
         "uppercase",
         Set.empty,
-        path,
       )
       // Case insensitive search for "UPPERCASE"
       _ = assertNoDiff(
@@ -214,7 +209,6 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
       lowercase <- server.headServer.queryEngine.globSearch(
         "lowercase",
         Set.empty,
-        path,
       )
       // Case insensitive search for "lowercase"
       _ = assertNoDiff(
@@ -273,16 +267,12 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
         "a/src/main/scala/com/test/nested/package1/Class1.scala"
       )
       _ = assertNoDiagnostics()
-      path = server.toPath(
-        "a/src/main/scala/com/test/nested/package1/Class1.scala"
-      )
 
       // Search for all packages
       packages <- server.headServer.queryEngine
         .globSearch(
           "package",
           Set(SymbolType.Package),
-          path,
         )
       _ = assertNoDiff(
         packages.show,
@@ -296,7 +286,6 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
         .globSearch(
           "test",
           Set(SymbolType.Package),
-          path,
         )
       _ = assertNoDiff(
         testPackages.show,
@@ -310,12 +299,230 @@ class McpQueryLspSuite extends BaseLspSuite("query") {
         .globSearch(
           "nested",
           Set(SymbolType.Package),
-          path,
         )
       _ = assertNoDiff(
         nestedPackages.show,
         """|package com.test.nested
            |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("glob search mid-word - workspace") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/a/src/main/scala/com/test/MidWordProbe.scala
+           |package com.test
+           |
+           |class MidWordProbe
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/test/MidWordProbe.scala")
+      _ = assertNoDiagnostics()
+
+      prefixMatch <- server.headServer.queryEngine.globSearch(
+        "MidWord",
+        Set(SymbolType.Class),
+      )
+      _ = assertNoDiff(
+        prefixMatch.show,
+        """|class com.test.MidWordProbe
+           |""".stripMargin,
+        "query: globSearch(\"MidWord\", Set(SymbolType.Class))",
+      )
+
+      // `McpSymbolSearch.matches` accepts this substring, but the candidate
+      // lookup in `WorkspaceSymbolQuery.matches` rejects it. This asserts a
+      // deficiency: if candidate lookup ever matches substrings, invert the
+      // assertion instead of deleting it.
+      midWord <- server.headServer.queryEngine.globSearch(
+        "idWordProbe",
+        Set(SymbolType.Class),
+      )
+      _ = assert(
+        !midWord.show.contains("MidWordProbe"),
+        s"""|query: globSearch("idWordProbe", Set(SymbolType.Class))
+            |expected no `MidWordProbe` result, but got:
+            |${midWord.show}""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("glob search all modules - workspace") {
+    cleanWorkspace()
+    for {
+      // modules without a dependency between them, so that neither module's
+      // transitive sources cover the other one
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}, "b": {}}
+           |/a/src/main/scala/com/mcpshared/McpProbeAlpha.scala
+           |package com.mcpshared
+           |
+           |class McpProbeAlpha
+           |/b/src/main/scala/com/mcpshared/McpProbeBeta.scala
+           |package com.mcpshared
+           |
+           |class McpProbeBeta
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/mcpshared/McpProbeAlpha.scala")
+      _ = assertNoDiagnostics()
+
+      // symbols from every module are returned, without a file in focus
+      classes <- server.headServer.queryEngine.globSearch(
+        "McpProbe",
+        Set(SymbolType.Class),
+      )
+      _ = assertNoDiff(
+        classes.show,
+        """|class com.mcpshared.McpProbeAlpha
+           |class com.mcpshared.McpProbeBeta
+           |""".stripMargin,
+        "query: globSearch(\"McpProbe\", Set(SymbolType.Class))",
+      )
+      _ = assertEquals(classes.cappedByResultLimit, false)
+      _ = assertEquals(classes.searchBudgetExhausted, false)
+
+      // the package is declared in both modules, but reported once
+      packages <- server.headServer.queryEngine.globSearch(
+        "mcpshared",
+        Set(SymbolType.Package),
+      )
+      _ = assertNoDiff(
+        packages.show,
+        """|package com.mcpshared
+           |""".stripMargin,
+        "query: globSearch(\"mcpshared\", Set(SymbolType.Package))",
+      )
+
+      // packages are not returned when the requested types exclude them
+      notPackages <- server.headServer.queryEngine.globSearch(
+        "mcpshared",
+        Set(SymbolType.Class),
+      )
+      _ = assertNoDiff(
+        notPackages.show,
+        "No symbols found.",
+        "query: globSearch(\"mcpshared\", Set(SymbolType.Class))",
+      )
+    } yield ()
+  }
+
+  test("glob search ignores packages from unknown targets") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/a/src/main/scala/com/active/Main.scala
+           |package com.active
+           |
+           |object Main
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/active/Main.scala")
+      _ = assertNoDiagnostics()
+
+      // Package entries can outlive their build targets after a build reimport.
+      _ = server.headServer.workspaceSymbols.addWorkspacePackages(
+        Seq(
+          WorkspaceSymbolInformation(
+            "com/staleprobe/StaleProbe#",
+            Kind.CLASS,
+            new Range(),
+          )
+        ),
+        new BuildTargetIdentifier("stale-target"),
+      )
+      result <- server.headServer.queryEngine.globSearch(
+        "staleprobe",
+        Set(SymbolType.Package),
+      )
+      _ = assertNoDiff(
+        result.show,
+        "No symbols found.",
+        "packages from build targets that no longer exist must be ignored",
+      )
+    } yield ()
+  }
+
+  test("glob search module dependency - workspace") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {},
+           |  "b": {"libraryDependencies": ["com.lihaoyi::sourcecode:0.1.7"]}
+           |}
+           |/a/src/main/scala/com/module_a/OnlyA.scala
+           |package com.module_a
+           |
+           |class OnlyA
+           |/b/src/main/scala/com/module_b/OnlyB.scala
+           |package com.module_b
+           |
+           |class OnlyB
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/module_a/OnlyA.scala")
+      _ = assertNoDiagnostics()
+
+      // `sourcecode` is only on module "b"'s classpath, dependency search is
+      // workspace wide regardless
+      result <- server.headServer.queryEngine.globSearch(
+        "Enclosing",
+        Set(SymbolType.Class, SymbolType.Object),
+      )
+      _ = assert(
+        result.show.contains("sourcecode.Enclosing"),
+        s"""|query: globSearch("Enclosing", Set(SymbolType.Class, SymbolType.Object))
+            |expected a `sourcecode.Enclosing` result, but got:
+            |${result.show}""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("glob search budget exhausted - dependencies") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/a/src/main/scala/Main.scala
+           |object Main
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ = assertNoDiagnostics()
+
+      // longer than `Fuzzy.PrefixSearchLimit`, so not a short query, but broad
+      // enough to exceed `ClasspathSearch.maxNonExactMatches`, which allows 10
+      // non-exact matches, all of them from the JDK here
+      result <- server.headServer.queryEngine.globSearch(
+        "String",
+        Set.empty,
+      )
+      _ = assert(
+        result.searchBudgetExhausted,
+        s"""|query: globSearch("String", Set.empty)
+            |expected the classpath search to report incompleteness, but got:
+            |${result.show}""".stripMargin,
+      )
+      _ = assert(
+        result.show.contains("additional matches may exist"),
+        s"""|query: globSearch("String", Set.empty)
+            |expected an incompleteness notice, but got:
+            |${result.show}""".stripMargin,
       )
     } yield ()
   }


### PR DESCRIPTION
Fixes the issue with the `glob-search`: https://github.com/scalameta/metals/issues/8769

---

- `glob-search` and `typed-glob-search` now search all modules
- the `fileInFocus` parameter is removed
- results are deduplicated, ranked by relevance and capped (configurable via `-Dmetals.max-mcp-search-results`, default `100`)
- the response tells the caller when matches were dropped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved MCP symbol search with case-insensitive, name-boundary matching across workspace modules and dependencies.
  * Added typed filtering for symbol categories, including packages, with improved relevance ranking and duplicate removal.
  * Added configurable result limits, defaulting to 100, with clear partial-result indicators when limits or search budgets are reached.
  * Simplified searches by removing the file-in-focus requirement.

* **Documentation**
  * Expanded MCP search behavior, configuration, and release history documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->