### PR TITLE
improvement: Use  MBT route when running tests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -41,6 +41,9 @@ trait LogForwarder {
   def warn(message: String): Unit = ()
   def info(message: String): Unit = ()
   def log(message: String): Unit = ()
+
+  def infoWithOrigin(originId: String, message: String): Unit = info(message)
+  def errorWithOrigin(originId: String, message: String): Unit = error(message)
 }
 
 /**
@@ -292,13 +295,15 @@ final class ForwardingMetalsBuildClient(
 
   @JsonNotification("run/printStdout")
   def runPrintStdout(params: b.PrintParams): Unit = {
-    forwarders.get().foreach(_.info(params.getMessage()))
+    val originId = Option(params.getOriginId).getOrElse("")
+    forwarders.get().foreach(_.infoWithOrigin(originId, params.getMessage()))
     runPrintOutput(params)
   }
 
   @JsonNotification("run/printStderr")
   def runPrintStderr(params: b.PrintParams): Unit = {
-    forwarders.get().foreach(_.error(params.getMessage()))
+    val originId = Option(params.getOriginId).getOrElse("")
+    forwarders.get().foreach(_.errorWithOrigin(originId, params.getMessage()))
     runPrintOutput(params)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -106,6 +106,14 @@ class DebugProvider(
   private val currentRunner =
     new ju.concurrent.atomic.AtomicReference[DebugRunner](null)
 
+  private case class OriginCallbacks(
+      onInfo: String => Unit,
+      onError: String => Unit,
+  )
+
+  private val originListeners =
+    new ju.concurrent.ConcurrentHashMap[String, OriginCallbacks]()
+
   override def info(message: String): Unit = {
     val runner = currentRunner.get()
     if (runner != null) runner.stdout(message)
@@ -114,6 +122,81 @@ class DebugProvider(
   override def error(message: String): Unit = {
     val runner = currentRunner.get()
     if (runner != null) runner.error(message)
+  }
+
+  override def infoWithOrigin(originId: String, message: String): Unit = {
+    val runner = currentRunner.get()
+    if (runner != null) runner.stdout(message)
+    Option(originListeners.get(originId)).foreach(_.onInfo(message))
+  }
+
+  override def errorWithOrigin(originId: String, message: String): Unit = {
+    val runner = currentRunner.get()
+    if (runner != null) runner.error(message)
+    Option(originListeners.get(originId)).foreach(_.onError(message))
+  }
+
+  /**
+   * Whether tests for this target should be run via BSP `buildTarget/test`
+   * (same path as non-debug editor test runs for MBT).
+   */
+  def usesBuildTargetTest(id: BuildTargetIdentifier): Boolean =
+    buildTargets.buildServerOf(id).exists(_.isMbt)
+
+  /**
+   * Run tests through BSP `buildTarget/test`, capturing process output.
+   * Used by MCP and mirrors [[runMbtTestLocally]] without a DAP session.
+   * Uses request-specific origin ID routing to isolate output from concurrent requests.
+   */
+  def runBuildTargetTest(
+      id: BuildTargetIdentifier,
+      testSuites: b.ScalaTestSuites,
+      cancelPromise: Promise[Unit],
+      verbose: Boolean,
+  )(implicit ec: ExecutionContext): Either[String, Future[String]] = {
+    buildTargets
+      .buildServerOf(id)
+      .toRight(s"No build server connection for $id")
+      .map { buildServer =>
+        val buffer = new StringBuffer()
+        val originId = ju.UUID.randomUUID().toString()
+        val onInfo: String => Unit = msg => if (verbose) buffer.append(msg)
+        val onError: String => Unit = msg => buffer.append(msg)
+        originListeners.put(originId, OriginCallbacks(onInfo, onError))
+        val testParams = scalaTestParams(id, testSuites, originId)
+        buildServer
+          .buildTargetTest(testParams, cancelPromise)
+          .map { result =>
+            val suites = testSuites.getSuites.asScala.map(_.getClassName)
+            val status =
+              if (result.getStatusCode == b.StatusCode.OK) "passed"
+              else "failed"
+            val summary =
+              s"""|
+                  |${suites.map(name => s"$name: $status").mkString("\n")}
+                  |Status: ${result.getStatusCode}
+                  |""".stripMargin
+            buffer.append(summary)
+            buffer.toString
+          }
+          .andThen { case _ => originListeners.remove(originId) }
+          .recoverWith { case NonFatal(e) =>
+            originListeners.remove(originId)
+            Future.failed(e)
+          }
+      }
+  }
+
+  private def scalaTestParams(
+      id: BuildTargetIdentifier,
+      testSuites: b.ScalaTestSuites,
+      originId: String,
+  ): b.TestParams = {
+    val testParams = new b.TestParams(singletonList(id))
+    testParams.setOriginId(originId)
+    testParams.setDataKind(b.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION)
+    testParams.setData(testSuites.toJson)
+    testParams
   }
 
   override def cancel(): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
@@ -49,6 +49,57 @@ class McpTestRunner(
         .inverseSources(path)
         .toRight(s"Could not find build target for $path")
       jvmTestEnv = debugProvider.jvmTestEnvironment(id)
+      result <-
+        if (debugProvider.usesBuildTargetTest(id)) {
+          // Same path as non-debug editor runs for MBT: BSP buildTarget/test.
+          Right {
+            jvmTestEnv.flatMap { env =>
+              val testSuites = createTestSuites(testSelection, env)
+              debugProvider.runBuildTargetTest(
+                id,
+                testSuites,
+                cancelPromise,
+                verbose,
+              ) match {
+                case Right(future) => future.map(output => AnsiFilter()(output))
+                case Left(error) => Future.successful(error)
+              }
+            }
+          }
+        } else {
+          runLocally(
+            id,
+            path,
+            testSelection,
+            jvmTestEnv,
+            cancelPromise,
+            verbose,
+          )
+        }
+    } yield result
+  }
+
+  private def createTestSuites(
+      testSelection: b.ScalaTestSuiteSelection,
+      env: Option[b.JvmEnvironmentItem],
+  ): b.ScalaTestSuites = {
+    val settings = DebugProvider.scalaTestLocalRunSettings(workspace, env)
+    new b.ScalaTestSuites(
+      List(testSelection).asJava,
+      settings.jvmOptions.asJava,
+      settings.environmentVariablesAsStrings.asJava,
+    )
+  }
+
+  private def runLocally(
+      id: b.BuildTargetIdentifier,
+      path: AbsolutePath,
+      testSelection: b.ScalaTestSuiteSelection,
+      jvmTestEnv: Future[Option[b.JvmEnvironmentItem]],
+      cancelPromise: Promise[Unit],
+      verbose: Boolean,
+  ): Either[String, Future[String]] = {
+    for {
       projectFut <- debugProvider.createDebugeeProjectForTests(
         id,
         cancelPromise,
@@ -58,12 +109,7 @@ class McpTestRunner(
       for {
         _ <- compilations.compileFile(path)
         env <- jvmTestEnv
-        settings = DebugProvider.scalaTestLocalRunSettings(workspace, env)
-        testSuites = new b.ScalaTestSuites(
-          List(testSelection).asJava,
-          settings.jvmOptions.asJava,
-          settings.environmentVariablesAsStrings.asJava,
-        )
+        testSuites = createTestSuites(testSelection, env)
         discovered <- debugProvider.discoverTests(id, testSuites)
         project <- projectFut
         listener = new McpDebuggeeListener(verbose)

--- a/tests/unit/src/test/scala/tests/mcp/McpRunTestSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpRunTestSuite.scala
@@ -296,6 +296,97 @@ class McpRunTestSuite extends BaseLspSuite("mcp-test") {
     } yield ()
   }
 
+  test("concurrent-requests-output-isolation", maxRetry = 3) {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "libraryDependencies" : ["org.scalameta::munit:1.0.0-M4"]
+           |  }
+           |}
+           |/a/src/test/scala/a/ConcurrentTestSuiteA.scala
+           |package a
+           |
+           |class ConcurrentTestSuiteA extends munit.FunSuite {
+           |  test("suite-a-test") {
+           |    println("OUTPUT_FROM_SUITE_A_UNIQUE_MARKER")
+           |    assert(true)
+           |  }
+           |}
+           |
+           |/a/src/test/scala/a/ConcurrentTestSuiteB.scala
+           |package a
+           |
+           |class ConcurrentTestSuiteB extends munit.FunSuite {
+           |  test("suite-b-test") {
+           |    println("OUTPUT_FROM_SUITE_B_UNIQUE_MARKER")
+           |    assert(true)
+           |  }
+           |}
+           |
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/test/scala/a/ConcurrentTestSuiteA.scala")
+      _ <- server.didOpen("a/src/test/scala/a/ConcurrentTestSuiteB.scala")
+      _ = assertNoDiagnostics()
+      _ <- server.server.indexingPromise.future
+      pathA = server.toPath("a/src/test/scala/a/ConcurrentTestSuiteA.scala")
+      pathB = server.toPath("a/src/test/scala/a/ConcurrentTestSuiteB.scala")
+
+      futureA = server.headServer.mcpTestRunner
+        .runTests(
+          "a.ConcurrentTestSuiteA",
+          Some(pathA),
+          None,
+          verbose = true,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      futureB = server.headServer.mcpTestRunner
+        .runTests(
+          "a.ConcurrentTestSuiteB",
+          Some(pathB),
+          None,
+          verbose = true,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+
+      resultA <- futureA
+      resultB <- futureB
+
+      _ = assert(
+        resultA.contains("OUTPUT_FROM_SUITE_A_UNIQUE_MARKER"),
+        s"Suite A result should contain its own output: $resultA",
+      )
+      _ = assert(
+        !resultA.contains("OUTPUT_FROM_SUITE_B_UNIQUE_MARKER"),
+        s"Suite A result should NOT contain Suite B's output: $resultA",
+      )
+      _ = assert(
+        resultB.contains("OUTPUT_FROM_SUITE_B_UNIQUE_MARKER"),
+        s"Suite B result should contain its own output: $resultB",
+      )
+      _ = assert(
+        !resultB.contains("OUTPUT_FROM_SUITE_A_UNIQUE_MARKER"),
+        s"Suite B result should NOT contain Suite A's output: $resultB",
+      )
+      _ = assert(
+        resultA.contains("ConcurrentTestSuiteA"),
+        s"Suite A result should reference Suite A: $resultA",
+      )
+      _ = assert(
+        resultB.contains("ConcurrentTestSuiteB"),
+        s"Suite B result should reference Suite B: $resultB",
+      )
+    } yield ()
+  }
+
   test("individual-test-execution", maxRetry = 3) {
     cleanWorkspace()
     for {


### PR DESCRIPTION
Unfortunately, we can't really do the same as we do with normal DAP running, since we don't have a fully fledged client inside metals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running Scala test suites through the build system’s test execution pathway.
  * Test output now includes captured build and per-suite status information.
  * Added cancellation support for build-based test runs.
  * Test output is cleaned up for improved readability.

* **Bug Fixes**
  * Retained local test execution when build-based testing is unavailable.
  * Improved concurrent test runs so each result contains only its corresponding suite’s output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->