### PR TITLE
fix(mcp): don't hang on linkage error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -536,6 +536,7 @@ lazy val `metals-mcp` = project
     sharedSettings,
     moduleName := "metals-mcp",
     Compile / mainClass := Some("scala.meta.metals.McpMain"),
+    Compile / run / javaOptions ++= sharedJavaOptions,
   )
   .dependsOn(metals)
 

--- a/mtags/src/main/scala/scala/meta/internal/metals/SemanticdbDefinition.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/SemanticdbDefinition.scala
@@ -99,6 +99,7 @@ object SemanticdbDefinition {
         try mtags.indexRoot()
         catch {
           case NonFatal(_) =>
+          case _: LinkageError =>
         }
         Some(mtags)
       case _ => None


### PR DESCRIPTION
Found while testing the [`glob-search`](https://github.com/scalameta/metals/pull/8776) with metals-mcp on a large workspace: tool calls timed out instead of failing fast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Java indexing resilience by continuing when linkage-related errors occur.
* **Configuration**
  * Applied shared runtime options when launching forked project runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->