### PR TITLE
feat(mcp): resolve test suites across modules

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpSymbolSearch.scala
@@ -56,6 +56,16 @@ class McpSymbolSearch(
   def exactSearch(
       query: String,
       path: Option[AbsolutePath],
+  ): Seq[SearchResult] =
+    exactSearchInTarget(query, singleBuildTarget(path))
+
+  /** Search every workspace build target for an exact FQCN match. */
+  def exactSearchAllTargets(query: String): Seq[SearchResult] =
+    exactSearchInTarget(query, None)
+
+  private def exactSearchInTarget(
+      query: String,
+      target: Option[BuildTargetIdentifier],
   ): Seq[SearchResult] = {
     val matches: String => Boolean = { symbol =>
       symbol.fqcn == query
@@ -64,7 +74,7 @@ class McpSymbolSearch(
       WorkspaceSymbolQuery.exact(query),
       matches,
       Set.empty,
-      target = singleBuildTarget(path),
+      target,
     ).results
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
@@ -42,9 +42,10 @@ class McpTestRunner(
     }
     val cancelPromise = Promise[Unit]()
     for {
-      path <- optPath
-        .orElse(resolvePath(testClass))
-        .toRight(s"Missing path to test suite and failed to resolve it.")
+      path <- optPath match {
+        case Some(path) => Right(path)
+        case None => resolvePath(testClass)
+      }
       id <- buildTargets
         .inverseSources(path)
         .toRight(s"Could not find build target for $path")
@@ -80,8 +81,15 @@ class McpTestRunner(
     }
   }
 
-  private def resolvePath(fqcn: String): Option[AbsolutePath] = {
-    mcpSearch.exactSearch(fqcn, None).flatMap(_.definitionPath).headOption
+  private def resolvePath(fqcn: String): Either[String, AbsolutePath] = {
+    mcpSearch
+      .exactSearchAllTargets(fqcn)
+      .flatMap(_.definitionPath)
+      .distinct match {
+      case Seq(path) => Right(path)
+      case Nil => Left("Missing path to test suite and failed to resolve it.")
+      case _ => Left(s"Multiple test suites found for $fqcn. Provide testFile.")
+    }
   }
 }
 

--- a/tests/unit/src/test/scala/tests/mcp/McpRunTestSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpRunTestSuite.scala
@@ -147,6 +147,85 @@ class McpRunTestSuite extends BaseLspSuite("mcp-test") {
     } yield ()
   }
 
+  // Regression: without testFile, resolve must work across modules — symbol
+  // search used to scope to the first build target only and miss suites in others.
+  test("resolve-test-class-without-path-multi-module", maxRetry = 3) {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {},
+           |  "b": {
+           |    "libraryDependencies" : ["org.scalameta::munit:1.0.0-M4"]
+           |  }
+           |}
+           |/b/src/test/scala/b/MultiModuleMcpSuite.scala
+           |package b
+           |
+           |class MultiModuleMcpSuite extends munit.FunSuite {
+           |  test("works") {
+           |    assert(true)
+           |  }
+           |}
+           |
+           |""".stripMargin
+      )
+      _ <- server.didOpen("b/src/test/scala/b/MultiModuleMcpSuite.scala")
+      _ = assertNoDiagnostics()
+      _ <- server.server.indexingPromise.future
+      result <- server.headServer.mcpTestRunner
+        .runTests(
+          "b.MultiModuleMcpSuite",
+          None,
+          None,
+          verbose = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        result.contains("1 tests, 1 passed"),
+        s"Expected multi-module suite to resolve from testClass alone; got:\n$result",
+      )
+    } yield ()
+  }
+
+  test("reject-ambiguous-test-class-without-path") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {},
+           |  "b": {}
+           |}
+           |/a/src/main/scala/duplicate/A.scala
+           |package duplicate
+           |class McpSuite
+           |
+           |/b/src/main/scala/duplicate/B.scala
+           |package duplicate
+           |class McpSuite
+           |""".stripMargin
+      )
+      _ <- server.server.indexingPromise.future
+      result = server.headServer.mcpTestRunner.runTests(
+        "duplicate.McpSuite",
+        None,
+        None,
+        verbose = false,
+      )
+      _ = result match {
+        case Left(error) => assert(error.contains("Provide testFile"), error)
+        case Right(_) =>
+          throw new RuntimeException("Expected an ambiguous suite error")
+      }
+    } yield ()
+  }
+
   test("zio-test", maxRetry = 3) {
     cleanWorkspace()
     for {


### PR DESCRIPTION
Follow-up to [`glob-search`](https://github.com/scalameta/metals/pull/8776) (stacked on top of that branch)

Resolves MCP test suites across all modules when `testFile` is omitted.

---

Current behaviour:

<details>
  <summary>metals_scala_mcp_test { "testClass": "tests.mcp.McpRunTestSuite" }</summary>

```
Error: Error: Missing path to test suite and failed to resolve it.
```
</details>

Fixed:

<details>
  <summary>metals_scala_mcp_dev_test { "testClass": "tests.mcp.McpRunTestSuite" }</summary>

```
tests.mcp.McpRunTestSuite:
  + basic passed
  + mcp-run-tests-respects-test-jvmopts passed
  + resolve-test-class-without-path-multi-module passed
  + zio-test passed
  + testng passed
  + individual-test-execution passed
Execution took 16327ms
6 tests, 6 passed, 0 failed, 0 skipped
```
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP symbol searches now scan workspace modules and dependencies without requiring a file-in-focus.
  - Added case-insensitive, exact name-boundary matching with package and symbol-type filtering.
  - Search results are deduplicated, ranked, sorted, and capped at 100 by default.
  - Added configuration for customizing the maximum result count.
  - Partial-result messages indicate when search limits or result caps apply.

- **Bug Fixes**
  - Improved test-class resolution across multi-module workspaces.
  - Searches now handle build-target packages and dependency results more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->