### PR TITLE
fix(mcp): don't hang on linkage error (#8783)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -791,6 +791,7 @@ lazy val `metals-mcp` = project
     sharedSettings,
     moduleName := "metals-mcp",
     Compile / mainClass := Some("scala.meta.metals.McpMain"),
+    Compile / run / javaOptions ++= sharedJavaOptions,
   )
   .dependsOn(metals)
 

--- a/mtags/src/main/scala/scala/meta/internal/metals/SemanticdbDefinition.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/SemanticdbDefinition.scala
@@ -106,6 +106,7 @@ object SemanticdbDefinition {
         try indexer.indexRoot()
         catch {
           case NonFatal(_) =>
+          case _: LinkageError =>
         }
         Some(indexer)
       case Semanticdb.Language.PROTOBUF =>


### PR DESCRIPTION
Port from main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Java indexing resilience by handling linkage-related errors more reliably, reducing the chance of indexing failures.

* **Chores**
  * Updated project run settings to apply shared JVM options consistently during development and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->