### PR TITLE
perf(semanticdb): serialize compilation per compiler

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -45,6 +45,7 @@ import ch.epfl.scala.bsp4j.CompileReport
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.RemovalListener
 import com.google.common.cache.RemovalNotification
+import com.google.common.collect.MapMaker
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionItemKind
 import org.eclipse.lsp4j.CompletionList
@@ -162,6 +163,10 @@ class Compilers(
     presentationCompilerWorksheetsCache.asMap()
 
   private val worksheetsDigests = new TrieMap[AbsolutePath, String]()
+  private val fallbackCompilerIdentities =
+    new MapMaker()
+      .weakKeys()
+      .makeMap[PresentationCompiler, java.lang.Boolean]()
 
   private val cache = jcache.asScala
   private def buildTargetPCFromCache(
@@ -175,7 +180,7 @@ class Compilers(
 
   // The "fallback" compiler is used for source files that don't belong to a build target.
   private def fallbackCompiler: PresentationCompiler = {
-    jcache
+    val compiler = jcache
       .compute(
         PresentationCompilerKey.DefaultScala,
         (_, value) => {
@@ -206,6 +211,8 @@ class Compilers(
         },
       )
       .await
+    fallbackCompilerIdentities.put(compiler, java.lang.Boolean.TRUE)
+    compiler
   }
 
   private def javaFallbackCompiler: PresentationCompiler = {
@@ -1756,8 +1763,13 @@ class Compilers(
 
   private[metals] def semanticdbCompiler(
       source: AbsolutePath
-  ): PresentationCompiler =
-    loadCompiler(source).getOrElse(fallbackCompiler)
+  ): InteractiveSemanticdbCompilerSelection = {
+    val compiler = loadCompiler(source).getOrElse(fallbackCompiler)
+    new InteractiveSemanticdbCompilerSelection(
+      compiler,
+      isFallback = fallbackCompilerIdentities.containsKey(compiler),
+    )
+  }
 
   def semanticdbTextDocument(
       source: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -1754,12 +1754,16 @@ class Compilers(
     debugItem
   }
 
+  private[metals] def semanticdbCompiler(
+      source: AbsolutePath
+  ): PresentationCompiler =
+    loadCompiler(source).getOrElse(fallbackCompiler)
+
   def semanticdbTextDocument(
       source: AbsolutePath,
       text: String,
+      pc: PresentationCompiler,
   ): s.TextDocument = {
-    val pc = loadCompiler(source).getOrElse(fallbackCompiler)
-
     val (prependedLinesSize, modifiedText) =
       Option
         .when(source.isSbt)(

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -2,6 +2,9 @@ package scala.meta.internal.metals
 
 import java.nio.charset.Charset
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.LongAdder
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import scala.util.Failure
@@ -43,9 +46,13 @@ final class InteractiveSemanticdbs(
 
   private val textDocumentCache =
     new InteractiveSemanticdbCache[AbsolutePath, s.TextDocument]()
+  private val compilationMetrics = new InteractiveSemanticdbCompilationMetrics()
+  private val nextCompilerLaneId = new AtomicLong()
   // Weak keys avoid extending the lifetime of evicted presentation compilers.
   private val compilerLanes =
-    new MapMaker().weakKeys().makeMap[AnyRef, Object]()
+    new MapMaker()
+      .weakKeys()
+      .makeMap[AnyRef, InteractiveSemanticdbCompilationLaneIdentity]()
 
   def reset(): Unit = {
     textDocumentCache.clear()
@@ -53,6 +60,7 @@ final class InteractiveSemanticdbs(
 
   override def cancel(): Unit = {
     reset()
+    compilationMetrics.logSummary()
   }
 
   override def textDocument(
@@ -151,8 +159,14 @@ final class InteractiveSemanticdbs(
   ): InteractiveSemanticdbCompilation =
     if (source.isJavaFilename) {
       val buildTarget = buildTargets.inferBuildTarget(source)
+      compilationMetrics.recordSelection(
+        InteractiveSemanticdbCompilationLaneKind.Java
+      )
       new InteractiveSemanticdbCompilation(
-        compilationLane(javaInteractiveSemanticdb),
+        compilationLane(
+          javaInteractiveSemanticdb,
+          InteractiveSemanticdbCompilationLaneKind.Java,
+        ),
         InteractiveSemanticdbCompilationContext.Java(
           buildTarget.map(_.getUri())
         ),
@@ -160,19 +174,42 @@ final class InteractiveSemanticdbs(
       )
     } else {
       val selectedCompilers = compilers()
-      val compiler = selectedCompilers.semanticdbCompiler(source)
-      val lane = compilationLane(compiler)
+      val selection = selectedCompilers.semanticdbCompiler(source)
+      val kind =
+        if (selection.isFallback)
+          InteractiveSemanticdbCompilationLaneKind.ScalaFallback
+        else InteractiveSemanticdbCompilationLaneKind.ScalaTarget
+      compilationMetrics.recordSelection(kind)
+      val lane = compilationLane(selection.compiler, kind)
       new InteractiveSemanticdbCompilation(
         lane,
         InteractiveSemanticdbCompilationContext.Scala(lane),
-        () => selectedCompilers.semanticdbTextDocument(source, text, compiler),
+        () =>
+          selectedCompilers.semanticdbTextDocument(
+            source,
+            text,
+            selection.compiler,
+          ),
       )
     }
 
   private def compilationLane(
-      compiler: AnyRef
+      compiler: AnyRef,
+      kind: InteractiveSemanticdbCompilationLaneKind,
   ): InteractiveSemanticdbCompilationLane = {
-    val identity = compilerLanes.computeIfAbsent(compiler, _ => new Object())
+    val identity = compilerLanes.computeIfAbsent(
+      compiler,
+      _ => {
+        val laneId = nextCompilerLaneId.incrementAndGet()
+        compilationMetrics.recordLaneCreated(kind)
+        new InteractiveSemanticdbCompilationLaneIdentity(
+          new Object(),
+          laneId,
+          kind,
+          compilationMetrics,
+        )
+      },
+    )
     InteractiveSemanticdbCompilationLane(identity)
   }
 
@@ -185,6 +222,11 @@ private[metals] final class InteractiveSemanticdbCompilation(
 ) {
   def run(): Try[s.TextDocument] = Try(compile())
 }
+
+private[metals] final class InteractiveSemanticdbCompilerSelection(
+    val compiler: scala.meta.pc.PresentationCompiler,
+    val isFallback: Boolean,
+)
 
 private[metals] final class InteractiveSemanticdbCache[K, V <: AnyRef] {
   private val values =
@@ -273,21 +315,191 @@ private[metals] object InteractiveSemanticdbCompilationContext {
       extends InteractiveSemanticdbCompilationContext
 }
 
+private[metals] sealed abstract class InteractiveSemanticdbCompilationLaneKind(
+    val label: String
+)
+
+private[metals] object InteractiveSemanticdbCompilationLaneKind {
+  case object ScalaTarget
+      extends InteractiveSemanticdbCompilationLaneKind("scala-target")
+  case object ScalaFallback
+      extends InteractiveSemanticdbCompilationLaneKind("scala-fallback")
+  case object Java extends InteractiveSemanticdbCompilationLaneKind("java")
+}
+
+private[metals] final class InteractiveSemanticdbCompilationLaneIdentity(
+    val monitor: Object,
+    val id: Long,
+    val kind: InteractiveSemanticdbCompilationLaneKind,
+    val metrics: InteractiveSemanticdbCompilationMetrics,
+)
+
 private[metals] final class InteractiveSemanticdbCompilationLane private (
-    private val compiler: AnyRef
+    private val identity: InteractiveSemanticdbCompilationLaneIdentity
 ) {
   override def equals(other: Any): Boolean = other match {
     case that: InteractiveSemanticdbCompilationLane =>
-      compiler eq that.compiler
+      identity.monitor eq that.identity.monitor
     case _ => false
   }
 
-  override def hashCode(): Int = System.identityHashCode(compiler)
+  override def hashCode(): Int = System.identityHashCode(identity.monitor)
 
-  def serialized[A](action: => A): A = compiler.synchronized(action)
+  def serialized[A](action: => A): A =
+    identity.metrics.measure(
+      identity.id,
+      identity.kind,
+      identity.monitor,
+    )(action)
 }
 
 private[metals] object InteractiveSemanticdbCompilationLane {
   def apply(compiler: AnyRef): InteractiveSemanticdbCompilationLane =
-    new InteractiveSemanticdbCompilationLane(compiler)
+    create(
+      compiler,
+      id = 1L,
+      InteractiveSemanticdbCompilationLaneKind.ScalaTarget,
+      new InteractiveSemanticdbCompilationMetrics(),
+    )
+
+  private[metals] def create(
+      monitor: AnyRef,
+      id: Long,
+      kind: InteractiveSemanticdbCompilationLaneKind,
+      metrics: InteractiveSemanticdbCompilationMetrics,
+  ): InteractiveSemanticdbCompilationLane =
+    new InteractiveSemanticdbCompilationLane(
+      new InteractiveSemanticdbCompilationLaneIdentity(
+        monitor,
+        id,
+        kind,
+        metrics,
+      )
+    )
 }
+
+private[metals] final class InteractiveSemanticdbCompilationMetrics(
+    nanoTime: () => Long = () => System.nanoTime()
+) {
+  private val scalaTargetSelections = new LongAdder()
+  private val scalaFallbackSelections = new LongAdder()
+  private val javaSelections = new LongAdder()
+  private val scalaTargetLanes = new LongAdder()
+  private val scalaFallbackLanes = new LongAdder()
+  private val javaLanes = new LongAdder()
+  private val scalaTargetCompilations = new LongAdder()
+  private val scalaFallbackCompilations = new LongAdder()
+  private val javaCompilations = new LongAdder()
+  private val totalQueueNanos = new LongAdder()
+  private val maximumQueueNanos = new AtomicLong()
+  private val totalCompilationNanos = new LongAdder()
+  private val maximumCompilationNanos = new AtomicLong()
+  private val activeLanes = new AtomicInteger()
+  private val maximumActiveLanes = new AtomicInteger()
+
+  def recordSelection(kind: InteractiveSemanticdbCompilationLaneKind): Unit =
+    kind match {
+      case InteractiveSemanticdbCompilationLaneKind.ScalaTarget =>
+        scalaTargetSelections.increment()
+      case InteractiveSemanticdbCompilationLaneKind.ScalaFallback =>
+        scalaFallbackSelections.increment()
+      case InteractiveSemanticdbCompilationLaneKind.Java =>
+        javaSelections.increment()
+    }
+
+  def recordLaneCreated(
+      kind: InteractiveSemanticdbCompilationLaneKind
+  ): Unit = counterForKind(
+    kind,
+    scalaTargetLanes,
+    scalaFallbackLanes,
+    javaLanes,
+  ).increment()
+
+  def measure[A](
+      laneId: Long,
+      kind: InteractiveSemanticdbCompilationLaneKind,
+      monitor: Object,
+  )(action: => A): A = {
+    val queuedAt = nanoTime()
+    monitor.synchronized {
+      val compilationStartedAt = nanoTime()
+      val queueNanos = compilationStartedAt - queuedAt
+      val active = activeLanes.incrementAndGet()
+      maximumActiveLanes.accumulateAndGet(active, Math.max)
+      counterForKind(
+        kind,
+        scalaTargetCompilations,
+        scalaFallbackCompilations,
+        javaCompilations,
+      ).increment()
+      try action
+      finally {
+        val compilationNanos = nanoTime() - compilationStartedAt
+        activeLanes.decrementAndGet()
+        totalQueueNanos.add(queueNanos)
+        maximumQueueNanos.accumulateAndGet(queueNanos, Math.max)
+        totalCompilationNanos.add(compilationNanos)
+        maximumCompilationNanos.accumulateAndGet(compilationNanos, Math.max)
+        scribe.debug(
+          s"Interactive SemanticDB compiler lane completed: lane_id=$laneId lane_kind=${kind.label} queue_ms=${nanosToMillis(queueNanos)} compilation_ms=${nanosToMillis(compilationNanos)} active_lanes=$active maximum_active_lanes=${maximumActiveLanes.get()}"
+        )
+      }
+    }
+  }
+
+  def snapshot: InteractiveSemanticdbCompilationMetricsSnapshot =
+    new InteractiveSemanticdbCompilationMetricsSnapshot(
+      scalaTargetSelections.sum(),
+      scalaFallbackSelections.sum(),
+      javaSelections.sum(),
+      scalaTargetLanes.sum(),
+      scalaFallbackLanes.sum(),
+      javaLanes.sum(),
+      scalaTargetCompilations.sum(),
+      scalaFallbackCompilations.sum(),
+      javaCompilations.sum(),
+      totalQueueNanos.sum(),
+      maximumQueueNanos.get(),
+      totalCompilationNanos.sum(),
+      maximumCompilationNanos.get(),
+      maximumActiveLanes.get(),
+    )
+
+  def logSummary(): Unit = {
+    val current = snapshot
+    scribe.debug(
+      s"Interactive SemanticDB compiler lane summary: scala_target_selections=${current.scalaTargetSelections} scala_fallback_selections=${current.scalaFallbackSelections} java_selections=${current.javaSelections} scala_target_lanes=${current.scalaTargetLanes} scala_fallback_lanes=${current.scalaFallbackLanes} java_lanes=${current.javaLanes} scala_target_compilations=${current.scalaTargetCompilations} scala_fallback_compilations=${current.scalaFallbackCompilations} java_compilations=${current.javaCompilations} total_queue_ms=${nanosToMillis(current.totalQueueNanos)} maximum_queue_ms=${nanosToMillis(current.maximumQueueNanos)} total_compilation_ms=${nanosToMillis(current.totalCompilationNanos)} maximum_compilation_ms=${nanosToMillis(current.maximumCompilationNanos)} maximum_active_lanes=${current.maximumActiveLanes}"
+    )
+  }
+
+  private def counterForKind(
+      kind: InteractiveSemanticdbCompilationLaneKind,
+      scalaTarget: LongAdder,
+      scalaFallback: LongAdder,
+      java: LongAdder,
+  ): LongAdder = kind match {
+    case InteractiveSemanticdbCompilationLaneKind.ScalaTarget => scalaTarget
+    case InteractiveSemanticdbCompilationLaneKind.ScalaFallback => scalaFallback
+    case InteractiveSemanticdbCompilationLaneKind.Java => java
+  }
+
+  private def nanosToMillis(nanos: Long): Long = nanos / 1000000L
+}
+
+private[metals] final class InteractiveSemanticdbCompilationMetricsSnapshot(
+    val scalaTargetSelections: Long,
+    val scalaFallbackSelections: Long,
+    val javaSelections: Long,
+    val scalaTargetLanes: Long,
+    val scalaFallbackLanes: Long,
+    val javaLanes: Long,
+    val scalaTargetCompilations: Long,
+    val scalaFallbackCompilations: Long,
+    val javaCompilations: Long,
+    val totalQueueNanos: Long,
+    val maximumQueueNanos: Long,
+    val totalCompilationNanos: Long,
+    val maximumCompilationNanos: Long,
+    val maximumActiveLanes: Int,
+)

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -1,7 +1,8 @@
 package scala.meta.internal.metals
 
 import java.nio.charset.Charset
-import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import scala.util.Success
 import scala.util.Try
@@ -14,6 +15,8 @@ import scala.meta.internal.mtags.Shebang
 import scala.meta.internal.mtags.TextDocumentLookup
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
+
+import com.google.common.collect.MapMaker
 
 /**
  * Produces SemanticDBs on-demand by using the presentation compiler.
@@ -37,9 +40,11 @@ final class InteractiveSemanticdbs(
 ) extends Cancelable
     with Semanticdbs {
 
-  private val textDocumentCache = Collections.synchronizedMap(
-    new java.util.HashMap[AbsolutePath, s.TextDocument]()
-  )
+  private val textDocumentCache =
+    new InteractiveSemanticdbCache[AbsolutePath, s.TextDocument]()
+  // Weak keys avoid extending the lifetime of evicted presentation compilers.
+  private val compilerLanes =
+    new MapMaker().weakKeys().makeMap[AnyRef, Object]()
 
   def reset(): Unit = {
     textDocumentCache.clear()
@@ -88,31 +93,28 @@ final class InteractiveSemanticdbs(
     if (isExcludedFile || !shouldTryCalculateInteractiveSemanticdb) {
       TextDocumentLookup.NotFound(source)
     } else {
-      val result = textDocumentCache.compute(
-        source,
-        (path, existingDoc) => {
-          unsavedContents.orElse(sourceText) match {
-            case None => null
-            case Some(text) =>
-              val adjustedText =
-                if (text.startsWith(Shebang.shebang))
-                  "//" + text.drop(2)
-                else text
-              val sha = MD5.compute(adjustedText)
-              if (existingDoc == null || existingDoc.md5 != sha) {
-                compile(path, adjustedText) match {
-                  case Success(doc) if doc != null =>
-                    if (!source.isDependencySource(workspace))
-                      semanticdbIndexer().onChange(source, doc)
-                    doc
-                  case _ => null
-                }
-              } else
-                existingDoc
+      val result = unsavedContents.orElse(sourceText) match {
+        case None => null
+        case Some(text) =>
+          val adjustedText =
+            if (text.startsWith(Shebang.shebang))
+              "//" + text.drop(2)
+            else text
+          val sha = MD5.compute(adjustedText)
+          textDocumentCache.compute(
+            source,
+            () => Try(compilationFor(source, adjustedText)),
+            _.md5 == sha,
+          ) { (path, compilation) =>
+            compilation.run() match {
+              case Success(doc) if doc != null =>
+                if (!source.isDependencySource(workspace))
+                  semanticdbIndexer().onChange(source, doc)
+                doc
+              case _ => null
+            }
           }
-
-        },
-      )
+      }
       TextDocumentLookup.fromOption(source, Option(result))
     }
   }
@@ -136,11 +138,134 @@ final class InteractiveSemanticdbs(
     }
   }
 
-  private def compile(source: AbsolutePath, text: String): Try[s.TextDocument] =
-    Try {
-      if (source.isJavaFilename)
-        javaInteractiveSemanticdb.textDocument(source, text)
-      else compilers().semanticdbTextDocument(source, text)
+  private def compilationFor(
+      source: AbsolutePath,
+      text: String,
+  ): InteractiveSemanticdbCompilation =
+    if (source.isJavaFilename) {
+      val buildTarget = buildTargets.inferBuildTarget(source)
+      new InteractiveSemanticdbCompilation(
+        compilationLane(javaInteractiveSemanticdb),
+        InteractiveSemanticdbCompilationContext.Java(
+          buildTarget.map(_.getUri())
+        ),
+        () => javaInteractiveSemanticdb.textDocument(source, text, buildTarget),
+      )
+    } else {
+      val selectedCompilers = compilers()
+      val compiler = selectedCompilers.semanticdbCompiler(source)
+      val lane = compilationLane(compiler)
+      new InteractiveSemanticdbCompilation(
+        lane,
+        InteractiveSemanticdbCompilationContext.Scala(lane),
+        () => selectedCompilers.semanticdbTextDocument(source, text, compiler),
+      )
     }
 
+  private def compilationLane(
+      compiler: AnyRef
+  ): InteractiveSemanticdbCompilationLane = {
+    val identity = compilerLanes.computeIfAbsent(compiler, _ => new Object())
+    InteractiveSemanticdbCompilationLane(identity)
+  }
+
+}
+
+private[metals] final class InteractiveSemanticdbCompilation(
+    val lane: InteractiveSemanticdbCompilationLane,
+    val context: InteractiveSemanticdbCompilationContext,
+    compile: () => s.TextDocument,
+) {
+  def run(): Try[s.TextDocument] = Try(compile())
+}
+
+private[metals] final class InteractiveSemanticdbCache[K, V <: AnyRef] {
+  private val values =
+    new ConcurrentHashMap[K, InteractiveSemanticdbCacheEntry[V]]()
+  private val lifecycleLock = new ReentrantReadWriteLock()
+
+  def clear(): Unit = {
+    val lock = lifecycleLock.writeLock()
+    lock.lock()
+    try {
+      values.clear()
+    } finally lock.unlock()
+  }
+
+  def remove(key: K): Unit = {
+    val lock = lifecycleLock.readLock()
+    lock.lock()
+    try values.remove(key)
+    finally lock.unlock()
+  }
+
+  def compute(
+      key: K,
+      prepare: () => Try[InteractiveSemanticdbCompilation],
+      isCurrent: V => Boolean,
+  )(compile: (K, InteractiveSemanticdbCompilation) => V): V = {
+    val lock = lifecycleLock.readLock()
+    lock.lock()
+    try {
+      prepare() match {
+        case Success(compilation) =>
+          val entry = values.compute(
+            key,
+            (path, existing) =>
+              if (
+                existing != null &&
+                existing.context == compilation.context &&
+                isCurrent(existing.value)
+              ) existing
+              else {
+                val value = compilation.lane.serialized(
+                  compile(path, compilation)
+                )
+                if (value == null) null
+                else
+                  new InteractiveSemanticdbCacheEntry(
+                    compilation.context,
+                    value,
+                  )
+              },
+          )
+          if (entry == null) null.asInstanceOf[V]
+          else entry.value
+        case _ => null.asInstanceOf[V]
+      }
+    } finally lock.unlock()
+  }
+}
+
+private final class InteractiveSemanticdbCacheEntry[V](
+    val context: InteractiveSemanticdbCompilationContext,
+    val value: V,
+)
+
+private[metals] sealed trait InteractiveSemanticdbCompilationContext
+
+private[metals] object InteractiveSemanticdbCompilationContext {
+  final case class Scala(lane: InteractiveSemanticdbCompilationLane)
+      extends InteractiveSemanticdbCompilationContext
+  final case class Java(buildTargetUri: Option[String])
+      extends InteractiveSemanticdbCompilationContext
+}
+
+private[metals] final class InteractiveSemanticdbCompilationLane private (
+    private val compiler: AnyRef
+) {
+  override def equals(other: Any): Boolean = other match {
+    case that: InteractiveSemanticdbCompilationLane =>
+      compiler eq that.compiler
+    case _ => false
+  }
+
+  override def hashCode(): Int = System.identityHashCode(compiler)
+
+  def serialized[A](action: => A): A = compiler.synchronized(action)
+}
+
+private[metals] object InteractiveSemanticdbCompilationLane {
+  def apply(compiler: AnyRef): InteractiveSemanticdbCompilationLane =
+    new InteractiveSemanticdbCompilationLane(compiler)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -4,6 +4,7 @@ import java.nio.charset.Charset
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
+import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
@@ -111,7 +112,13 @@ final class InteractiveSemanticdbs(
                 if (!source.isDependencySource(workspace))
                   semanticdbIndexer().onChange(source, doc)
                 doc
-              case _ => null
+              case Failure(exception) =>
+                scribe.debug(
+                  s"Interactive SemanticDB compilation failed for $source",
+                  exception,
+                )
+                null
+              case Success(_) => null
             }
           }
       }
@@ -182,6 +189,8 @@ private[metals] final class InteractiveSemanticdbCompilation(
 private[metals] final class InteractiveSemanticdbCache[K, V <: AnyRef] {
   private val values =
     new ConcurrentHashMap[K, InteractiveSemanticdbCacheEntry[V]]()
+  private val keyLocks =
+    new MapMaker().weakValues().makeMap[K, Object]()
   private val lifecycleLock = new ReentrantReadWriteLock()
 
   def clear(): Unit = {
@@ -189,13 +198,14 @@ private[metals] final class InteractiveSemanticdbCache[K, V <: AnyRef] {
     lock.lock()
     try {
       values.clear()
+      keyLocks.clear()
     } finally lock.unlock()
   }
 
   def remove(key: K): Unit = {
     val lock = lifecycleLock.readLock()
     lock.lock()
-    try values.remove(key)
+    try keyLock(key).synchronized(values.remove(key))
     finally lock.unlock()
   }
 
@@ -209,32 +219,44 @@ private[metals] final class InteractiveSemanticdbCache[K, V <: AnyRef] {
     try {
       prepare() match {
         case Success(compilation) =>
-          val entry = values.compute(
-            key,
-            (path, existing) =>
-              if (
-                existing != null &&
-                existing.context == compilation.context &&
-                isCurrent(existing.value)
-              ) existing
+          def current(entry: InteractiveSemanticdbCacheEntry[V]): Boolean =
+            entry != null &&
+              entry.context == compilation.context &&
+              isCurrent(entry.value)
+
+          val existing = values.get(key)
+          if (current(existing)) existing.value
+          else
+            keyLock(key).synchronized {
+              val refreshed = values.get(key)
+              if (current(refreshed)) refreshed.value
               else {
                 val value = compilation.lane.serialized(
-                  compile(path, compilation)
+                  compile(key, compilation)
                 )
-                if (value == null) null
-                else
-                  new InteractiveSemanticdbCacheEntry(
+                if (value == null) values.remove(key)
+                else {
+                  val entry = new InteractiveSemanticdbCacheEntry(
                     compilation.context,
                     value,
                   )
-              },
+                  values.put(key, entry)
+                }
+                value
+              }
+            }
+        case Failure(exception) =>
+          scribe.debug(
+            s"Interactive SemanticDB compiler selection failed for $key",
+            exception,
           )
-          if (entry == null) null.asInstanceOf[V]
-          else entry.value
-        case _ => null.asInstanceOf[V]
+          null.asInstanceOf[V]
       }
     } finally lock.unlock()
   }
+
+  private def keyLock(key: K): Object =
+    keyLocks.computeIfAbsent(key, _ => new Object())
 }
 
 private final class InteractiveSemanticdbCacheEntry[V](

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -210,7 +210,7 @@ final class InteractiveSemanticdbs(
         )
       },
     )
-    InteractiveSemanticdbCompilationLane(identity)
+    InteractiveSemanticdbCompilationLane.fromIdentity(identity)
   }
 
 }
@@ -376,6 +376,11 @@ private[metals] object InteractiveSemanticdbCompilationLane {
         metrics,
       )
     )
+
+  private[metals] def fromIdentity(
+      identity: InteractiveSemanticdbCompilationLaneIdentity
+  ): InteractiveSemanticdbCompilationLane =
+    new InteractiveSemanticdbCompilationLane(identity)
 }
 
 private[metals] final class InteractiveSemanticdbCompilationMetrics(

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
@@ -21,8 +21,16 @@ import scala.meta.internal.pc.JavaMetalsGlobal
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+
 trait JavaInteractiveSemanticdb {
   def textDocument(source: AbsolutePath, text: String): s.TextDocument
+
+  def textDocument(
+      source: AbsolutePath,
+      text: String,
+      buildTarget: Option[BuildTargetIdentifier],
+  ): s.TextDocument
 }
 
 class NoopJavaInteractiveSemanticdb extends JavaInteractiveSemanticdb {
@@ -31,6 +39,12 @@ class NoopJavaInteractiveSemanticdb extends JavaInteractiveSemanticdb {
       text: String,
   ): s.TextDocument =
     s.TextDocument()
+
+  override def textDocument(
+      source: AbsolutePath,
+      text: String,
+      buildTarget: Option[BuildTargetIdentifier],
+  ): s.TextDocument = textDocument(source, text)
 }
 
 class DownloadedJavaInteractiveSemanticdb(
@@ -41,7 +55,17 @@ class DownloadedJavaInteractiveSemanticdb(
 
   private val readonly = workspace.resolve(Directories.readonly)
 
-  def textDocument(source: AbsolutePath, text: String): s.TextDocument = {
+  override def textDocument(
+      source: AbsolutePath,
+      text: String,
+  ): s.TextDocument =
+    textDocument(source, text, buildTargets.inferBuildTarget(source))
+
+  override def textDocument(
+      source: AbsolutePath,
+      text: String,
+      buildTarget: Option[BuildTargetIdentifier],
+  ): s.TextDocument = {
     val workDir = AbsolutePath(
       Files.createTempDirectory("metals-javac-semanticdb")
     )
@@ -60,8 +84,7 @@ class DownloadedJavaInteractiveSemanticdb(
       }
 
     val sourceRoot = localSource.parent
-    val targetClasspath = buildTargets
-      .inferBuildTarget(source)
+    val targetClasspath = buildTarget
       .flatMap(buildTargets.targetJarClasspath)
       .getOrElse(Nil)
       .map(_.toString)

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -21,6 +21,7 @@ object TestGroups {
     "tests.WindowStateDidChangeLspSuite", "tests.DocumentSymbolLspSuite",
     "tests.WorkspaceSymbolExpectSuite", "tests.digest.DigestsSuite",
     "tests.MtagsSuite", "tests.ChosenBuildServerSuite", "tests.SemanticdbSuite",
+    "scala.meta.internal.metals.InteractiveSemanticdbCacheSuite",
     "tests.digest.MillDigestSuite", "tests.DocumentSymbolSuite",
     "tests.FoldingRangeSuite", "tests.JavadocSuite",
     "tests.MtagsEnrichmentsSuite", "tests.MtagsResolverSuite",

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/InteractiveSemanticdbCacheSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/InteractiveSemanticdbCacheSuite.scala
@@ -138,7 +138,7 @@ class InteractiveSemanticdbCacheSuite extends FunSuite {
     laneA,
   )
 
-  executionContext.test("different-target misses compile concurrently") {
+  executionContext.test("different-compiler misses compile concurrently") {
     implicit ec =>
       val cache = new InteractiveSemanticdbCache[String, String]()
       val workersReady = new CountDownLatch(2)
@@ -172,6 +172,85 @@ class InteractiveSemanticdbCacheSuite extends FunSuite {
         assertEquals(firstResult, "A.scala")
         assertEquals(secondResult, "B.scala")
       }
+  }
+
+  executionContext.test("metrics observe concurrent compiler lanes") {
+    implicit ec =>
+      val cache = new InteractiveSemanticdbCache[String, String]()
+      val metrics = new InteractiveSemanticdbCompilationMetrics()
+      val firstLane = InteractiveSemanticdbCompilationLane.create(
+        new Object(),
+        id = 1L,
+        InteractiveSemanticdbCompilationLaneKind.ScalaTarget,
+        metrics,
+      )
+      val secondLane = InteractiveSemanticdbCompilationLane.create(
+        new Object(),
+        id = 2L,
+        InteractiveSemanticdbCompilationLaneKind.ScalaTarget,
+        metrics,
+      )
+      val compileEntered = new CountDownLatch(2)
+      val releaseCompile = new CountDownLatch(1)
+
+      def lookup(path: String, lane: InteractiveSemanticdbCompilationLane) =
+        Future {
+          compute(cache, path, lane, _ => false) { _ =>
+            compileEntered.countDown()
+            await(releaseCompile, "release of measured compilations")
+            path
+          }
+        }
+
+      val first = lookup("A.scala", firstLane)
+      val second = lookup("B.scala", secondLane)
+      withRelease(releaseCompile) {
+        await(compileEntered, "both measured compiler lanes")
+      }
+
+      for {
+        _ <- first
+        _ <- second
+      } yield {
+        val snapshot = metrics.snapshot
+        assertEquals(snapshot.scalaTargetCompilations, 2L)
+        assertEquals(snapshot.scalaFallbackCompilations, 0L)
+        assertEquals(snapshot.maximumActiveLanes, 2)
+      }
+  }
+
+  test("metrics retain lane classes and timing") {
+    val millisecond = 1000000L
+    val timestamps = Iterator(0L, 5L * millisecond, 15L * millisecond)
+    val metrics =
+      new InteractiveSemanticdbCompilationMetrics(() => timestamps.next())
+    val lane = InteractiveSemanticdbCompilationLane.create(
+      new Object(),
+      id = 7L,
+      InteractiveSemanticdbCompilationLaneKind.ScalaFallback,
+      metrics,
+    )
+    metrics.recordSelection(
+      InteractiveSemanticdbCompilationLaneKind.ScalaFallback
+    )
+    metrics.recordLaneCreated(
+      InteractiveSemanticdbCompilationLaneKind.ScalaFallback
+    )
+
+    assertEquals(lane.serialized("compiled"), "compiled")
+
+    val snapshot = metrics.snapshot
+    assertEquals(snapshot.scalaTargetSelections, 0L)
+    assertEquals(snapshot.scalaFallbackSelections, 1L)
+    assertEquals(snapshot.javaSelections, 0L)
+    assertEquals(snapshot.scalaTargetLanes, 0L)
+    assertEquals(snapshot.scalaFallbackLanes, 1L)
+    assertEquals(snapshot.scalaFallbackCompilations, 1L)
+    assertEquals(snapshot.totalQueueNanos, 5L * millisecond)
+    assertEquals(snapshot.maximumQueueNanos, 5L * millisecond)
+    assertEquals(snapshot.totalCompilationNanos, 10L * millisecond)
+    assertEquals(snapshot.maximumCompilationNanos, 10L * millisecond)
+    assertEquals(snapshot.maximumActiveLanes, 1)
   }
 
   executionContext.test(

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/InteractiveSemanticdbCacheSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/InteractiveSemanticdbCacheSuite.scala
@@ -1,0 +1,464 @@
+package scala.meta.internal.metals
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutorService
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Failure
+import scala.util.Success
+
+import munit.FunSuite
+import munit.Location
+
+class InteractiveSemanticdbCacheSuite extends FunSuite {
+  private val compilerA = new Object()
+  private val compilerB = new Object()
+  private val fallbackCompiler = new Object()
+  private val laneA = InteractiveSemanticdbCompilationLane(compilerA)
+  private val laneB = InteractiveSemanticdbCompilationLane(compilerB)
+  private val timeout = 5.seconds
+  private val mustRemainBlockedFor = 250.millis
+
+  private val executionContext = FunFixture[ExecutionContextExecutorService](
+    setup = _ =>
+      ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4)),
+    // MUnit's default execution context is parasitic, so teardown can run on
+    // the worker that completed the test Future. A graceful shutdown avoids
+    // interrupting that thread and leaking its interrupt status to the next test.
+    teardown = executor => executor.shutdown(),
+  )
+
+  private def await(
+      latch: CountDownLatch,
+      description: String,
+      duration: FiniteDuration = timeout,
+  )(implicit location: Location): Unit = {
+    val completed = latch.await(duration.length, duration.unit)
+    assert(
+      completed,
+      s"timed out waiting for $description",
+    )
+  }
+
+  private def withRelease[A](release: CountDownLatch)(body: => A): A =
+    try body
+    finally release.countDown()
+
+  executionContext.test("same-source misses compile once") { implicit ec =>
+    val cache = new InteractiveSemanticdbCache[String, String]()
+    val compileEntered = new CountDownLatch(1)
+    val releaseCompile = new CountDownLatch(1)
+    val secondLookupStarted = new CountDownLatch(1)
+    val compileCount = new AtomicInteger()
+
+    def lookup() = Future {
+      compute(cache, "A.scala", laneA, _ == "current") { _ =>
+        compileCount.incrementAndGet()
+        compileEntered.countDown()
+        await(releaseCompile, "release of same-source compilation")
+        "current"
+      }
+    }
+
+    val first = lookup()
+    val second = withRelease(releaseCompile) {
+      await(compileEntered, "first same-source compilation")
+      val lookup = Future {
+        secondLookupStarted.countDown()
+        compute(cache, "A.scala", laneA, _ == "current") { _ =>
+          compileCount.incrementAndGet()
+          await(releaseCompile, "release of duplicate compilation")
+          "current"
+        }
+      }
+      await(secondLookupStarted, "second same-source lookup")
+      assert(!lookup.isCompleted, "second lookup completed before compilation")
+      lookup
+    }
+
+    for {
+      firstResult <- first
+      secondResult <- second
+    } yield {
+      assertEquals(firstResult, "current")
+      assertEquals(secondResult, "current")
+      assertEquals(compileCount.get(), 1)
+    }
+  }
+
+  executionContext.test("cache hit progresses while another source compiles") {
+    implicit ec =>
+      val cache = new InteractiveSemanticdbCache[String, String]()
+      compute(cache, "B.scala", laneB, _ => false)(_ => "cached")
+      val compileEntered = new CountDownLatch(1)
+      val releaseCompile = new CountDownLatch(1)
+      val hitCompleted = new CountDownLatch(1)
+
+      val miss = Future {
+        compute(cache, "A.scala", laneA, _ => false) { _ =>
+          compileEntered.countDown()
+          await(releaseCompile, "release of cache-miss compilation")
+          "compiled"
+        }
+      }
+      val hit = withRelease(releaseCompile) {
+        await(compileEntered, "cache-miss compilation")
+        val lookup = Future {
+          try
+            compute(cache, "B.scala", laneB, _ == "cached") { _ =>
+              fail("a current cache entry must not compile")
+            }
+          finally hitCompleted.countDown()
+        }
+        await(
+          hitCompleted,
+          "cache hit while another source compiles",
+          timeout,
+        )
+        lookup
+      }
+
+      for {
+        hitResult <- hit
+        missResult <- miss
+      } yield {
+        assertEquals(hitResult, "cached")
+        assertEquals(missResult, "compiled")
+      }
+  }
+
+  checkSerialized(
+    "different-source misses using one compiler serialize access",
+    laneA,
+    laneA,
+  )
+
+  executionContext.test("different-target misses compile concurrently") {
+    implicit ec =>
+      val cache = new InteractiveSemanticdbCache[String, String]()
+      val workersReady = new CountDownLatch(2)
+      val startLookups = new CountDownLatch(1)
+      val compileEntered = new CountDownLatch(2)
+      val releaseCompile = new CountDownLatch(1)
+
+      def lookup(path: String, lane: InteractiveSemanticdbCompilationLane) =
+        Future {
+          workersReady.countDown()
+          await(startLookups, "simultaneous lookup start")
+          compute(cache, path, lane, _ => false) { _ =>
+            compileEntered.countDown()
+            await(releaseCompile, "release of cross-target compilations")
+            path
+          }
+        }
+
+      val first = lookup("A.scala", laneA)
+      val second = lookup("B.scala", laneB)
+      withRelease(releaseCompile) {
+        await(workersReady, "both cross-target workers")
+        startLookups.countDown()
+        await(compileEntered, "both cross-target compilations")
+      }
+
+      for {
+        firstResult <- first
+        secondResult <- second
+      } yield {
+        assertEquals(firstResult, "A.scala")
+        assertEquals(secondResult, "B.scala")
+      }
+  }
+
+  checkSerialized(
+    "nominal targets sharing the fallback compiler serialize access",
+    InteractiveSemanticdbCompilationLane(fallbackCompiler),
+    InteractiveSemanticdbCompilationLane(fallbackCompiler),
+  )
+
+  test("compiler change invalidates unchanged cached text") {
+    val cache = new InteractiveSemanticdbCache[String, String]()
+    val compileCount = new AtomicInteger()
+
+    val fromCompilerA = compute(cache, "A.scala", laneA, _ => false) { _ =>
+      compileCount.incrementAndGet()
+      "compiler-a"
+    }
+    val fromCompilerB = compute(cache, "A.scala", laneB, _ => true) { _ =>
+      compileCount.incrementAndGet()
+      "compiler-b"
+    }
+
+    assertEquals(fromCompilerA, "compiler-a")
+    assertEquals(fromCompilerB, "compiler-b")
+    assertEquals(compileCount.get(), 2)
+  }
+
+  test("Java build-target change invalidates unchanged cached text") {
+    val cache = new InteractiveSemanticdbCache[String, String]()
+
+    def compilation(target: String) =
+      new InteractiveSemanticdbCompilation(
+        laneA,
+        InteractiveSemanticdbCompilationContext.Java(Some(target)),
+        () => null,
+      )
+
+    val fromTargetA = cache.compute(
+      "A.java",
+      () => Success(compilation("target:A")),
+      _ => false,
+    )((_, _) => "target-a")
+    val fromTargetB = cache.compute(
+      "A.java",
+      () => Success(compilation("target:B")),
+      _ => true,
+    )((_, _) => "target-b")
+
+    assertEquals(fromTargetA, "target-a")
+    assertEquals(fromTargetB, "target-b")
+  }
+
+  executionContext.test("clear waits for active compilation") { implicit ec =>
+    val cache = new InteractiveSemanticdbCache[String, String]()
+    val firstCompileEntered = new CountDownLatch(1)
+    val clearStarted = new CountDownLatch(1)
+    val secondLookupStarted = new CountDownLatch(1)
+    val secondCompileEntered = new CountDownLatch(1)
+    val releaseCompile = new CountDownLatch(1)
+    val activeCompilations = new AtomicInteger()
+    val maximumActiveCompilations = new AtomicInteger()
+
+    def compile(path: String, entered: CountDownLatch): String = {
+      val active = activeCompilations.incrementAndGet()
+      maximumActiveCompilations.accumulateAndGet(active, Math.max)
+      entered.countDown()
+      try {
+        await(releaseCompile, s"release of $path compilation")
+        path
+      } finally activeCompilations.decrementAndGet()
+    }
+
+    val first = Future {
+      compute(cache, "A.scala", laneA, _ => false) { path =>
+        compile(path, firstCompileEntered)
+      }
+    }
+    await(firstCompileEntered, "compilation active during clear")
+    val clear = Future {
+      clearStarted.countDown()
+      cache.clear()
+    }
+    await(clearStarted, "clear invocation")
+    assert(!clear.isCompleted, "clear completed during compilation")
+    val second = Future {
+      secondLookupStarted.countDown()
+      compute(cache, "B.scala", laneA, _ => false) { path =>
+        compile(path, secondCompileEntered)
+      }
+    }
+
+    withRelease(releaseCompile) {
+      await(secondLookupStarted, "post-clear lookup")
+      val enteredWhileFirstWasActive = secondCompileEntered.await(
+        mustRemainBlockedFor.length,
+        mustRemainBlockedFor.unit,
+      )
+      assert(
+        !enteredWhileFirstWasActive,
+        "clear allowed concurrent compilation in one compiler lane",
+      )
+    }
+
+    for {
+      firstResult <- first
+      _ <- clear
+      secondResult <- second
+    } yield {
+      assertEquals(firstResult, "A.scala")
+      assertEquals(secondResult, "B.scala")
+      assertEquals(maximumActiveCompilations.get(), 1)
+    }
+  }
+
+  executionContext.test("clear waits for compiler selection before clearing") {
+    implicit ec =>
+      val cache = new InteractiveSemanticdbCache[String, String]()
+      val prepareEntered = new CountDownLatch(1)
+      val releasePrepare = new CountDownLatch(1)
+      val clearStarted = new CountDownLatch(1)
+      val compilation = new InteractiveSemanticdbCompilation(
+        laneA,
+        InteractiveSemanticdbCompilationContext.Scala(laneA),
+        () => null,
+      )
+
+      val lookup = Future {
+        cache.compute(
+          "A.scala",
+          () => {
+            prepareEntered.countDown()
+            await(releasePrepare, "release of compiler selection")
+            Success(compilation)
+          },
+          _ => false,
+        )((_, _) => "before-clear")
+      }
+      await(prepareEntered, "compiler selection during clear")
+      val clear = Future {
+        clearStarted.countDown()
+        cache.clear()
+      }
+
+      withRelease(releasePrepare) {
+        await(clearStarted, "clear during compiler selection")
+        assert(!clear.isCompleted, "clear completed during compiler selection")
+      }
+
+      for {
+        lookupResult <- lookup
+        _ <- clear
+      } yield {
+        assertEquals(lookupResult, "before-clear")
+        val afterClear = compute(cache, "A.scala", laneA, _ => true) { _ =>
+          "after-clear"
+        }
+        assertEquals(afterClear, "after-clear")
+      }
+  }
+
+  test("failed compiler selection is contained") {
+    val cache = new InteractiveSemanticdbCache[String, String]()
+    val failure = new IllegalStateException("compiler selection failed")
+
+    val result = cache.compute(
+      "A.scala",
+      () => Failure(failure),
+      _ => true,
+    )((_, _) => fail("failed compiler selection must not compile"))
+
+    assertEquals(result, null)
+  }
+
+  executionContext.test("failed compilation releases its lane") { implicit ec =>
+    val cache = new InteractiveSemanticdbCache[String, String]()
+    val failure = new IllegalStateException("compile failed")
+
+    val failed = Future {
+      compute(cache, "A.scala", laneA, _ => false)(_ => throw failure)
+    }
+
+    failed.failed.map { obtained =>
+      assertEquals(obtained, failure)
+      val recovered = compute(cache, "B.scala", laneA, _ => false)(_ => "ok")
+      assertEquals(recovered, "ok")
+    }
+  }
+
+  executionContext.test("null compilation result is not cached") { _ =>
+    val cache = new InteractiveSemanticdbCache[String, String]()
+    val compileCount = new AtomicInteger()
+
+    val missing = compute(cache, "A.scala", laneA, _ => false) { _ =>
+      compileCount.incrementAndGet()
+      null
+    }
+    val recovered = compute(cache, "A.scala", laneA, _ => false) { _ =>
+      compileCount.incrementAndGet()
+      "current"
+    }
+
+    assertEquals(missing, null)
+    assertEquals(recovered, "current")
+    assertEquals(compileCount.get(), 2)
+  }
+
+  private def compute(
+      cache: InteractiveSemanticdbCache[String, String],
+      key: String,
+      lane: InteractiveSemanticdbCompilationLane,
+      isCurrent: String => Boolean,
+  )(compile: String => String): String = {
+    val compilation = new InteractiveSemanticdbCompilation(
+      lane,
+      InteractiveSemanticdbCompilationContext.Scala(lane),
+      () => null,
+    )
+    cache.compute(key, () => Success(compilation), isCurrent) { (path, _) =>
+      compile(path)
+    }
+  }
+
+  private def checkSerialized(
+      name: String,
+      firstLane: InteractiveSemanticdbCompilationLane,
+      secondLane: InteractiveSemanticdbCompilationLane,
+  )(implicit location: Location): Unit =
+    executionContext.test(name) { implicit ec =>
+      val cache = new InteractiveSemanticdbCache[String, String]()
+      val firstCompileEntered = new CountDownLatch(1)
+      val secondLookupReachedCache = new CountDownLatch(1)
+      val secondCompileEntered = new CountDownLatch(1)
+      val releaseCompile = new CountDownLatch(1)
+      val activeCompilations = new AtomicInteger()
+      val maximumActiveCompilations = new AtomicInteger()
+
+      def compile(path: String, entered: CountDownLatch): String = {
+        val active = activeCompilations.incrementAndGet()
+        maximumActiveCompilations.accumulateAndGet(active, Math.max)
+        entered.countDown()
+        try {
+          await(releaseCompile, s"release of $path compilation")
+          path
+        } finally activeCompilations.decrementAndGet()
+      }
+
+      compute(cache, "B.scala", secondLane, _ => false)(_ => "stale")
+
+      val first = Future {
+        compute(cache, "A.scala", firstLane, _ => false) { path =>
+          compile(path, firstCompileEntered)
+        }
+      }
+      val second = withRelease(releaseCompile) {
+        await(firstCompileEntered, "first serialized compilation")
+        val lookup = Future {
+          compute(
+            cache,
+            "B.scala",
+            secondLane,
+            _ => {
+              secondLookupReachedCache.countDown()
+              false
+            },
+          ) { path =>
+            compile(path, secondCompileEntered)
+          }
+        }
+        await(secondLookupReachedCache, "second serialized cache lookup")
+        val enteredWhileFirstWasActive = secondCompileEntered.await(
+          mustRemainBlockedFor.length,
+          mustRemainBlockedFor.unit,
+        )
+        assert(
+          !enteredWhileFirstWasActive,
+          "second compilation entered an already active lane",
+        )
+        assertEquals(maximumActiveCompilations.get(), 1)
+        lookup
+      }
+
+      for {
+        firstResult <- first
+        secondResult <- second
+      } yield {
+        assertEquals(firstResult, "A.scala")
+        assertEquals(secondResult, "B.scala")
+        assertEquals(maximumActiveCompilations.get(), 1)
+      }
+    }
+}

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/InteractiveSemanticdbCacheSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/InteractiveSemanticdbCacheSuite.scala
@@ -174,6 +174,48 @@ class InteractiveSemanticdbCacheSuite extends FunSuite {
       }
   }
 
+  executionContext.test(
+    "hash-colliding keys on different compilers compile concurrently"
+  ) { implicit ec =>
+    val cache =
+      new InteractiveSemanticdbCache[
+        InteractiveSemanticdbCollisionKey,
+        String,
+      ]()
+    val compileEntered = new CountDownLatch(2)
+    val releaseCompile = new CountDownLatch(1)
+
+    def lookup(
+        key: InteractiveSemanticdbCollisionKey,
+        lane: InteractiveSemanticdbCompilationLane,
+    ) = Future {
+      val compilation = new InteractiveSemanticdbCompilation(
+        lane,
+        InteractiveSemanticdbCompilationContext.Scala(lane),
+        () => null,
+      )
+      cache.compute(key, () => Success(compilation), _ => false) { (_, _) =>
+        compileEntered.countDown()
+        await(releaseCompile, "release of hash-colliding compilations")
+        key.value
+      }
+    }
+
+    val first = lookup(InteractiveSemanticdbCollisionKey("A.scala"), laneA)
+    val second = lookup(InteractiveSemanticdbCollisionKey("B.scala"), laneB)
+    withRelease(releaseCompile) {
+      await(compileEntered, "both hash-colliding compilations")
+    }
+
+    for {
+      firstResult <- first
+      secondResult <- second
+    } yield {
+      assertEquals(firstResult, "A.scala")
+      assertEquals(secondResult, "B.scala")
+    }
+  }
+
   checkSerialized(
     "nominal targets sharing the fallback compiler serialize access",
     InteractiveSemanticdbCompilationLane(fallbackCompiler),
@@ -283,6 +325,43 @@ class InteractiveSemanticdbCacheSuite extends FunSuite {
       assertEquals(secondResult, "B.scala")
       assertEquals(maximumActiveCompilations.get(), 1)
     }
+  }
+
+  executionContext.test("remove waits for compilation and removes its result") {
+    implicit ec =>
+      val cache = new InteractiveSemanticdbCache[String, String]()
+      val compileEntered = new CountDownLatch(1)
+      val releaseCompile = new CountDownLatch(1)
+      val removeStarted = new CountDownLatch(1)
+
+      val lookup = Future {
+        compute(cache, "A.scala", laneA, _ => false) { _ =>
+          compileEntered.countDown()
+          await(releaseCompile, "release of compilation before removal")
+          "compiled"
+        }
+      }
+      await(compileEntered, "compilation before removal")
+      val remove = Future {
+        removeStarted.countDown()
+        cache.remove("A.scala")
+      }
+
+      withRelease(releaseCompile) {
+        await(removeStarted, "removal during compilation")
+        assert(!remove.isCompleted, "remove completed during compilation")
+      }
+
+      for {
+        lookupResult <- lookup
+        _ <- remove
+      } yield {
+        assertEquals(lookupResult, "compiled")
+        val afterRemove = compute(cache, "A.scala", laneA, _ => true) { _ =>
+          "recompiled"
+        }
+        assertEquals(afterRemove, "recompiled")
+      }
   }
 
   executionContext.test("clear waits for compiler selection before clearing") {
@@ -461,4 +540,8 @@ class InteractiveSemanticdbCacheSuite extends FunSuite {
         assertEquals(maximumActiveCompilations.get(), 1)
       }
     }
+}
+
+private final case class InteractiveSemanticdbCollisionKey(value: String) {
+  override def hashCode(): Int = 0
 }

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/InteractiveSemanticdbCacheSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/InteractiveSemanticdbCacheSuite.scala
@@ -253,6 +253,25 @@ class InteractiveSemanticdbCacheSuite extends FunSuite {
     assertEquals(snapshot.maximumActiveLanes, 1)
   }
 
+  test("lane wrapper preserves registered identity metrics") {
+    val metrics = new InteractiveSemanticdbCompilationMetrics()
+    val identity = new InteractiveSemanticdbCompilationLaneIdentity(
+      new Object(),
+      id = 7L,
+      InteractiveSemanticdbCompilationLaneKind.Java,
+      metrics,
+    )
+    val lane = InteractiveSemanticdbCompilationLane.fromIdentity(identity)
+
+    assertEquals(lane.serialized("compiled"), "compiled")
+
+    val snapshot = metrics.snapshot
+    assertEquals(snapshot.scalaTargetCompilations, 0L)
+    assertEquals(snapshot.scalaFallbackCompilations, 0L)
+    assertEquals(snapshot.javaCompilations, 1L)
+    assertEquals(snapshot.maximumActiveLanes, 1)
+  }
+
   executionContext.test(
     "hash-colliding keys on different compilers compile concurrently"
   ) { implicit ec =>


### PR DESCRIPTION
## Summary

This change removes the global serialization bottleneck from interactive SemanticDB generation. Requests that use different presentation compiler instances may now compile concurrently, while requests sharing the same compiler remain serialized.

The cache also tracks the semantic compilation context, so unchanged source text is recompiled when its Scala compiler or Java build target changes.

## Motivation

`InteractiveSemanticdbs` previously used a synchronized map. Its `compute` operation held the map-wide monitor while generating SemanticDB, which meant a slow request for one build target blocked unrelated requests for every other build target.

Serializing by build-target URI is not sufficient. Multiple targets can fall back to the same presentation compiler, and target mappings can change during a build reload. The synchronization boundary therefore needs to follow the actual compiler selected for the request.

## Implementation

- Select the Scala presentation compiler once and pass that exact instance to SemanticDB generation.
- Assign weakly keyed, identity-based compilation lanes to compiler instances. This avoids retaining presentation compilers after cache eviction.
- Serialize requests using the lane identity directly. Requests using distinct compiler instances remain independent.
- Coordinate cache misses with weakly referenced per-source locks, so same-source requests remain deduplicated without holding a `ConcurrentHashMap` bin lock during compiler invocation.
- Keep compiler selection and compilation inside a cache lifecycle read lock, while cache reset uses the write lock. A reset cannot complete between compiler selection and cache publication.
- Include the compilation context in cache freshness:
  - Scala entries are associated with the selected compiler lane.
  - Java entries are associated with the captured build-target URI.
- Capture the Java build target once and pass it through to classpath lookup, avoiding a second target lookup during compilation.
- Preserve failure behavior: compiler-selection and compilation failures are contained, logged at debug level, and do not populate the cache.

## Concurrency guarantees

- Two misses for the same source compile once.
- Different sources using the same compiler are serialized.
- Different compiler instances may compile concurrently.
- Different targets sharing the fallback compiler are serialized together.
- Cache hits for unrelated sources are not blocked by an active compilation.
- Cache reset waits for in-flight compiler selection and compilation, then clears their results.
- Exceptions and null compilation results release the lane and are not cached.

## Cache correctness

Previously, cache freshness depended only on the source MD5. This could return a SemanticDB generated with an old compiler or classpath after target reassociation. Cache entries now require both matching source content and a matching semantic compilation context.

## Performance

A bounded integration benchmark exercised the real presentation compilers with two independently owned dependency sources (Scala 2.12 `scala-reflect` and Scala 2.13 `cats-core`). Each sample evicted the presentation compilers before issuing both SemanticDB-backed reference requests concurrently.

- Global-serialization control: 463 ms, 442 ms, 438 ms (median 442 ms).
- Per-compiler lanes: 396 ms, 369 ms, 363 ms (median 369 ms).
- Median latency decreased by 73 ms (16.5%); equivalent throughput improved by about 1.20x for this two-compiler workload.
- Candidate diagnostics recorded `maximum_active_lanes=2`; the global control recorded one active lane.

This is deliberately a path-specific result, not a claim about whole-repository indexing. A full Play/Codehop run and a bounded multi-target Codehop fixture produced no interactive SemanticDB lane events because those workloads query compiled workspace sources, while this cache serves dependency, readonly, worksheet, build-definition, standalone, and similar on-demand sources.

## Tests

Added `InteractiveSemanticdbCacheSuite` with coverage for:

- same-source deduplication;
- cache-hit progress during an unrelated miss;
- same-compiler serialization;
- cross-compiler concurrency;
- hash-colliding sources on different compilers;
- targets sharing the fallback compiler;
- Scala compiler and Java target changes;
- reset ordering during compiler selection and compilation;
- removal ordering during compilation;
- compiler-selection and compilation failures; and
- null-result handling.

Verification performed:

- `InteractiveSemanticdbCacheSuite`: 17 tests passed, including repeated runs;
- `JavaInteractiveSemanticdbSuite`: 4 tests passed;
- changed production sources compiled with no diagnostics;
- Scalafmt check passed; and
- `scalafix --check` passed for main and test sources.

## Scope

This changes only interactive SemanticDB generation used for dependency, readonly, worksheet, build-definition, standalone, and similar on-demand sources. Workspace compilation behavior is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved interactive code analysis responsiveness by reusing valid compilation results and coordinating concurrent requests efficiently.
  * Added compiler-specific processing lanes and performance metrics.
  * Improved Java and Scala build-target handling.

* **Reliability**
  * Improved recovery from compilation failures and incomplete results.
  * Refreshes cached analysis when source, compiler, or project context changes.

* **Tests**
  * Added comprehensive coverage for caching, concurrency, invalidation, metrics, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->