### PR TITLE
improvement: preserve same-package link resolution for dotted nested types

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/parsing/DocumentLinksProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/DocumentLinksProvider.scala
@@ -212,8 +212,9 @@ final class DocumentLinksProvider(
       val allCandidates = symbolCandidates ++ importedSymbols
       val locationsFromDefinition = for {
         provider <- definitionProvider
-        locs <- allCandidates
-          .map(sym => provider.fromSymbol(sym, Some(path)))
+        // Lazily, so a candidate after the first one to resolve costs no lookup.
+        locs <- allCandidates.view
+          .map(candidate => provider.fromSymbol(candidate, Some(path)))
           .find(!_.isEmpty)
       } yield locs
 
@@ -243,15 +244,16 @@ final class DocumentLinksProvider(
   }
 
   /**
-   * Converts a Javadoc-style reference to candidate SemanticDB symbols.
-   * Returns multiple candidates for simple class names to handle same-package references.
+   * Converts a Javadoc-style reference to candidate SemanticDB symbols, the
+   * most likely first, see [[classRefToSymbols]].
    *
-   * For "ConnectorPageSourceProvider" in package "com.example":
-   *   - First tries "com/example/ConnectorPageSourceProvider#" (same package)
-   *   - Then falls back to "ConnectorPageSourceProvider#" (unqualified)
+   * For "PageSourceProvider" in package "com.example":
+   *   - First tries "com/example/PageSourceProvider#" (same package)
+   *   - Then falls back to "PageSourceProvider#" (unqualified)
    *
-   * For fully qualified "java.util.List":
-   *   - Returns only "java/util/List#"
+   * For fully qualified "java.util.Map.Entry":
+   *   - First tries "java/util/Map#Entry#" (Entry nested in Map)
+   *   - Then "java/util/Map/Entry#" (Entry in package java.util.Map)
    */
   private def javadocRefToSemanticdbSymbols(
       ref: String,
@@ -261,63 +263,124 @@ final class DocumentLinksProvider(
     cleanRef.split("#", 2) match {
       case Array(classRef, memberRef) if classRef.nonEmpty =>
         val classSymbols = classRefToSymbols(classRef, fileUri)
-        if (memberRef.nonEmpty)
+        if (memberRef.isEmpty) classSymbols
+        else if (isJavaIdentifier(memberRef))
           classSymbols.map(_ + memberRef + "().")
-        else
-          classSymbols
+        else Nil
       case Array(classRef) =>
         classRefToSymbols(classRef, fileUri)
       case Array("", memberRef) =>
-        List(resolveLocalMemberSymbol(memberRef, fileUri))
+        resolveLocalMemberSymbol(memberRef, fileUri)
       case _ =>
-        List(ref)
+        Nil
     }
   }
 
   /**
-   * Converts a class reference to candidate SemanticDB symbols.
-   * For simple names (no dots), tries same-package first.
+   * Whether every `.` or `/` separated part of the reference is a Java
+   * identifier. The limit of -1 keeps the empty part left by a trailing
+   * separator, so `com/other/Outer.` fails.
+   */
+  private def isJavaIdentifier(reference: String): Boolean =
+    reference
+      .split("[./]", -1)
+      .forall(part =>
+        part.headOption.exists(Character.isJavaIdentifierStart) &&
+          part.forall(Character.isJavaIdentifierPart)
+      )
+
+  /**
+   * Converts a class reference to candidate SemanticDB symbols. It takes the
+   * readings of [[classReferenceReadings]] as written and prefixed with the
+   * current package, so `Outer.Inner` in `package a` gives `a/Outer#Inner#`.
+   *
+   * A lowercase first part is usually a package. `foo.Inner` therefore tries
+   * the prefixed readings last, and keeps them, as a class can be lowercase.
    */
   private def classRefToSymbols(
       classRef: String,
       fileUri: String,
   ): List[String] = {
-    val isSimpleName = !classRef.contains('.')
-    if (isSimpleName) {
-      val path = fileUri.toAbsolutePath
-      val packagePrefix = buffers.get(path).map(findPackageName).getOrElse("")
-      val samePackageSymbol =
-        if (packagePrefix.nonEmpty) s"$packagePrefix/$classRef#"
-        else s"$classRef#"
-      val simpleSymbol = s"$classRef#"
-      if (samePackageSymbol != simpleSymbol)
-        List(samePackageSymbol, simpleSymbol)
-      else
-        List(simpleSymbol)
-    } else {
-      List(classRef.replace('.', '/') + "#")
+    if (!isJavaIdentifier(classRef)) Nil
+    else {
+      val unqualifiedSymbols = classReferenceReadings(classRef)
+      val packagePrefix = currentPackage(fileUri)
+      val samePackageSymbols =
+        if (packagePrefix.nonEmpty)
+          unqualifiedSymbols.map(symbol => s"$packagePrefix/$symbol")
+        else Nil
+      val startsWithPackageName =
+        classRef.contains('.') && !classRef.headOption.exists(_.isUpper)
+      if (startsWithPackageName) unqualifiedSymbols ++ samePackageSymbols
+      else samePackageSymbols ++ unqualifiedSymbols
+    }
+  }
+
+  private def currentPackage(fileUri: String): String =
+    buffers.get(fileUri.toAbsolutePath).map(findPackageName).getOrElse("")
+
+  /**
+   * The readings of a class reference, since its dots don't say which of them
+   * separate packages. A reading takes some leading parts for the package and
+   * reads the rest as nested classes, the most likely reading first.
+   *
+   *   - "Outer" gives
+   *     - "Outer#"
+   *   - "outer.inner" gives
+   *     - "outer/inner#"
+   *     - "outer#inner#"
+   *   - "java.util.Map.Entry" gives
+   *     - "java/util/Map#Entry#"
+   *     - "java/util/Map/Entry#"
+   *     - "java#util#Map#Entry#"
+   *     - "java/util#Map#Entry#"
+   *
+   * By convention a package name is all lowercase and a type name starts with
+   * a capital, `java.util` and `Map` (Java Language Specification 6.1, Naming
+   * Conventions). The compiler does not enforce it, so the convention orders
+   * the readings and rules none out: a lowercase class, `outer.inner`, or a
+   * capitalized package just reads later.
+   */
+  private def classReferenceReadings(classReference: String): List[String] = {
+    val parts = classReference.split('.')
+    // The last part has to name a class, so it never belongs to the package.
+    val allButLast = parts.length - 1
+    val conventionalPackagePartCount =
+      parts.indexWhere(_.headOption.exists(_.isUpper)) match {
+        case -1 => allButLast
+        case firstCapitalized => firstCapitalized
+      }
+    val preferred = List(conventionalPackagePartCount, allButLast).distinct
+    val packagePartCounts =
+      preferred ++ (0 to allButLast).filterNot(count =>
+        preferred.contains(count)
+      )
+    for (packagePartCount <- packagePartCounts) yield {
+      val (packageParts, types) = parts.splitAt(packagePartCount)
+      (packageParts :+ types.mkString("#")).mkString("", "/", "#")
     }
   }
 
   /**
    * Resolves a local member reference (e.g., "#myMethod") against the
-   * containing class. Uses the file name to derive the class name.
+   * containing class. Uses the file name to derive the class name. Empty when
+   * the file is not in the buffers or the member is no name.
    */
   private def resolveLocalMemberSymbol(
       memberRef: String,
       fileUri: String,
-  ): String = {
+  ): List[String] = {
     val path = fileUri.toAbsolutePath
     val className = path.filename.stripSuffix(".java")
-    buffers.get(path) match {
-      case Some(content) =>
+    if (!isJavaIdentifier(memberRef)) Nil
+    else
+      buffers.get(path).toList.map { content =>
         val packageName = findPackageName(content)
         val fullClass =
           if (packageName.nonEmpty) s"$packageName/$className"
           else className
         s"$fullClass#$memberRef()."
-      case None => memberRef
-    }
+      }
   }
 
   private val packageNameRegex = raw"package\s+([\w.]+)".r

--- a/tests/unit/src/test/scala/tests/DocumentLinkLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DocumentLinkLspSuite.scala
@@ -1,6 +1,21 @@
 package tests
 
+import scala.concurrent.Future
+
+import munit.Location
+import org.eclipse.lsp4j.DocumentLink
+
 class DocumentLinkLspSuite extends BaseLspSuite("document-link") {
+
+  private def linkWithTooltip(
+      links: List[DocumentLink],
+      tooltip: String,
+  )(implicit loc: Location): DocumentLink =
+    links
+      .find(_.getTooltip == tooltip)
+      .getOrElse(
+        fail(s"no link '$tooltip', got: ${links.map(_.getTooltip)}")
+      )
 
   test("java-link-tag-resolve") {
     val file = "a/src/main/java/a/Main.java"
@@ -36,9 +51,9 @@ class DocumentLinkLspSuite extends BaseLspSuite("document-link") {
       _ <- server.didOpen(targetFile)
       links <- server.documentLinks(file)
       _ = assertEquals(links.length, 3)
-      linkTag = links.find(_.getTooltip == "a.Helper").get
-      seeTag = links.find(_.getTooltip == "a.Helper#doSomething").get
-      linkTag2 = links.find(_.getTooltip == "Optional#empty").get
+      linkTag = linkWithTooltip(links, "a.Helper")
+      seeTag = linkWithTooltip(links, "a.Helper#doSomething")
+      linkTag2 = linkWithTooltip(links, "Optional#empty")
       resolvedLinkTag <- server.documentLinkResolve(linkTag)
       resolvedSeeTag <- server.documentLinkResolve(seeTag)
       resolvedSeeTag2 <- server.documentLinkResolve(linkTag2)
@@ -229,8 +244,8 @@ class DocumentLinkLspSuite extends BaseLspSuite("document-link") {
       _ <- server.didOpen(targetFile)
       links <- server.documentLinks(file)
       _ = assertEquals(links.length, 2)
-      linkTag = links.find(_.getTooltip == "Helper").get
-      seeTag = links.find(_.getTooltip == "Helper#doSomething").get
+      linkTag = linkWithTooltip(links, "Helper")
+      seeTag = linkWithTooltip(links, "Helper#doSomething")
       resolvedLinkTag <- server.documentLinkResolve(linkTag)
       resolvedSeeTag <- server.documentLinkResolve(seeTag)
     } yield {
@@ -292,6 +307,401 @@ class DocumentLinkLspSuite extends BaseLspSuite("document-link") {
       assert(
         resolved.getTarget.contains("OtherClass.java"),
         s"different package class should resolve to OtherClass.java but got: ${resolved.getTarget}",
+      )
+    }
+  }
+
+  // `Outer.Inner` is dotted but names no package, so for a file in `package a`
+  // it means `a/Outer#Inner#`.
+  test("java-link-to-nested-class-same-package") {
+    val file = "a/src/main/java/a/Main.java"
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a":{}}
+           |/a/src/main/java/a/Outer.java
+           |package a;
+           |
+           |public class Outer {
+           |  public static class Inner {
+           |    public static void doSomething() {}
+           |  }
+           |}
+           |/a/src/main/java/a/Main.java
+           |package a;
+           |
+           |/**
+           | * Uses {@link Outer.Inner} and {@link Outer.Inner#doSomething}.
+           | */
+           |public class Main {
+           |  public static void main(String[] args) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen(file)
+      _ <- server.didOpen("a/src/main/java/a/Outer.java")
+      links <- server.documentLinks(file)
+      _ = assertEquals(links.length, 2)
+      classLink = linkWithTooltip(links, "Outer.Inner")
+      memberLink = linkWithTooltip(links, "Outer.Inner#doSomething")
+      resolvedClass <- server.documentLinkResolve(classLink)
+      resolvedMember <- server.documentLinkResolve(memberLink)
+    } yield {
+      assert(
+        resolvedClass.getTarget != null,
+        "same-package nested class link should resolve",
+      )
+      assert(
+        resolvedClass.getTarget.contains("Outer.java"),
+        s"same-package nested class link should resolve to Outer.java but got: ${resolvedClass.getTarget}",
+      )
+      assert(
+        resolvedMember.getTarget != null,
+        "same-package nested class member link should resolve",
+      )
+      assert(
+        resolvedMember.getTarget.contains("Outer.java"),
+        s"same-package nested class member link should resolve to Outer.java but got: ${resolvedMember.getTarget}",
+      )
+    }
+  }
+
+  /**
+   * Checks that references of one kind, `42` or `e.g.`, produce links with no
+   * definition behind them.
+   */
+  private def checkNoDefinition(
+      name: String,
+      references: List[String],
+  ): Unit =
+    test(name) {
+      val file = "a/src/main/java/a/Main.java"
+      val referenceLinks =
+        references.map(reference => s"{@link $reference}").mkString(", ")
+      for {
+        _ <- initialize(
+          s"""|/metals.json
+              |{"a":{}}
+              |/a/src/main/java/a/Outer.java
+              |package a;
+              |
+              |public class Outer {}
+              |/a/src/main/java/a/Main.java
+              |package a;
+              |
+              |/**
+              | * Uses $referenceLinks.
+              | */
+              |public class Main {
+              |  public static void main(String[] args) {}
+              |}
+              |""".stripMargin
+        )
+        _ <- server.didOpen(file)
+        _ <- server.didOpen("a/src/main/java/a/Outer.java")
+        links <- server.documentLinks(file)
+        _ = assertEquals(
+          obtained = links.map(_.getTooltip),
+          expected = references,
+        )
+        resolved <- Future.sequence(links.map(server.documentLinkResolve))
+      } yield assertEquals(
+        obtained = resolved.filter(_.getTarget != null).map(_.getTooltip),
+        expected = List.empty[String],
+        clue = "a reference that names no class must not resolve",
+      )
+    }
+
+  checkNoDefinition(
+    name = "java-link-to-package-name",
+    references = List("a"),
+  )
+  checkNoDefinition(
+    name = "java-link-to-parameterized-type",
+    references = List("Outer<Foo,Bar>"),
+  )
+  checkNoDefinition(
+    name = "java-link-to-abbreviation",
+    references = List("e.g."),
+  )
+  checkNoDefinition(
+    name = "java-link-to-member-of-nothing",
+    references = List("#"),
+  )
+  checkNoDefinition(
+    name = "java-link-to-number",
+    references = List("42", "3.14", "0x1F"),
+  )
+  // `true` and `null` read as identifiers, so they are looked up like a name
+  // and find nothing.
+  checkNoDefinition(
+    name = "java-link-to-boolean",
+    references = List("true", "false"),
+  )
+  checkNoDefinition(
+    name = "java-link-to-null-literal",
+    references = List("null"),
+  )
+
+  // `com.example` is the shape closest to a qualified class,
+  // `com.example.Outer`. The current package is a prefix of two parts too.
+  test("java-link-to-multi-part-package-name") {
+    val file = "a/src/main/java/com/example/Main.java"
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a":{}}
+           |/a/src/main/java/com/example/Outer.java
+           |package com.example;
+           |
+           |public class Outer {}
+           |/a/src/main/java/com/example/Main.java
+           |package com.example;
+           |
+           |/**
+           | * Uses {@link com.example}.
+           | */
+           |public class Main {
+           |  public static void main(String[] args) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen(file)
+      _ <- server.didOpen("a/src/main/java/com/example/Outer.java")
+      links <- server.documentLinks(file)
+      _ = assertEquals(
+        obtained = links.map(_.getTooltip),
+        expected = List("com.example"),
+      )
+      resolved <- server.documentLinkResolve(links.head)
+    } yield assert(
+      cond = resolved.getTarget == null,
+      clue =
+        s"a package names no class, so its link must not resolve, but got: ${resolved.getTarget}",
+    )
+  }
+
+  // A comment mixes references that name something with references that don't.
+  // A neighbour must not change what a link resolves to.
+  test("java-link-to-valid-and-invalid-references") {
+    val file = "a/src/main/java/a/Main.java"
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a":{}}
+           |/a/src/main/java/a/Outer.java
+           |package a;
+           |
+           |public class Outer {
+           |  public static class Inner {
+           |    public static void doSomething() {}
+           |  }
+           |}
+           |/a/src/main/java/a/Main.java
+           |package a;
+           |
+           |/**
+           | * Uses {@link Outer}, {@link 42}, {@link Outer.Inner}, {@link a},
+           | * {@link Outer.Inner#doSomething} and {@link Outer<Foo>}.
+           | */
+           |public class Main {
+           |  public static void main(String[] args) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen(file)
+      _ <- server.didOpen("a/src/main/java/a/Outer.java")
+      links <- server.documentLinks(file)
+      _ = assertEquals(obtained = links.length, expected = 6)
+      resolved <- Future.sequence(links.map(server.documentLinkResolve))
+    } yield {
+      val (withTarget, withoutTarget) =
+        resolved.partition(_.getTarget != null)
+      assertEquals(
+        obtained = withTarget.map(_.getTooltip).sorted,
+        expected = List("Outer", "Outer.Inner", "Outer.Inner#doSomething"),
+      )
+      assertEquals(
+        obtained = withoutTarget.map(_.getTooltip).sorted,
+        expected = List("42", "Outer<Foo>", "a"),
+      )
+      val elsewhere =
+        withTarget.filterNot(_.getTarget.contains("Outer.java"))
+      assertEquals(
+        obtained = elsewhere.map(_.getTarget),
+        expected = List.empty[String],
+        clue = "a reference that resolves names something in Outer.java",
+      )
+    }
+  }
+
+  // Convention reads the lowercase `outer` as a package, so `a/outer#Inner#`
+  // is the last reading tried. A class is free to be lowercase, so the link
+  // still has to resolve.
+  test("java-link-to-nested-class-of-lowercase-class") {
+    val file = "a/src/main/java/a/Main.java"
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a":{}}
+           |/a/src/main/java/a/outer.java
+           |package a;
+           |
+           |public class outer {
+           |  public static class Inner {
+           |    public static void doSomething() {}
+           |  }
+           |}
+           |/a/src/main/java/a/Main.java
+           |package a;
+           |
+           |/**
+           | * Uses {@link outer.Inner} and {@link outer.Inner#doSomething}.
+           | */
+           |public class Main {
+           |  public static void main(String[] args) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen(file)
+      _ <- server.didOpen("a/src/main/java/a/outer.java")
+      links <- server.documentLinks(file)
+      _ = assertEquals(obtained = links.length, expected = 2)
+      classLink = linkWithTooltip(links, "outer.Inner")
+      memberLink = linkWithTooltip(links, "outer.Inner#doSomething")
+      resolvedClass <- server.documentLinkResolve(classLink)
+      resolvedMember <- server.documentLinkResolve(memberLink)
+    } yield {
+      assert(
+        cond = resolvedClass.getTarget != null,
+        clue = "lowercase class nested class link should resolve",
+      )
+      assert(
+        cond = resolvedClass.getTarget.contains("outer.java"),
+        clue =
+          s"lowercase class nested class link should resolve to outer.java but got: ${resolvedClass.getTarget}",
+      )
+      assert(
+        cond = resolvedMember.getTarget != null,
+        clue = "lowercase class nested class member link should resolve",
+      )
+      assert(
+        cond = resolvedMember.getTarget.contains("outer.java"),
+        clue =
+          s"lowercase class nested class member link should resolve to outer.java but got: ${resolvedMember.getTarget}",
+      )
+    }
+  }
+
+  // With no capitalized part, `outer.inner` reads as class `inner` of package
+  // `outer`, so `a/outer#inner#` is the last of the four readings.
+  test("java-link-to-lowercase-nested-class-of-lowercase-class") {
+    val file = "a/src/main/java/a/Main.java"
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a":{}}
+           |/a/src/main/java/a/outer.java
+           |package a;
+           |
+           |public class outer {
+           |  public static class inner {
+           |    public static void doSomething() {}
+           |  }
+           |}
+           |/a/src/main/java/a/Main.java
+           |package a;
+           |
+           |/**
+           | * Uses {@link outer.inner} and {@link outer.inner#doSomething}.
+           | */
+           |public class Main {
+           |  public static void main(String[] args) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen(file)
+      _ <- server.didOpen("a/src/main/java/a/outer.java")
+      links <- server.documentLinks(file)
+      _ = assertEquals(obtained = links.length, expected = 2)
+      classLink = linkWithTooltip(links, "outer.inner")
+      memberLink = linkWithTooltip(links, "outer.inner#doSomething")
+      resolvedClass <- server.documentLinkResolve(classLink)
+      resolvedMember <- server.documentLinkResolve(memberLink)
+    } yield {
+      assert(
+        cond = resolvedClass.getTarget != null,
+        clue = "all-lowercase nested class link should resolve",
+      )
+      assert(
+        cond = resolvedClass.getTarget.contains("outer.java"),
+        clue =
+          s"all-lowercase nested class link should resolve to outer.java but got: ${resolvedClass.getTarget}",
+      )
+      assert(
+        cond = resolvedMember.getTarget != null,
+        clue = "all-lowercase nested class member link should resolve",
+      )
+      assert(
+        cond = resolvedMember.getTarget.contains("outer.java"),
+        clue =
+          s"all-lowercase nested class member link should resolve to outer.java but got: ${resolvedMember.getTarget}",
+      )
+    }
+  }
+
+  // Javadoc separates a nested class from its outer one with a dot, the same
+  // character that separates packages, so `a.Outer.Inner` has to be tried as
+  // `a/Outer#Inner#` and not only as `a/Outer/Inner#`.
+  test("java-link-to-nested-class") {
+    val file = "a/src/main/java/a/Main.java"
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{"a":{}}
+           |/a/src/main/java/a/Outer.java
+           |package a;
+           |
+           |public class Outer {
+           |  public static class Inner {
+           |    public static void doSomething() {}
+           |  }
+           |}
+           |/a/src/main/java/a/Main.java
+           |package a;
+           |
+           |/**
+           | * Uses {@link a.Outer.Inner} and {@link a.Outer.Inner#doSomething}.
+           | */
+           |public class Main {
+           |  public static void main(String[] args) {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen(file)
+      _ <- server.didOpen("a/src/main/java/a/Outer.java")
+      links <- server.documentLinks(file)
+      _ = assertEquals(links.length, 2)
+      classLink = linkWithTooltip(links, "a.Outer.Inner")
+      memberLink = linkWithTooltip(links, "a.Outer.Inner#doSomething")
+      resolvedClass <- server.documentLinkResolve(classLink)
+      resolvedMember <- server.documentLinkResolve(memberLink)
+    } yield {
+      assert(
+        resolvedClass.getTarget != null,
+        "nested class link should resolve",
+      )
+      assert(
+        resolvedClass.getTarget.contains("Outer.java"),
+        s"nested class link should resolve to Outer.java but got: ${resolvedClass.getTarget}",
+      )
+      assert(
+        resolvedMember.getTarget != null,
+        "nested class member link should resolve",
+      )
+      assert(
+        resolvedMember.getTarget.contains("Outer.java"),
+        s"nested class member link should resolve to Outer.java but got: ${resolvedMember.getTarget}",
       )
     }
   }

--- a/tests/unit/src/test/scala/tests/parsing/DocumentLinksProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/parsing/DocumentLinksProviderSuite.scala
@@ -158,6 +158,41 @@ class DocumentLinksProviderSuite extends BaseSuite {
     assertEquals(links.head.getTooltip, "#myLocalMethod")
   }
 
+  test("java-empty-link-tag-ignored") {
+    val buffers = new Buffers()
+    val path = workspace.resolve("App.java")
+    val content =
+      """|/**
+         | * Empty {@link }, {@link} and {@linkplain }, but a real {@link Foo}.
+         | */
+         |class App {}
+         |""".stripMargin
+    buffers.put(path, content)
+    val provider = new DocumentLinksProvider(buffers, None)
+    val links = provider.getLinks(path).asScala.toList
+
+    assertEquals(obtained = links.length, expected = 1)
+    assertEquals(obtained = links.head.getTooltip, expected = "Foo")
+  }
+
+  test("java-empty-see-tag-ignored") {
+    val buffers = new Buffers()
+    val path = workspace.resolve("App.java")
+    val content =
+      """|/**
+         | * @see
+         | * @see java.util.List
+         | */
+         |class App {}
+         |""".stripMargin
+    buffers.put(path, content)
+    val provider = new DocumentLinksProvider(buffers, None)
+    val links = provider.getLinks(path).asScala.toList
+
+    assertEquals(obtained = links.length, expected = 1)
+    assertEquals(obtained = links.head.getTooltip, expected = "java.util.List")
+  }
+
   test("java-see-tag-captures-full-method-ref") {
     val buffers = new Buffers()
     val path = workspace.resolve("App.java")


### PR DESCRIPTION
Extracted from https://github.com/scalameta/metals/pull/8763

these changes address the following automated feedback:
https://github.com/scalameta/metals/pull/8763#discussion_r3710273021

and also this comment (resolving links to classes with lowercase names):
https://github.com/scalameta/metals/pull/8763#discussion_r3756812263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaDoc link resolution for nested classes, package and class references, same-package symbols, and local members.
  * Invalid or unresolved references no longer generate incorrect document links.
  * Empty JavaDoc link tags are now ignored.

* **Tests**
  * Added coverage for valid, invalid, mixed, qualified, and lowercase references.
  * Improved verification of link counts, tooltips, and resolution targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->