### PR TITLE
improvement(mcp): suggest `import-build` when no build target is found

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
@@ -48,7 +48,9 @@ class McpTestRunner(
       }
       id <- buildTargets
         .inverseSources(path)
-        .toRight(s"Could not find build target for $path")
+        .toRight(
+          s"Could not find build target for $path, try running `import-build`."
+        )
       jvmTestEnv = debugProvider.jvmTestEnvironment(id)
       projectFut <- debugProvider.createDebugeeProjectForTests(
         id,

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpTools.scala
@@ -158,26 +158,42 @@ trait MetalsMcpTools extends Cancelable {
     new AsyncToolSpecification(
       tool,
       withErrorHandling { (exchange, _) =>
-        compilations
-          .cascadeCompile(buildTargets.allBuildTargetIds)
-          .map { _ =>
-            val allDiagnostics = diagnostics.allDiagnostics
-            val diagnosticsOutput = allDiagnostics.show(projectPath)
-            val content =
-              if (diagnosticsOutput.isEmpty) {
-                "Compilation successful."
-              } else if (allDiagnostics.hasErrors) {
-                s"Compilation failed with errors:\n$diagnosticsOutput"
-              } else {
-                s"Compilation successful with warnings:\n$diagnosticsOutput"
-              }
-            CallToolResult
-              .builder()
-              .content(createContent(content))
-              .isError(false)
-              .build()
-          }
-          .toMono
+        val allTargets = buildTargets.allBuildTargetIds
+        if (allTargets.isEmpty)
+          Future
+            .successful(
+              CallToolResult
+                .builder()
+                .content(
+                  createContent(
+                    "Error: no modules found, try running `import-build`."
+                  )
+                )
+                .isError(true)
+                .build()
+            )
+            .toMono
+        else
+          compilations
+            .cascadeCompile(allTargets)
+            .map { _ =>
+              val allDiagnostics = diagnostics.allDiagnostics
+              val diagnosticsOutput = allDiagnostics.show(projectPath)
+              val content =
+                if (diagnosticsOutput.isEmpty) {
+                  "Compilation successful."
+                } else if (allDiagnostics.hasErrors) {
+                  s"Compilation failed with errors:\n$diagnosticsOutput"
+                } else {
+                  s"Compilation successful with warnings:\n$diagnosticsOutput"
+                }
+              CallToolResult
+                .builder()
+                .content(createContent(content))
+                .isError(false)
+                .build()
+            }
+            .toMono
       },
     )
   }
@@ -251,10 +267,12 @@ trait MetalsMcpTools extends Cancelable {
                 .orElse(inUpstreamModulesErrors)
 
               val content =
-                if (compileResult.getStatusCode == StatusCode.CANCELLED) {
-                  diagnosticsContent.getOrElse(
-                    "Compilation cancelled."
-                  )
+                if (buildTarget.isEmpty) {
+                  s"Error: no build target for $path, try running `import-build`."
+                } else if (
+                  compileResult.getStatusCode == StatusCode.CANCELLED
+                ) {
+                  diagnosticsContent.getOrElse("Compilation cancelled.")
                 } else {
                   diagnosticsContent.getOrElse("Compilation successful.")
                 }
@@ -262,7 +280,7 @@ trait MetalsMcpTools extends Cancelable {
               CallToolResult
                 .builder()
                 .content(createContent(content))
-                .isError(false)
+                .isError(buildTarget.isEmpty)
                 .build()
             }
             .toMono
@@ -303,9 +321,8 @@ trait MetalsMcpTools extends Cancelable {
       tool,
       withErrorHandling { (exchange, arguments) =>
         val module = arguments.getAs[String]("module")
-        (buildTargets.allScala ++ buildTargets.allJava).find(
-          _.displayName == module
-        ) match {
+        val targets = (buildTargets.allScala ++ buildTargets.allJava).toList
+        targets.find(_.displayName == module) match {
           case Some(target) =>
             compilations
               .compileTarget(target.id)
@@ -344,7 +361,14 @@ trait MetalsMcpTools extends Cancelable {
               .successful(
                 CallToolResult
                   .builder()
-                  .content(createContent(s"Error: Module not found: $module"))
+                  .content(
+                    createContent(
+                      if (targets.isEmpty)
+                        "Error: no modules found, try running `import-build`."
+                      else
+                        s"Error: Module not found: $module, see `list-modules`."
+                    )
+                  )
                   .isError(true)
                   .build()
               )
@@ -880,7 +904,10 @@ trait MetalsMcpTools extends Cancelable {
             .builder()
             .content(
               createContent(
-                s"Available modules (build targets):${modules.map(module => s"\n- $module").mkString}"
+                if (modules.isEmpty)
+                  "No modules (build targets) found, try running `import-build`."
+                else
+                  s"Available modules (build targets):${modules.map(module => s"\n- $module").mkString}"
               )
             )
             .isError(false)

--- a/tests/slow/src/test/scala/tests/feature/McpStdioSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/McpStdioSuite.scala
@@ -30,12 +30,11 @@ class McpStdioSuite extends BaseSuite with StdioMcpTestHelper {
 
       for {
         _ <- client.initialize()
+        _ <- client.waitForIndexing("a")
 
         modules <- client.listModules()
         findDepResult <- client.findDep("org.scala-lang")
         scalafixRules <- client.listScalafixRules()
-
-        _ <- client.waitForIndexing("a")
 
         typedGlobResult <- client.typedGlobSearch(
           "Hello",

--- a/tests/unit/src/main/scala/tests/mcp/TestMcpStdioClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/TestMcpStdioClient.scala
@@ -167,7 +167,9 @@ class TestMcpStdioClient(
         )
       } else {
         listModules().flatMap { modules =>
-          if (modules.contains(expectedModule)) {
+          if (
+            modules.linesIterator.map(_.trim).contains(s"- $expectedModule")
+          ) {
             Future.successful(())
           } else {
             Future {

--- a/tests/unit/src/test/scala/tests/mcp/McpCompileToolsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpCompileToolsLspSuite.scala
@@ -58,6 +58,28 @@ class McpCompileToolsLspSuite
     } yield ()
   }
 
+  test("compile-file-outside-build") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/a/src/main/scala/com/example/Hello.scala
+           |package com.example
+           |object Hello
+           |/Outside.scala
+           |object Outside
+           |""".stripMargin
+      )
+      client <- startMcpServer()
+      result <- client.compileFile("Outside.scala")
+      _ = assert(result.contains("no build target for"), result)
+      _ = assert(result.contains("`import-build`"), result)
+      _ <- client.shutdown()
+    } yield ()
+  }
+
   test("compile-module") {
     cleanWorkspace()
     for {


### PR DESCRIPTION
Hit this several times, e.g.:

> I couldn't verify it: Metals reports no build targets (build not imported),
> so test/compile can't run. Please re-import the build (or restart Metals),
> then I'll rerun the suite.

(...)

> Yes — import-build worked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compilation and test error messages when build targets or modules are unavailable.
  * Errors now identify the affected file or path and recommend running `import-build`.
  * Module and target listing tools now clearly report when no build information is available.
  * File compilation outside a configured build now provides an actionable error instead of an unclear or incomplete result.
  * Module lookups now distinguish between missing build targets and unknown modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->