### PR TITLE
bugfix: Don't show abstract class as test suite

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -413,8 +413,9 @@ final class BuildTargetClasses(
       // Only Scala files depend on inheritance for test frameworks
       if (path.isJava)
         None
-      else
+      else if (!symbolInfo.isAbstract)
         processTestClassHierarchy(symbolInfo, doc, path, testClasses)
+      else None
     }
 
     Future.sequence(futures).map(_ => testClasses.toList)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test class discovery by excluding Java files and abstract symbols.
  * Inherited test frameworks are now identified only for concrete Scala symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->