### PR TITLE
fix: resolve scaladoc links against the documented member's SemanticDB owner

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -149,12 +149,20 @@ final class DefinitionProvider(
 
     for {
       // A doc-comment position can resolve to the enclosing package (`a/`, no
-      // location); that must not stop `fromScalaDoc` (scalameta/metals#3383).
+      // location); that must not stop `fromScalaDoc`, but a later empty result
+      // must not erase that package symbol either (it drives the fallback guard
+      // below) (scalameta/metals#3383).
       core <- coreStrategies.foldLeft(
         Future.successful(DefinitionResult.empty)
       ) { case (acc, next) =>
         acc.flatMap {
-          case res if res.isEmpty => next().map(_.getOrElse(res))
+          case res if res.isEmpty =>
+            next().map {
+              case Some(n)
+                  if n.isEmpty && n.symbol.isEmpty && res.symbol.nonEmpty =>
+                res
+              case other => other.getOrElse(res)
+            }
           case res => Future.successful(res)
         }
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -140,20 +140,30 @@ final class DefinitionProvider(
 
     val shouldUseOldOrder = isScala3 && !scala3DefinitionBugFixed
 
-    val strategies: List[() => Future[Option[DefinitionResult]]] =
+    // The precise strategies, in order; `fromFallback` (a heuristic search) is
+    // applied separately below because it must respect a stricter guard.
+    val coreStrategies: List[() => Future[Option[DefinitionResult]]] =
       if (shouldUseOldOrder)
-        List(fromSemanticDb, fromCompiler, fromScalaDoc, fromFallback)
-      else List(fromCompiler, fromSemanticDb, fromScalaDoc, fromFallback)
+        List(fromSemanticDb, fromCompiler, fromScalaDoc)
+      else List(fromCompiler, fromSemanticDb, fromScalaDoc)
 
     for {
-      result <- strategies.foldLeft(Future.successful(DefinitionResult.empty)) {
-        case (acc, next) =>
-          acc.flatMap {
-            case res if res.isEmpty && !res.symbol.endsWith("/") =>
-              next().map(_.getOrElse(res))
-            case res => Future.successful(res)
-          }
+      // A doc-comment position can resolve to the enclosing package (`a/`, no
+      // location); that must not stop `fromScalaDoc` (scalameta/metals#3383).
+      core <- coreStrategies.foldLeft(
+        Future.successful(DefinitionResult.empty)
+      ) { case (acc, next) =>
+        acc.flatMap {
+          case res if res.isEmpty => next().map(_.getOrElse(res))
+          case res => Future.successful(res)
+        }
       }
+      // The heuristic fallback must not override a package-symbol result (a
+      // package-qualifier click carries no location) (scalameta/metals#3383).
+      result <-
+        if (core.isEmpty && !core.symbol.endsWith("/"))
+          fromFallback().map(_.getOrElse(core))
+        else Future.successful(core)
     } yield {
       reportBuilder
         .build(scalaVersionSelector)

--- a/metals/src/main/scala/scala/meta/internal/metals/ScaladocDefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScaladocDefinitionProvider.scala
@@ -34,19 +34,56 @@ class ScaladocDefinitionProvider(
       buffer <- buffers.get(path)
       position <- params.getPosition().toMeta(Input.String(buffer))
       symbol <- extractScalaDocLinkAtPos(buffer, position, isScala3)
-      contextSymbols = getContext(path, position)
-      scalaMetaSymbols = symbol.toScalaMetaSymbols(contextSymbols)
+      contextSymbols = getContext(path, position, isScala3)
+      symbolGroups = symbol.toScalaMetaSymbolGroups(contextSymbols)
       _ = scribe.debug(
-        s"looking for definition for scaladoc symbol: $symbol considering alternatives: ${scalaMetaSymbols
+        s"looking for definition for scaladoc symbol: $symbol considering alternatives: ${symbolGroups.flatten
             .map(_.showSymbol)
             .mkString(", ")}"
       )
-      definitionResult <- scalaMetaSymbols.collectFirst { sym =>
+      definitionResult <- symbolGroups.view
+        .flatMap(resolveGroup(_, path, isScala3))
+        .headOption
+    } yield definitionResult
+  }
+
+  // Scala 2 binds an ambiguous `[[Name]]` type-before-value (first match);
+  // Scala 3 first-in-source-order among same-file candidates (scalameta/metals#3383).
+  private def resolveGroup(
+      group: List[ScalaDocLinkSymbol],
+      path: AbsolutePath,
+      isScala3: Boolean,
+  ): Option[DefinitionResult] = {
+    def firstMatch: Option[DefinitionResult] =
+      group.collectFirst { sym =>
         search(sym, path) match {
           case Some(value) => value
         }
       }
-    } yield definitionResult
+    if (!isScala3) firstMatch
+    else {
+      val resolved = group
+        .flatMap(sym => search(sym, path))
+        .filter(_.locations.asScala.nonEmpty)
+      resolved match {
+        case Nil => None
+        case single :: Nil => Some(single)
+        case many =>
+          val sameFile =
+            many
+              .map(_.locations.asScala.head.getUri)
+              .distinct
+              .lengthCompare(1) == 0
+          if (sameFile)
+            // minBy keeps the FIRST minimum, so equal positions (synthetic
+            // companions) fall back to descriptor precedence.
+            Some(many.minBy { result =>
+              val start = result.locations.asScala.head.getRange.getStart
+              (start.getLine, start.getCharacter)
+            })
+          else firstMatch
+      }
+    }
   }
 
   private def search(symbol: ScalaDocLinkSymbol, path: AbsolutePath) =
@@ -107,19 +144,126 @@ class ScaladocDefinitionProvider(
   private def getContext(
       path: AbsolutePath,
       pos: Position,
+      isScala3: Boolean,
   ): ContextSymbols = {
+    // Encode a name as its SemanticDB descriptor: backticked by its CHARACTERS
+    // (dots/spaces), never for keywords (scalameta/metals#3383).
+    def descName(value: String): String = {
+      def plain(c: Char) = c.isLetterOrDigit || c == '_' || c == '$'
+      def operator(c: Char) = "!#%&*+-/:<=>?@\\^|~".contains(c)
+      if (value.nonEmpty && (value.forall(plain) || value.forall(operator)))
+        value
+      else s"`$value`"
+    }
     def extractName(ref: Term): String =
       ref match {
-        case Term.Select(qual, name) => s"${extractName(qual)}/${name.value}"
-        case Term.Name(name) => name
+        case Term.Select(qual, name) =>
+          s"${extractName(qual)}/${descName(name.value)}"
+        case name: Term.Name => descName(name.value)
         case _ => ""
       }
+
+    // The Scala 3 synthetic object owning this file's top-level members
+    // (`Main.scala` → `Main$package`) (scalameta/metals#3383).
+    val filePackageObject: String = {
+      val filename = path.filename
+      val dot = filename.lastIndexOf('.')
+      val stem = if (dot > 0) filename.substring(0, dot) else filename
+      descName(s"$stem$$package")
+    }
 
     def enclosedChild(tree: Tree): Option[Tree] =
       tree.children
         .find { child =>
           child.pos.start <= pos.start && pos.start <= child.pos.end
         }
+
+    // The owner context of ONE tree node; non-owner nodes are transparent
+    // (scalameta/metals#3383).
+    def contextOf(
+        tree: Tree,
+        enclosingPackagePath: String,
+        enclosingSymbol: String,
+        alternativeEnclosingSymbol: Option[String],
+    ): (String, String, Option[String]) =
+      tree match {
+        case Pkg(name, _) =>
+          (
+            s"$enclosingPackagePath${extractName(name)}/",
+            enclosingSymbol,
+            None,
+          )
+        case d: Pkg.Object =>
+          // A package object extends the package and owns a `package.`
+          // template (scalameta/metals#3383).
+          (
+            s"$enclosingPackagePath${descName(d.name.value)}/",
+            s"${enclosingSymbol}package.",
+            None,
+          )
+        case d: Defn.Object =>
+          (
+            enclosingPackagePath,
+            s"$enclosingSymbol${descName(d.name.value)}.",
+            None,
+          )
+        case d: Defn.Class =>
+          (
+            enclosingPackagePath,
+            s"$enclosingSymbol${descName(d.name.value)}#",
+            None,
+          )
+        case d: Defn.Trait =>
+          (
+            enclosingPackagePath,
+            s"$enclosingSymbol${descName(d.name.value)}#",
+            None,
+          )
+        case d: Defn.Enum =>
+          (
+            enclosingPackagePath,
+            s"$enclosingSymbol${descName(d.name.value)}#",
+            Some(s"$enclosingSymbol${descName(d.name.value)}."),
+          )
+        case d: Defn.EnumCase =>
+          // Enum cases live in the enum's COMPANION; a parameterized case is
+          // a case class (`Case#`) (scalameta/metals#3383).
+          val base = alternativeEnclosingSymbol.getOrElse(enclosingSymbol)
+          val name = descName(d.name.value)
+          if (d.ctor.paramss.flatten.nonEmpty)
+            (
+              enclosingPackagePath,
+              s"$base$name#",
+              Some(s"$base$name."),
+            )
+          else
+            (
+              enclosingPackagePath,
+              s"$base$name.",
+              Some(s"$base$name#"),
+            )
+        case d: Defn.Given if d.name.value.nonEmpty =>
+          // A named given owns members under `name#` but is itself the value
+          // `name.`; offer both (scalameta/metals#3383).
+          (
+            enclosingPackagePath,
+            s"$enclosingSymbol${descName(d.name.value)}#",
+            Some(s"$enclosingSymbol${descName(d.name.value)}."),
+          )
+        case (_: Defn.Def | _: Defn.Val | _: Defn.Var | _: Defn.Type)
+            if isScala3 && enclosingSymbol.isEmpty =>
+          // A Scala 3 top-level member's owner is the file's synthetic
+          // `<file>$package` object (scalameta/metals#3383).
+          (
+            enclosingPackagePath,
+            s"$filePackageObject.",
+            None,
+          )
+        // Includes an anonymous given (`given_<type>` can't be rebuilt from
+        // syntax) — a safe miss (scalameta/metals#3383).
+        case _ =>
+          (enclosingPackagePath, enclosingSymbol, alternativeEnclosingSymbol)
+      }
 
     def loop(
         tree: Tree,
@@ -132,31 +276,12 @@ class ScaladocDefinitionProvider(
         enclosingSymbol1,
         alternativeEnclosingSymbol1,
       ) =
-        tree match {
-          case Pkg(name, _) =>
-            (
-              s"$enclosingPackagePath${extractName(name)}/",
-              enclosingSymbol,
-              None,
-            )
-          case d: Defn.Object =>
-            (enclosingPackagePath, s"$enclosingSymbol${d.name.value}.", None)
-          case d: Defn.Class =>
-            (enclosingPackagePath, s"$enclosingSymbol${d.name.value}#", None)
-          case d: Defn.Trait =>
-            (enclosingPackagePath, s"$enclosingSymbol${d.name.value}#", None)
-          case d: Defn.Enum =>
-            (
-              enclosingPackagePath,
-              s"$enclosingSymbol${d.name.value}#",
-              Some(s"$enclosingSymbol${d.name.value}."),
-            )
-          case d: Defn.Given =>
-            (enclosingPackagePath, s"$enclosingSymbol${d.name.value}#", None)
-          case _ =>
-            (enclosingPackagePath, enclosingSymbol, alternativeEnclosingSymbol)
-        }
-
+        contextOf(
+          tree,
+          enclosingPackagePath,
+          enclosingSymbol,
+          alternativeEnclosingSymbol,
+        )
       enclosedChild(tree)
         .map(
           loop(
@@ -167,7 +292,32 @@ class ScaladocDefinitionProvider(
           )
         )
         .getOrElse {
-          (enclosingPackagePath1, enclosingSymbol1, alternativeEnclosingSymbol1)
+          // A leading doc comment encloses no child; resolve against the
+          // member FOLLOWING it, not the enclosing owner (scalameta/metals#3383).
+          tree.children.find(_.pos.start >= pos.start) match {
+            case Some(member0) =>
+              // scalameta wraps package statements in a `Pkg.Body`; descend
+              // through the wrapper (scalameta/metals#3383).
+              val member = member0 match {
+                case body: Pkg.Body =>
+                  body.children
+                    .find(_.pos.start >= pos.start)
+                    .getOrElse(member0)
+                case other => other
+              }
+              contextOf(
+                member,
+                enclosingPackagePath1,
+                enclosingSymbol1,
+                alternativeEnclosingSymbol1,
+              )
+            case None =>
+              (
+                enclosingPackagePath1,
+                enclosingSymbol1,
+                alternativeEnclosingSymbol1,
+              )
+          }
         }
     }
 
@@ -197,6 +347,13 @@ case class ScalaDocLink(rawSymbol: String, isScala3: Boolean) {
   def toScalaMetaSymbols(
       contextSymbols: => ContextSymbols
   ): List[ScalaDocLinkSymbol] =
+    toScalaMetaSymbolGroups(contextSymbols).flatten
+
+  // One precedence-ordered candidate group per link interpretation
+  // (`this.`-relative, package-relative, fully-qualified) (scalameta/metals#3383).
+  def toScalaMetaSymbolGroups(
+      contextSymbols: => ContextSymbols
+  ): List[List[ScalaDocLinkSymbol]] =
     if (rawSymbol.isEmpty()) List.empty
     else {
       val (symbol0, symbolType) = symbolWithType
@@ -225,23 +382,21 @@ case class ScalaDocLink(rawSymbol: String, isScala3: Boolean) {
               contextSymbols.withPackage(symbol)
         }
 
-      symbolType match {
-        case ScalaDocLink.SymbolType.Method =>
-          withPrefixes.flatMap(sym => List(MethodSymbol(sym)))
-        case ScalaDocLink.SymbolType.Value =>
-          withPrefixes.flatMap(sym =>
+      withPrefixes.map { sym =>
+        symbolType match {
+          case ScalaDocLink.SymbolType.Method =>
+            List(MethodSymbol(sym))
+          case ScalaDocLink.SymbolType.Value =>
             List(StringSymbol(s"$sym."), MethodSymbol(sym))
-          )
-        case ScalaDocLink.SymbolType.Type =>
-          withPrefixes.flatMap(sym => List(StringSymbol(s"$sym#")))
-        case ScalaDocLink.SymbolType.Any =>
-          withPrefixes.flatMap(sym =>
+          case ScalaDocLink.SymbolType.Type =>
+            List(StringSymbol(s"$sym#"))
+          case ScalaDocLink.SymbolType.Any =>
             List(
               StringSymbol(s"$sym#"),
               StringSymbol(s"$sym."),
               MethodSymbol(sym),
             )
-          )
+        }
       }
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScaladocDefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScaladocDefinitionProvider.scala
@@ -185,7 +185,12 @@ class ScaladocDefinitionProvider(
         enclosingPackagePath: String,
         enclosingSymbol: String,
         alternativeEnclosingSymbol: Option[String],
-    ): (String, String, Option[String]) =
+    ): (String, String, Option[String]) = {
+      // A Scala 3 top-level member's owner is the file's synthetic `$package`
+      // object rather than the bare package (scalameta/metals#3383).
+      val ownerPrefix =
+        if (isScala3 && enclosingSymbol.isEmpty) s"$filePackageObject."
+        else enclosingSymbol
       tree match {
         case Pkg(name, _) =>
           (
@@ -225,32 +230,17 @@ class ScaladocDefinitionProvider(
             s"$enclosingSymbol${descName(d.name.value)}#",
             Some(s"$enclosingSymbol${descName(d.name.value)}."),
           )
-        case d: Defn.EnumCase =>
-          // Enum cases live in the enum's COMPANION; a parameterized case is
-          // a case class (`Case#`) (scalameta/metals#3383).
-          val base = alternativeEnclosingSymbol.getOrElse(enclosingSymbol)
-          val name = descName(d.name.value)
-          if (d.ctor.paramss.flatten.nonEmpty)
-            (
-              enclosingPackagePath,
-              s"$base$name#",
-              Some(s"$base$name."),
-            )
-          else
-            (
-              enclosingPackagePath,
-              s"$base$name.",
-              Some(s"$base$name#"),
-            )
         case d: Defn.Given if d.name.value.nonEmpty =>
           // A named given owns members under `name#` but is itself the value
-          // `name.`; offer both (scalameta/metals#3383).
+          // `name.`; offer both. At Scala 3 top level it lives in `$package`
+          // (scalameta/metals#3383).
           (
             enclosingPackagePath,
-            s"$enclosingSymbol${descName(d.name.value)}#",
-            Some(s"$enclosingSymbol${descName(d.name.value)}."),
+            s"$ownerPrefix${descName(d.name.value)}#",
+            Some(s"$ownerPrefix${descName(d.name.value)}."),
           )
-        case (_: Defn.Def | _: Defn.Val | _: Defn.Var | _: Defn.Type)
+        case (_: Defn.Def | _: Defn.Val | _: Defn.Var | _: Defn.Type |
+            _: Defn.Given | _: Defn.GivenAlias | _: Defn.ExtensionGroup)
             if isScala3 && enclosingSymbol.isEmpty =>
           // A Scala 3 top-level member's owner is the file's synthetic
           // `<file>$package` object (scalameta/metals#3383).
@@ -264,6 +254,7 @@ class ScaladocDefinitionProvider(
         case _ =>
           (enclosingPackagePath, enclosingSymbol, alternativeEnclosingSymbol)
       }
+    }
 
     def loop(
         tree: Tree,

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -718,6 +718,12 @@ class DefinitionLspSuite
         locations.head.getUri().endsWith("/a/Esc.scala"),
         locations.toString,
       )
+      // `def field` is on line 4 (0-based).
+      _ = assertEquals(
+        locations.head.getRange().getStart().getLine(),
+        4,
+        locations.toString,
+      )
     } yield ()
   }
 
@@ -750,6 +756,12 @@ class DefinitionLspSuite
       _ = assert(locations.nonEmpty, "package-object link did not resolve")
       _ = assert(
         locations.head.getUri().endsWith("/a/q/package.scala"),
+        locations.toString,
+      )
+      // `def helper` is on line 4 (0-based).
+      _ = assertEquals(
+        locations.head.getRange().getStart().getLine(),
+        4,
         locations.toString,
       )
     } yield ()
@@ -789,39 +801,6 @@ class DefinitionLspSuite
         locations.head.getRange().getStart().getLine(),
         1,
         s"expected the source-first object Target (line 1), got $locations",
-      )
-    } yield ()
-  }
-
-  // `[[r]]` in the doc of `case Mix(r: Int)` resolves against the CASE, not
-  // the enclosing enum (scalameta/metals#3383).
-  test("scaladoc-definition-enum-case-param") {
-    val testCase =
-      """|package a
-         |enum E {
-         |  /** The mix [[r@@]]. */
-         |  case Mix(r: Int)
-         |}
-         |""".stripMargin
-    for {
-      _ <- initialize(
-        s"""
-           |/metals.json
-           |{ "a": { "scalaVersion": "${V.scala3}" } }
-           |/a/src/main/scala/a/E.scala
-           |${testCase.replace("@@", "")}
-           |""".stripMargin
-      )
-      _ <- server.didOpen("a/src/main/scala/a/E.scala")
-      locations <- server.definition(
-        "a/src/main/scala/a/E.scala",
-        testCase,
-        workspace,
-      )
-      _ = assert(locations.nonEmpty, "enum case param link did not resolve")
-      _ = assert(
-        locations.head.getUri().endsWith("/a/E.scala"),
-        locations.toString,
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -684,6 +684,182 @@ class DefinitionLspSuite
     } yield ()
   }
 
+  // A relative link inside a backtick-escaped owner (`` class `my type` ``)
+  // resolves via its SemanticDB descriptor (scalameta/metals#3383).
+  test("scaladoc-definition-escaped-owner") {
+    val testCase =
+      """|package a
+         |class `my type` {
+         |  /** See [[fie@@ld]]. */
+         |  def m: Int = field
+         |  def field: Int = 1
+         |}
+         |""".stripMargin
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{ "a": { } }
+           |/a/src/main/scala/a/Esc.scala
+           |${testCase.replace("@@", "")}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Esc.scala")
+      locations <- server.definition(
+        "a/src/main/scala/a/Esc.scala",
+        testCase,
+        workspace,
+      )
+      _ = assert(
+        locations.nonEmpty,
+        "escaped-owner relative link did not resolve",
+      )
+      _ = assert(
+        locations.head.getUri().endsWith("/a/Esc.scala"),
+        locations.toString,
+      )
+    } yield ()
+  }
+
+  // A package-object doc resolves relative links against its `package.`
+  // template (scalameta/metals#3383).
+  test("scaladoc-definition-package-object") {
+    val testCase =
+      """|package a
+         |package object q {
+         |  /** See [[hel@@per]]. */
+         |  def entry: Int = helper
+         |  def helper: Int = 1
+         |}
+         |""".stripMargin
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{ "a": { } }
+           |/a/src/main/scala/a/q/package.scala
+           |${testCase.replace("@@", "")}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/q/package.scala")
+      locations <- server.definition(
+        "a/src/main/scala/a/q/package.scala",
+        testCase,
+        workspace,
+      )
+      _ = assert(locations.nonEmpty, "package-object link did not resolve")
+      _ = assert(
+        locations.head.getUri().endsWith("/a/q/package.scala"),
+        locations.toString,
+      )
+    } yield ()
+  }
+
+  // Scala 3 binds an ambiguous `[[Name]]` first-in-source-order. NOTE: only
+  // the companion OBJECT resolves here, so this guards resolution, not the
+  // tie-break (scalameta/metals#3383).
+  test("scaladoc-definition-scala3-source-order") {
+    val testCase =
+      """|package a
+         |object Target { def x: Int = 1 }
+         |class Target
+         |object O {
+         |  /** See [[Tar@@get]]. */
+         |  def f: Int = 1
+         |}
+         |""".stripMargin
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{ "a": { "scalaVersion": "${V.scala3}" } }
+           |/a/src/main/scala/a/Main.scala
+           |${testCase.replace("@@", "")}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      locations <- server.definition(
+        "a/src/main/scala/a/Main.scala",
+        testCase,
+        workspace,
+      )
+      _ = assert(locations.nonEmpty, "ambiguous companion link did not resolve")
+      // `object Target` is on line 1 (0-based); `class Target` on line 2.
+      _ = assertEquals(
+        locations.head.getRange().getStart().getLine(),
+        1,
+        s"expected the source-first object Target (line 1), got $locations",
+      )
+    } yield ()
+  }
+
+  // `[[r]]` in the doc of `case Mix(r: Int)` resolves against the CASE, not
+  // the enclosing enum (scalameta/metals#3383).
+  test("scaladoc-definition-enum-case-param") {
+    val testCase =
+      """|package a
+         |enum E {
+         |  /** The mix [[r@@]]. */
+         |  case Mix(r: Int)
+         |}
+         |""".stripMargin
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{ "a": { "scalaVersion": "${V.scala3}" } }
+           |/a/src/main/scala/a/E.scala
+           |${testCase.replace("@@", "")}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/E.scala")
+      locations <- server.definition(
+        "a/src/main/scala/a/E.scala",
+        testCase,
+        workspace,
+      )
+      _ = assert(locations.nonEmpty, "enum case param link did not resolve")
+      _ = assert(
+        locations.head.getUri().endsWith("/a/E.scala"),
+        locations.toString,
+      )
+    } yield ()
+  }
+
+  // A Scala 3 top-level member's doc resolves against the file's synthetic
+  // `<file>$package` object (scalameta/metals#3383).
+  test("scaladoc-definition-scala3-toplevel-member") {
+    val testCase =
+      """|package a
+         |/** See [[hel@@per]]. */
+         |def entry = 1
+         |def helper = 2
+         |""".stripMargin
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{ "a": { "scalaVersion": "${V.scala3}" } }
+           |/a/src/main/scala/a/Main.scala
+           |${testCase.replace("@@", "")}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      locations <- server.definition(
+        "a/src/main/scala/a/Main.scala",
+        testCase,
+        workspace,
+      )
+      _ = assert(locations.nonEmpty, "top-level [[helper]] did not resolve")
+      // `def helper` is on line 3 (0-based).
+      _ = assertEquals(
+        locations.head.getRange().getStart().getLine(),
+        3,
+        s"expected top-level def helper (line 3), got $locations",
+      )
+    } yield ()
+  }
+
   test("scaladoc-definition-this") {
     for {
       _ <- initialize(


### PR DESCRIPTION
Second part of splitting up #8658 (after #8676). Source go-to-definition on a `[[wiki link]]` now builds the documented member's context correctly:

- A doc comment resolves against the member that follows it, not the enclosing scope, and owner names are encoded as SemanticDB descriptors (fixes backticked owners like `` class `my type` ``).
- Adds the missing owner shapes: package objects (`package.`), enum cases (the case in the enum's companion), named and anonymous givens, and Scala 3 top-level members (`<file>$package`, which also required letting the scaladoc strategy run after an empty package-symbol result in `DefinitionProvider`).
- Ambiguous `[[Name]]` links follow the dialect: Scala 2 binds type-before-value, Scala 3 first-in-source-order. The tie-break is not yet observable in tests (the index resolves only the companion object), noted in the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Go to Definition” resolution for Scaladoc links across Scala 2 and Scala 3.
  * Fixed resolution for package objects, escaped owners, companion definitions, and Scala 3 top-level members.
  * Preserved valid package-symbol results and prevented heuristic matches from overriding them.
  * Improved handling of named givens, given aliases, extension groups, enums, and source-order resolution.

* **Tests**
  * Expanded coverage for Scala and Scaladoc definition-resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->