### PR TITLE
Bazel-MBT: Fix various issues with running test cases

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -15,6 +15,7 @@ import scala.meta.internal.metals.mbt.importer.BazelMbtImporter
 import scala.meta.internal.metals.mbt.importer.BazelQuery
 import scala.meta.io.AbsolutePath
 
+import bloop.config.Config.TestFramework
 import ch.epfl.scala.bsp4j.ScalaMainClass
 import ch.epfl.scala.bsp4j.ScalaTestSuites
 import coursier.Dependency
@@ -135,9 +136,15 @@ case class BazelBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Future[List[String]] =
     resolveTestRunTargets(workspace, target, sourceFiles).map { runTargets =>
-      mbtTestExecCommand(runTargets, testSuites, debugAgentFlag = None)
+      mbtTestExecCommand(
+        runTargets,
+        testSuites,
+        debugAgentFlag = None,
+        frameworkOf = frameworkOf,
+      )
     }
 
   override def mbtTestDebugCommand(
@@ -146,12 +153,14 @@ case class BazelBuildTool(
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Future[List[String]] =
     resolveTestRunTargets(workspace, target, sourceFiles).map { runTargets =>
       mbtTestExecCommand(
         runTargets,
         testSuites,
         debugAgentFlag = Some(debugAgentFlag),
+        frameworkOf = frameworkOf,
       )
     }
 
@@ -162,6 +171,7 @@ case class BazelBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Int => Future[List[String]] = {
     val resolvedRunTargets =
       resolveTestRunTargets(workspace, target, sourceFiles)
@@ -171,6 +181,7 @@ case class BazelBuildTool(
           runTargets,
           testSuites,
           debugAgentFlag = None,
+          frameworkOf = frameworkOf,
         ) ::: List(
           "--nocache_test_results",
           "--test_output=streamed",
@@ -230,12 +241,17 @@ case class BazelBuildTool(
       runTargets: List[String],
       testSuites: ScalaTestSuites,
       debugAgentFlag: Option[String],
+      frameworkOf: String => Option[TestFramework],
   ): List[String] = {
     val jvmFlags =
       debugAgentFlag.toList ::: MbtDebugLauncher
         .listOrNil(testSuites.getJvmOptions)
     val suites = MbtDebugLauncher.listOrNil(testSuites.getSuites)
-    val testFilter = suites.flatMap { suite =>
+    val (scalaTestSuites, otherSuites) = suites.partition { suite =>
+      MbtDebugLauncher.listOrNil(suite.getTests).nonEmpty &&
+      frameworkOf(suite.getClassName).contains(TestFramework.ScalaTest)
+    }
+    val testFilter = otherSuites.flatMap { suite =>
       val className = suite.getClassName
       val tests = MbtDebugLauncher.listOrNil(suite.getTests)
       if (tests.isEmpty) List(className)
@@ -244,12 +260,22 @@ case class BazelBuildTool(
     val testFilterArgs =
       if (testFilter.isEmpty) Nil
       else List(s"--test_filter=${testFilter.mkString(",")}")
+    // rules_scala's scala_test runner interprets Bazel's
+    // `--test_filter` as its own `-s <className>` flag, which doesn't work with
+    // individual test cases, so we special case it to use the ScalaTest
+    // settings directly.
+    val scalaTestArgs = scalaTestSuites.flatMap { suite =>
+      val className = suite.getClassName
+      val tests = MbtDebugLauncher.listOrNil(suite.getTests)
+      List("--test_arg=-s", s"--test_arg=$className") :::
+        tests.flatMap(test => List("--test_arg=-t", s"--test_arg=$test"))
+    }
     val jvmFlagsArgs =
       jvmFlags.map(flag => s"--test_arg=--wrapper_script_flag=--jvm_flag=$flag")
     List(
       "bazel", "test", "--ui_event_filters=-info,-stderr,-warning",
       "--noshow_progress", "--test_output=all", "--test_tag_filters=",
-    ) ::: runTargets ::: testFilterArgs ::: jvmFlagsArgs
+    ) ::: runTargets ::: testFilterArgs ::: scalaTestArgs ::: jvmFlagsArgs
   }
 
   private def bazelBuildTargets(target: MbtTarget): List[String] =

--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -136,14 +136,14 @@ case class BazelBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Future[List[String]] =
     resolveTestRunTargets(workspace, target, sourceFiles).map { runTargets =>
       mbtTestExecCommand(
         runTargets,
         testSuites,
         debugAgentFlag = None,
-        frameworkOf = frameworkOf,
+        framework = framework,
       )
     }
 
@@ -153,14 +153,14 @@ case class BazelBuildTool(
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Future[List[String]] =
     resolveTestRunTargets(workspace, target, sourceFiles).map { runTargets =>
       mbtTestExecCommand(
         runTargets,
         testSuites,
         debugAgentFlag = Some(debugAgentFlag),
-        frameworkOf = frameworkOf,
+        framework = framework,
       )
     }
 
@@ -171,7 +171,7 @@ case class BazelBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Int => Future[List[String]] = {
     val resolvedRunTargets =
       resolveTestRunTargets(workspace, target, sourceFiles)
@@ -181,7 +181,7 @@ case class BazelBuildTool(
           runTargets,
           testSuites,
           debugAgentFlag = None,
-          frameworkOf = frameworkOf,
+          framework = framework,
         ) ::: List(
           "--nocache_test_results",
           "--test_output=streamed",
@@ -241,41 +241,40 @@ case class BazelBuildTool(
       runTargets: List[String],
       testSuites: ScalaTestSuites,
       debugAgentFlag: Option[String],
-      frameworkOf: String => Option[TestFramework],
+      framework: Option[TestFramework],
   ): List[String] = {
     val jvmFlags =
       debugAgentFlag.toList ::: MbtDebugLauncher
         .listOrNil(testSuites.getJvmOptions)
     val suites = MbtDebugLauncher.listOrNil(testSuites.getSuites)
-    val (scalaTestSuites, otherSuites) = suites.partition { suite =>
-      MbtDebugLauncher.listOrNil(suite.getTests).nonEmpty &&
-      frameworkOf(suite.getClassName).contains(TestFramework.ScalaTest)
-    }
-    val testFilter = otherSuites.flatMap { suite =>
-      val className = suite.getClassName
-      val tests = MbtDebugLauncher.listOrNil(suite.getTests)
-      if (tests.isEmpty) List(className)
-      else tests.map(test => s"$className#$test")
-    }
     val testFilterArgs =
-      if (testFilter.isEmpty) Nil
-      else List(s"--test_filter=${testFilter.mkString(",")}")
-    // rules_scala's scala_test runner interprets Bazel's
-    // `--test_filter` as its own `-s <className>` flag, which doesn't work with
-    // individual test cases, so we special case it to use the ScalaTest
-    // settings directly.
-    val scalaTestArgs = scalaTestSuites.flatMap { suite =>
-      val className = suite.getClassName
-      val tests = MbtDebugLauncher.listOrNil(suite.getTests)
-      List("--test_arg=-s", s"--test_arg=$className") :::
-        tests.flatMap(test => List("--test_arg=-t", s"--test_arg=$test"))
-    }
+      if (framework.contains(TestFramework.ScalaTest)) {
+        // rules_scala's scala_test runner interprets Bazel's
+        // `--test_filter` as its own `-s <className>` flag, which doesn't work with
+        // individual test cases, so we special case it to use the ScalaTest
+        // settings directly.
+        suites.flatMap { suite =>
+          val className = suite.getClassName
+          val tests = MbtDebugLauncher.listOrNil(suite.getTests)
+          List("--test_arg=-s", s"--test_arg=$className") :::
+            tests.flatMap(test => List("--test_arg=-t", s"--test_arg=$test"))
+        }
+      } else {
+        val testFilter = suites.flatMap { suite =>
+          val className = suite.getClassName
+          val tests = MbtDebugLauncher.listOrNil(suite.getTests)
+          if (tests.isEmpty) List(className)
+          else tests.map(test => s"$className#$test")
+        }
+        if (testFilter.isEmpty) Nil
+        else List(s"--test_filter=${testFilter.mkString(",")}")
+      }
     val jvmFlagsArgs =
       jvmFlags.map(flag => s"--test_arg=--wrapper_script_flag=--jvm_flag=$flag")
     List(
       "bazel", "test", "--ui_event_filters=-info,-stderr,-warning",
       "--noshow_progress", "--test_output=all", "--test_tag_filters=",
-    ) ::: runTargets ::: testFilterArgs ::: scalaTestArgs ::: jvmFlagsArgs
+    ) ::: runTargets ::: testFilterArgs ::: jvmFlagsArgs
   }
 
   private def bazelBuildTargets(target: MbtTarget): List[String] =

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -266,7 +266,7 @@ case class GradleBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Future[List[String]] =
     Future.successful(
       gradleTestCommand(target, testSuites, debugAgentFlag = None)
@@ -278,7 +278,7 @@ case class GradleBuildTool(
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Future[List[String]] =
     Future.successful(
       gradleTestCommand(target, testSuites, Some(debugAgentFlag))
@@ -291,7 +291,7 @@ case class GradleBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Int => Future[List[String]] = { port =>
     val debugAgentFlag =
       s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$port"

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -17,6 +17,7 @@ import scala.meta.internal.metals.mbt.importer.GradleMbtImporter
 import scala.meta.internal.mtags.MD5
 import scala.meta.io.AbsolutePath
 
+import bloop.config.Config.TestFramework
 import ch.epfl.scala.bsp4j.ScalaMainClass
 import ch.epfl.scala.bsp4j.ScalaTestSuites
 import coursier.MavenRepository
@@ -265,6 +266,7 @@ case class GradleBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Future[List[String]] =
     Future.successful(
       gradleTestCommand(target, testSuites, debugAgentFlag = None)
@@ -276,6 +278,7 @@ case class GradleBuildTool(
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Future[List[String]] =
     Future.successful(
       gradleTestCommand(target, testSuites, Some(debugAgentFlag))
@@ -288,6 +291,7 @@ case class GradleBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Int => Future[List[String]] = { port =>
     val debugAgentFlag =
       s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$port"

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -16,6 +16,7 @@ import scala.meta.internal.metals.mbt.MbtTarget
 import scala.meta.internal.metals.mbt.importer.MavenMbtImporter
 import scala.meta.io.AbsolutePath
 
+import bloop.config.Config.TestFramework
 import ch.epfl.scala.bsp4j.ScalaMainClass
 import ch.epfl.scala.bsp4j.ScalaTestSuites
 
@@ -171,6 +172,7 @@ case class MavenBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Future[List[String]] =
     Future.successful(
       mbtTestExecCommand(
@@ -186,6 +188,7 @@ case class MavenBuildTool(
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Future[List[String]] =
     mbtTestDebugCommandWithPort(workspace, target, testSuites, sourceFiles)(
       5005
@@ -198,6 +201,7 @@ case class MavenBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Int => Future[List[String]] = { port =>
     // Use Surefire's forked JVM with a pre-assigned debug port.
     // This allows proper source mapping since tests run in a separate JVM.

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -172,7 +172,7 @@ case class MavenBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Future[List[String]] =
     Future.successful(
       mbtTestExecCommand(
@@ -188,7 +188,7 @@ case class MavenBuildTool(
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Future[List[String]] =
     mbtTestDebugCommandWithPort(workspace, target, testSuites, sourceFiles)(
       5005
@@ -201,7 +201,7 @@ case class MavenBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Int => Future[List[String]] = { port =>
     // Use Surefire's forked JVM with a pre-assigned debug port.
     // This allows proper source mapping since tests run in a separate JVM.

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -211,7 +211,7 @@ class ProjectMetalsLspService(
         userJavaHome = () => userConfig.javaHome,
         workDoneProgress = workDoneProgress,
         buildTargetClasses = buildTargetClasses,
-        knownTestCaseNames = testProvider.knownTestCaseNames,
+        testProvider = testProvider,
       )(ec)
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -211,6 +211,7 @@ class ProjectMetalsLspService(
         userJavaHome = () => userConfig.javaHome,
         workDoneProgress = workDoneProgress,
         classToSourceFile = buildTargetClasses.sourceFileForMbtTestClass,
+        classToFramework = buildTargetClasses.frameworkForMbtTestClass,
       )(ec)
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -212,6 +212,7 @@ class ProjectMetalsLspService(
         workDoneProgress = workDoneProgress,
         classToSourceFile = buildTargetClasses.sourceFileForMbtTestClass,
         classToFramework = buildTargetClasses.frameworkForMbtTestClass,
+        knownTestCaseNames = testProvider.knownTestCaseNames,
       )(ec)
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -210,8 +210,7 @@ class ProjectMetalsLspService(
         buildTool = buildTool,
         userJavaHome = () => userConfig.javaHome,
         workDoneProgress = workDoneProgress,
-        classToSourceFile = buildTargetClasses.sourceFileForMbtTestClass,
-        classToFramework = buildTargetClasses.frameworkForMbtTestClass,
+        buildTargetClasses = buildTargetClasses,
         knownTestCaseNames = testProvider.knownTestCaseNames,
       )(ec)
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -133,6 +133,12 @@ final class BuildTargetClasses(
   ): Option[AbsolutePath] =
     index.get(targetId).flatMap(_.confirmedMbtTestClassFile.get(className))
 
+  def frameworkForMbtTestClass(
+      className: String,
+      targetId: b.BuildTargetIdentifier,
+  ): Option[TestFramework] =
+    getTestClasses(className, targetId).headOption.map(_._2.framework)
+
   def resolveCandidateTestClass(
       name: String,
       target: Option[String],

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -350,6 +350,7 @@ class DebugProvider(
         .getOrElse(Seq.empty)
 
     openLocalDebugServer(sessionName, cancelPromise) { () =>
+      val startTime = System.currentTimeMillis()
       val testParams = new b.TestParams(parameters.getTargets())
       testParams.setOriginId(ju.UUID.randomUUID().toString())
       testParams.setDataKind(parameters.getDataKind)
@@ -360,14 +361,12 @@ class DebugProvider(
         val runner = currentRunner.get()
         if (runner != null && testSuites.nonEmpty) {
           val passed = result.getStatusCode == b.StatusCode.OK
-          // 0 is an obviously untrue value - a real duration will show up in the logs.
-          // Parsing the bazel xml output is an option, but might be hard to maintain.
-          val duration = 0L
           val targetIdOpt = parameters.getTargets().asScala.headOption
           val knownTestCaseNamesFor: String => List[String] = className =>
             targetIdOpt
               .map(id => testProvider.knownTestCaseNames(id, className))
               .getOrElse(Nil)
+          val duration = System.currentTimeMillis() - startTime
           MbtTestResultAdapter
             .testSuiteSummaries(
               testSuites.toList,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -363,27 +363,19 @@ class DebugProvider(
           // 0 is an obviously untrue value - a real duration will show up in the logs.
           // Parsing the bazel xml output is an option, but might be hard to maintain.
           val duration = 0L
-          testSuites.foreach { suite =>
-            val entry: dap.testing.SingleTestSummary =
-              if (passed)
-                dap.testing.SingleTestResult
-                  .Passed(suite.getClassName, duration)
-              else
-                dap.testing.SingleTestResult.Failed(
-                  suite.getClassName,
-                  duration,
-                  "Test suite failed",
-                  null,
-                  null,
-                )
-            runner.testResult(
-              dap.testing.TestSuiteSummary(
-                suite.getClassName,
-                duration,
-                ju.Collections.singletonList(entry),
-              )
+          val targetIdOpt = parameters.getTargets().asScala.headOption
+          val knownTestCaseNamesFor: String => List[String] = className =>
+            targetIdOpt
+              .map(id => testProvider.knownTestCaseNames(id, className))
+              .getOrElse(Nil)
+          MbtTestResultAdapter
+            .testSuiteSummaries(
+              testSuites.toList,
+              knownTestCaseNamesFor,
+              passed,
+              duration,
             )
-          }
+            .foreach(runner.testResult)
         }
         result
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -361,16 +361,14 @@ class DebugProvider(
         val runner = currentRunner.get()
         if (runner != null && testSuites.nonEmpty) {
           val passed = result.getStatusCode == b.StatusCode.OK
-          val targetIdOpt = parameters.getTargets().asScala.headOption
-          val knownTestCaseNamesFor: String => List[String] = className =>
-            targetIdOpt
-              .map(id => testProvider.knownTestCaseNames(id, className))
-              .getOrElse(Nil)
           val duration = System.currentTimeMillis() - startTime
+          // Targets cannot be empty
+          val targetId = parameters.getTargets().asScala.head
           MbtTestResultAdapter
             .testSuiteSummaries(
               testSuites.toList,
-              knownTestCaseNamesFor,
+              testProvider,
+              targetId,
               passed,
               duration,
             )

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -57,6 +57,7 @@ import scala.meta.internal.metals.debug.server.MetalsDebugToolsResolver
 import scala.meta.internal.metals.debug.server.MetalsDebuggee
 import scala.meta.internal.metals.debug.server.TestSuiteDebugAdapter
 import scala.meta.internal.metals.mbt.MbtBuildServer
+import scala.meta.internal.metals.mbt.MbtTestResultAdapter
 import scala.meta.internal.metals.testProvider.TestSuitesProvider
 import scala.meta.io.AbsolutePath
 
@@ -142,6 +143,12 @@ class DebugProvider(
    */
   def usesBuildTargetTest(id: BuildTargetIdentifier): Boolean =
     buildTargets.buildServerOf(id).exists(_.isMbt)
+
+  def confirmMbtTestClassCandidates(
+      path: AbsolutePath,
+      id: BuildTargetIdentifier,
+  ): Future[Unit] =
+    buildTargetClasses.confirmMbtTestClassCandidates(path, id)
 
   /**
    * Run tests through BSP `buildTarget/test`, capturing process output.

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugLauncher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugLauncher.scala
@@ -37,7 +37,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Future[List[String]]
 
   def mbtTestDebugCommand(
@@ -46,7 +46,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Future[List[String]]
 
   /**
@@ -64,7 +64,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
-      frameworkOf: String => Option[TestFramework] = _ => None,
+      framework: Option[TestFramework] = None,
   ): Int => Future[List[String]] = { _ =>
     mbtTestDebugCommand(
       workspace,
@@ -72,7 +72,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       testSuites,
       MbtDebugLauncher.DebugAgentFlag,
       sourceFiles,
-      frameworkOf,
+      framework,
     )
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugLauncher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugLauncher.scala
@@ -6,6 +6,7 @@ import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.meta.internal.builds.BuildTool
 import scala.meta.io.AbsolutePath
 
+import bloop.config.Config.TestFramework
 import ch.epfl.scala.bsp4j.ScalaMainClass
 import ch.epfl.scala.bsp4j.ScalaTestSuites
 
@@ -36,6 +37,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Future[List[String]]
 
   def mbtTestDebugCommand(
@@ -44,6 +46,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       testSuites: ScalaTestSuites,
       debugAgentFlag: String,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Future[List[String]]
 
   /**
@@ -61,6 +64,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       sourceFiles: Seq[AbsolutePath],
+      frameworkOf: String => Option[TestFramework] = _ => None,
   ): Int => Future[List[String]] = { _ =>
     mbtTestDebugCommand(
       workspace,
@@ -68,6 +72,7 @@ trait MbtDebugLauncher { self: BuildTool =>
       testSuites,
       MbtDebugLauncher.DebugAgentFlag,
       sourceFiles,
+      frameworkOf,
     )
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
@@ -20,6 +20,7 @@ import scala.meta.internal.process.ProcessOutput
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
 
+import bloop.config.Config.TestFramework
 import ch.epfl.scala.bsp4j.ScalaMainClass
 import ch.epfl.scala.bsp4j.ScalaTestSuites
 import ch.epfl.scala.debugadapter.MultiOutputModule
@@ -34,6 +35,10 @@ class MbtDebugSessionStarter(
         String,
         ch.epfl.scala.bsp4j.BuildTargetIdentifier,
     ) => Option[AbsolutePath] = (_, _) => None,
+    classToFramework: (
+        String,
+        ch.epfl.scala.bsp4j.BuildTargetIdentifier,
+    ) => Option[TestFramework] = (_, _) => None,
     debuggeeGracePeriodSeconds: Long = 60L,
 )(implicit ec: ExecutionContext) {
 
@@ -114,6 +119,11 @@ class MbtDebugSessionStarter(
       .listOrNil(testSuites.getSuites)
       .flatMap(s => classToSourceFile(s.getClassName, target.id))
 
+  private def frameworkOf(
+      target: MbtTarget
+  ): String => Option[TestFramework] =
+    className => classToFramework(className, target.id)
+
   def test(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
@@ -122,8 +132,13 @@ class MbtDebugSessionStarter(
       err: String => Unit,
   ): Future[Int] = {
     val sourceFiles = resolveSourceFiles(target, testSuites)
-    val command =
-      buildTool.mbtTestCommand(workspace, target, testSuites, sourceFiles)
+    val command = buildTool.mbtTestCommand(
+      workspace,
+      target,
+      testSuites,
+      sourceFiles,
+      frameworkOf(target),
+    )
     val toolName = buildTool.executableName
     val artifactId = {
       val parts = target.name.split(':')
@@ -231,6 +246,7 @@ class MbtDebugSessionStarter(
                     target,
                     testSuites,
                     sourceFiles,
+                    frameworkOf(target),
                   )
                 commandWithPort(0).foreach { command =>
                   scribe.info(
@@ -252,6 +268,7 @@ class MbtDebugSessionStarter(
                   testSuites,
                   debugAgentFlag,
                   sourceFiles,
+                  frameworkOf(target),
                 )
                 commandFuture.foreach { command =>
                   scribe.info(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
@@ -39,6 +39,10 @@ class MbtDebugSessionStarter(
         String,
         ch.epfl.scala.bsp4j.BuildTargetIdentifier,
     ) => Option[TestFramework] = (_, _) => None,
+    knownTestCaseNames: (
+        ch.epfl.scala.bsp4j.BuildTargetIdentifier,
+        String,
+    ) => List[String] = (_, _) => Nil,
     debuggeeGracePeriodSeconds: Long = 60L,
 )(implicit ec: ExecutionContext) {
 
@@ -123,6 +127,11 @@ class MbtDebugSessionStarter(
       target: MbtTarget
   ): String => Option[TestFramework] =
     className => classToFramework(className, target.id)
+
+  private def testCaseNamesOf(
+      target: MbtTarget
+  ): String => List[String] =
+    className => knownTestCaseNames(target.id, className)
 
   def test(
       target: MbtTarget,
@@ -283,7 +292,12 @@ class MbtDebugSessionStarter(
                   userJavaHome(),
                 )
               }
-            val debuggee = MbtTestResultAdapter(innerDebuggee, testSuites)
+            val debuggee =
+              MbtTestResultAdapter(
+                innerDebuggee,
+                testSuites,
+                testCaseNamesOf(target),
+              )
             val handler = dap.DebugServer.run(
               debuggee,
               new MetalsDebugToolsResolver(),

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
@@ -17,6 +17,7 @@ import scala.meta.internal.metals.debug.server.DebugeeParamsCreator
 import scala.meta.internal.metals.debug.server.DebugeeProject
 import scala.meta.internal.metals.debug.server.ForkedTestDebugAdapter
 import scala.meta.internal.metals.debug.server.MetalsDebugToolsResolver
+import scala.meta.internal.metals.testProvider.TestSuitesProvider
 import scala.meta.internal.process.ProcessOutput
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
@@ -33,10 +34,7 @@ class MbtDebugSessionStarter(
     userJavaHome: () => Option[String],
     workDoneProgress: BaseWorkDoneProgress,
     buildTargetClasses: BuildTargetClasses,
-    knownTestCaseNames: (
-        ch.epfl.scala.bsp4j.BuildTargetIdentifier,
-        String,
-    ) => List[String] = (_, _) => Nil,
+    testProvider: TestSuitesProvider,
     debuggeeGracePeriodSeconds: Long = 60L,
 )(implicit ec: ExecutionContext) {
 
@@ -129,11 +127,6 @@ class MbtDebugSessionStarter(
       .flatMap(s =>
         buildTargetClasses.frameworkForMbtTestClass(s.getClassName, target.id)
       )
-
-  private def testCaseNamesOf(
-      target: MbtTarget
-  ): String => List[String] =
-    className => knownTestCaseNames(target.id, className)
 
   def test(
       target: MbtTarget,
@@ -298,7 +291,8 @@ class MbtDebugSessionStarter(
               MbtTestResultAdapter(
                 innerDebuggee,
                 testSuites,
-                testCaseNamesOf(target),
+                testProvider,
+                target.id,
               )
             val handler = dap.DebugServer.run(
               debuggee,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration.Duration
 
 import scala.meta.internal.metals.BaseWorkDoneProgress
 import scala.meta.internal.metals.JdkSources
+import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.debug.server.BuildToolDebugAdapter
 import scala.meta.internal.metals.debug.server.DebugLogger
 import scala.meta.internal.metals.debug.server.DebugeeParamsCreator
@@ -31,14 +32,7 @@ class MbtDebugSessionStarter(
     buildTool: MbtDebugLauncher,
     userJavaHome: () => Option[String],
     workDoneProgress: BaseWorkDoneProgress,
-    classToSourceFile: (
-        String,
-        ch.epfl.scala.bsp4j.BuildTargetIdentifier,
-    ) => Option[AbsolutePath] = (_, _) => None,
-    classToFramework: (
-        String,
-        ch.epfl.scala.bsp4j.BuildTargetIdentifier,
-    ) => Option[TestFramework] = (_, _) => None,
+    buildTargetClasses: BuildTargetClasses,
     knownTestCaseNames: (
         ch.epfl.scala.bsp4j.BuildTargetIdentifier,
         String,
@@ -121,12 +115,20 @@ class MbtDebugSessionStarter(
   ): Seq[AbsolutePath] =
     MbtDebugLauncher
       .listOrNil(testSuites.getSuites)
-      .flatMap(s => classToSourceFile(s.getClassName, target.id))
+      .flatMap(s =>
+        buildTargetClasses.sourceFileForMbtTestClass(s.getClassName, target.id)
+      )
 
   private def frameworkOf(
-      target: MbtTarget
-  ): String => Option[TestFramework] =
-    className => classToFramework(className, target.id)
+      target: MbtTarget,
+      testSuites: ScalaTestSuites,
+  ): Option[TestFramework] =
+    MbtDebugLauncher
+      .listOrNil(testSuites.getSuites)
+      .headOption
+      .flatMap(s =>
+        buildTargetClasses.frameworkForMbtTestClass(s.getClassName, target.id)
+      )
 
   private def testCaseNamesOf(
       target: MbtTarget
@@ -146,7 +148,7 @@ class MbtDebugSessionStarter(
       target,
       testSuites,
       sourceFiles,
-      frameworkOf(target),
+      frameworkOf(target, testSuites),
     )
     val toolName = buildTool.executableName
     val artifactId = {
@@ -255,7 +257,7 @@ class MbtDebugSessionStarter(
                     target,
                     testSuites,
                     sourceFiles,
-                    frameworkOf(target),
+                    frameworkOf(target, testSuites),
                   )
                 commandWithPort(0).foreach { command =>
                   scribe.info(
@@ -277,7 +279,7 @@ class MbtDebugSessionStarter(
                   testSuites,
                   debugAgentFlag,
                   sourceFiles,
-                  frameworkOf(target),
+                  frameworkOf(target, testSuites),
                 )
                 commandFuture.foreach { command =>
                   scribe.info(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTestResultAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTestResultAdapter.scala
@@ -7,6 +7,7 @@ import scala.concurrent.Future
 
 import scala.meta.internal.metals.MetalsEnrichments._
 
+import ch.epfl.scala.bsp4j.ScalaTestSuiteSelection
 import ch.epfl.scala.bsp4j.ScalaTestSuites
 import ch.epfl.scala.debugadapter.CancelableFuture
 import ch.epfl.scala.debugadapter.ClassEntry
@@ -33,6 +34,7 @@ import ch.epfl.scala.debugadapter.testing.TestSuiteSummary
 class MbtTestResultAdapter(
     inner: Debuggee,
     testSuites: ScalaTestSuites,
+    knownTestCaseNames: String => List[String] = _ => Nil,
 )(implicit ec: ExecutionContext)
     extends Debuggee {
 
@@ -79,52 +81,15 @@ class MbtTestResultAdapter(
       listener: DebuggeeListener,
       passed: Boolean,
       duration: Long,
-  ): Unit = {
-    val suites = testSuites.getSuites.asScala.toList
-
-    for (suite <- suites) {
-      val className = suite.getClassName
-      val selectedTests = suite.getTests.asScala.toList
-
-      val testResults: java.util.List[SingleTestSummary] =
-        if (selectedTests.isEmpty) {
-          if (passed)
-            java.util.Collections.singletonList(
-              SingleTestResult.Passed(className, duration)
-            )
-          else
-            java.util.Collections.singletonList(
-              SingleTestResult.Failed(
-                className,
-                duration,
-                "Test suite failed",
-                null,
-                null,
-              )
-            )
-        } else {
-          val results = selectedTests.map { testName =>
-            val fullTestName = s"$className.$testName"
-            val result: SingleTestSummary =
-              if (passed)
-                SingleTestResult.Passed(fullTestName, duration)
-              else
-                SingleTestResult.Failed(
-                  fullTestName,
-                  duration,
-                  "Test failed",
-                  null,
-                  null,
-                )
-            result
-          }
-          results.asJava
-        }
-
-      val summary = TestSuiteSummary(className, duration, testResults)
-      listener.testResult(summary)
-    }
-  }
+  ): Unit =
+    MbtTestResultAdapter
+      .testSuiteSummaries(
+        testSuites.getSuites.asScala.toList,
+        knownTestCaseNames,
+        passed,
+        duration,
+      )
+      .foreach(listener.testResult)
 }
 
 object MbtTestResultAdapter {
@@ -135,6 +100,64 @@ object MbtTestResultAdapter {
   def apply(
       inner: Debuggee,
       testSuites: ScalaTestSuites,
+      knownTestCaseNames: String => List[String] = _ => Nil,
   )(implicit ec: ExecutionContext): MbtTestResultAdapter =
-    new MbtTestResultAdapter(inner, testSuites)
+    new MbtTestResultAdapter(inner, testSuites, knownTestCaseNames)
+
+  /**
+   * Builds one [[TestSuiteSummary]] per requested suite. Every
+   * name we can attribute to this run gets the same pass/fail verdict.
+   */
+  def testSuiteSummaries(
+      suites: List[ScalaTestSuiteSelection],
+      knownTestCaseNames: String => List[String],
+      passed: Boolean,
+      duration: Long,
+  ): List[TestSuiteSummary] =
+    suites.map { suite =>
+      val className = suite.getClassName
+      val selectedTests = suite.getTests.asScala.toList
+      val testNames =
+        if (selectedTests.nonEmpty) selectedTests
+        else
+          // If the whole suit is selected, we still need to send data about all test cases
+          // added to the client via `AddTestCases` for the results to show up correctly
+          knownTestCaseNames(className)
+
+      val testResults: java.util.List[SingleTestSummary] =
+        if (testNames.isEmpty) {
+          java.util.Collections.singletonList(
+            singleTestResult(className, passed, "Test suite failed", duration)
+          )
+        } else {
+          testNames
+            .map(testName =>
+              singleTestResult(
+                s"$className.$testName",
+                passed,
+                "Test failed",
+                duration,
+              )
+            )
+            .asJava
+        }
+
+      TestSuiteSummary(className, duration, testResults)
+    }
+
+  private def singleTestResult(
+      testName: String,
+      passed: Boolean,
+      message: String,
+      duration: Long,
+  ): SingleTestSummary =
+    if (passed) SingleTestResult.Passed(testName, duration)
+    else
+      SingleTestResult.Failed(
+        testName,
+        duration,
+        message,
+        null,
+        null,
+      )
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTestResultAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTestResultAdapter.scala
@@ -6,7 +6,9 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.testProvider.TestSuitesProvider
 
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.bsp4j.ScalaTestSuiteSelection
 import ch.epfl.scala.bsp4j.ScalaTestSuites
 import ch.epfl.scala.debugadapter.CancelableFuture
@@ -34,7 +36,8 @@ import ch.epfl.scala.debugadapter.testing.TestSuiteSummary
 class MbtTestResultAdapter(
     inner: Debuggee,
     testSuites: ScalaTestSuites,
-    knownTestCaseNames: String => List[String] = _ => Nil,
+    testProvider: TestSuitesProvider,
+    targetId: BuildTargetIdentifier,
 )(implicit ec: ExecutionContext)
     extends Debuggee {
 
@@ -85,7 +88,8 @@ class MbtTestResultAdapter(
     MbtTestResultAdapter
       .testSuiteSummaries(
         testSuites.getSuites.asScala.toList,
-        knownTestCaseNames,
+        testProvider,
+        targetId,
         passed,
         duration,
       )
@@ -100,9 +104,10 @@ object MbtTestResultAdapter {
   def apply(
       inner: Debuggee,
       testSuites: ScalaTestSuites,
-      knownTestCaseNames: String => List[String] = _ => Nil,
+      testProvider: TestSuitesProvider,
+      targetId: BuildTargetIdentifier,
   )(implicit ec: ExecutionContext): MbtTestResultAdapter =
-    new MbtTestResultAdapter(inner, testSuites, knownTestCaseNames)
+    new MbtTestResultAdapter(inner, testSuites, testProvider, targetId)
 
   /**
    * Builds one [[TestSuiteSummary]] per requested suite. Every
@@ -110,7 +115,8 @@ object MbtTestResultAdapter {
    */
   def testSuiteSummaries(
       suites: List[ScalaTestSuiteSelection],
-      knownTestCaseNames: String => List[String],
+      testProvider: TestSuitesProvider,
+      targetId: BuildTargetIdentifier,
       passed: Boolean,
       duration: Long,
   ): List[TestSuiteSummary] =
@@ -122,7 +128,7 @@ object MbtTestResultAdapter {
         else
           // If the whole suit is selected, we still need to send data about all test cases
           // added to the client via `AddTestCases` for the results to show up correctly
-          knownTestCaseNames(className)
+          testProvider.knownTestCaseNames(targetId, className)
 
       val testResults: java.util.List[SingleTestSummary] =
         if (testNames.isEmpty) {

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
@@ -53,16 +53,19 @@ class McpTestRunner(
         if (debugProvider.usesBuildTargetTest(id)) {
           // Same path as non-debug editor runs for MBT: BSP buildTarget/test.
           Right {
-            jvmTestEnv.flatMap { env =>
-              val testSuites = createTestSuites(testSelection, env)
-              debugProvider.runBuildTargetTest(
-                id,
-                testSuites,
-                cancelPromise,
-                verbose,
-              ) match {
-                case Right(future) => future.map(output => AnsiFilter()(output))
-                case Left(error) => Future.successful(error)
+            debugProvider.confirmMbtTestClassCandidates(path, id).flatMap { _ =>
+              jvmTestEnv.flatMap { env =>
+                val testSuites = createTestSuites(testSelection, env)
+                debugProvider.runBuildTargetTest(
+                  id,
+                  testSuites,
+                  cancelPromise,
+                  verbose,
+                ) match {
+                  case Right(future) =>
+                    future.map(output => AnsiFilter()(output))
+                  case Left(error) => Future.successful(error)
+                }
               }
             }
           }

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesIndex.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesIndex.scala
@@ -75,6 +75,29 @@ private[testProvider] final class TestSuitesIndex {
     ]()
   private val fileToMetadata = TrieMap[AbsolutePath, TestFileMetadata]()
 
+  /**
+   * Last known test case names per suite,
+   * as reported to the client via `AddTestCases`.
+   */
+  private val cachedTestCaseNames =
+    TrieMap[(BuildTarget, FullyQualifiedName), List[String]]()
+
+  def putTestCases(
+      buildTarget: BuildTarget,
+      fullyQualifiedName: FullyQualifiedName,
+      testCases: List[TestCaseEntry],
+  ): Unit =
+    cachedTestCaseNames.put(
+      (buildTarget, fullyQualifiedName),
+      testCases.map(_.name),
+    )
+
+  def getTestCaseNames(
+      buildTarget: BuildTarget,
+      fullyQualifiedName: FullyQualifiedName,
+  ): List[String] =
+    cachedTestCaseNames.getOrElse((buildTarget, fullyQualifiedName), Nil)
+
   def allSuites: Vector[(BuildTarget, Iterable[TestEntry])] =
     cachedTestSuites.mapValues(_.values).toVector
 
@@ -139,6 +162,7 @@ private[testProvider] final class TestSuitesIndex {
       suites <- cachedTestSuites.get(buildTarget)
       entry <- suites.remove(suiteName)
     } yield {
+      cachedTestCaseNames.remove((buildTarget, suiteName))
       fileToMetadata.get(entry.path).foreach { metadata =>
         val filtered =
           metadata.entries

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -343,16 +343,18 @@ final class TestSuitesProvider(
     val buildTargetUpdates =
       for {
         metadata <- index.getMetadata(path).toList
-        events = {
-          val suites = metadata.entries.map(_.suiteDetails).distinct
-          val canResolve = suites.exists(suite =>
-            TestFrameworkUtils.canResolveTests(suite.framework)
-          )
-          if (canResolve) getTestCasesForSuites(path, suites, textDocument)
-          else Seq.empty
-        }
-        buildTarget <- metadata.entries.map(_.buildTarget).distinct
+        (buildTarget, entriesForTarget) <- metadata.entries
+          .groupBy(_.buildTarget)
+          .toList
       } yield {
+        val suites = entriesForTarget.map(_.suiteDetails).distinct
+        val canResolve = suites.exists(suite =>
+          TestFrameworkUtils.canResolveTests(suite.framework)
+        )
+        val events =
+          if (canResolve)
+            getTestCasesForSuites(path, buildTarget, suites, textDocument)
+          else Seq.empty
         buildTargetUpdate(buildTarget, events)
       }
     buildTargetUpdates
@@ -368,6 +370,7 @@ final class TestSuitesProvider(
    */
   private def getTestCasesForSuites(
       path: AbsolutePath,
+      buildTarget: BuildTarget,
       suites: Seq[TestSuiteDetails],
       doc: Option[TextDocument],
   ): Seq[AddTestCases] = {
@@ -423,6 +426,11 @@ final class TestSuitesProvider(
 
           if (testCases.nonEmpty) {
             index.updateFileMetadata(path, semanticdb.md5)
+            index.putTestCases(
+              buildTarget,
+              suite.fullyQualifiedName,
+              testCases.toList,
+            )
             val event = AddTestCases(
               fullyQualifiedClassName = suite.fullyQualifiedName.value,
               className = suite.className.value,
@@ -470,7 +478,12 @@ final class TestSuitesProvider(
           val canResolve =
             TestFrameworkUtils.canResolveTests(entry.suiteDetails.framework)
           if (canResolve && buffers.contains(entry.path))
-            getTestCasesForSuites(entry.path, Vector(entry.suiteDetails), None)
+            getTestCasesForSuites(
+              entry.path,
+              entry.buildTarget,
+              Vector(entry.suiteDetails),
+              None,
+            )
           else Nil
         }
       }.toMap
@@ -652,5 +665,16 @@ final class TestSuitesProvider(
   ): Option[TestEntry] = {
     index.get(target, FullyQualifiedName(className))
   }
+
+  def knownTestCaseNames(
+      id: b.BuildTargetIdentifier,
+      className: String,
+  ): List[String] =
+    buildTargets
+      .info(id)
+      .map(target =>
+        index.getTestCaseNames(target, FullyQualifiedName(className))
+      )
+      .getOrElse(Nil)
 
 }

--- a/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
@@ -14,6 +14,8 @@ import scala.meta.internal.metals.DebugUnresolvedTestClassParams
 import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaTestSuiteSelection
+import scala.meta.internal.metals.ScalaTestSuites
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.debug.DebugWorkspaceLayout
 import scala.meta.internal.metals.mbt.MbtBuildServer
@@ -22,6 +24,7 @@ import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
 import ch.epfl.scala.bsp4j.ScalaMainClass
+import ch.epfl.scala.bsp4j.TestParamsDataKind
 import tests.BaseDapSuite
 import tests.BazelBuildLayout
 import tests.MbtTestInitializer
@@ -121,6 +124,53 @@ class BazelDapMbtLspSuite
       _ <- debugger.shutdown
       output <- debugger.allOutput
     } yield assertContains(output, "OK (1 test)")
+  }
+
+  test("bazel-mbt-scalatest-test-selection", maxRetry = 3) {
+    client.selectedServer = Messages.ChooseBuildServer.mbt
+    cleanWorkspace()
+
+    for {
+      _ <- initialize(
+        BazelBuildLayout(
+          scalatestSelectionLayout,
+          V.scala213,
+          bazelVersion,
+          List("org.scalatest:scalatest_2.13:3.2.19"),
+          includeScalatest = true,
+        ),
+        runAdditionalCommands = pinMaven,
+      )
+      _ <- server.headServer.connectionProvider.buildServerPromise.future
+      _ <- server.didOpen("test/FooSpec.scala")
+      _ <- awaitMbtTestClassDiscovery("test/FooSpec.scala")
+      // Confirms the candidate test class via semanticdb, which populates
+      // its test framework, that we need to know to run `bazel` with the right args
+      _ <- server.discoverTestSuites(
+        List("test/FooSpec.scala"),
+        uri = Some(server.toPath("test/FooSpec.scala").toURI.toString),
+      )
+      debugger <- server.startDebugging(
+        "//test",
+        TestParamsDataKind.SCALA_TEST_SUITES_SELECTION,
+        ScalaTestSuites(
+          List(
+            ScalaTestSuiteSelection("test.FooSpec", List("foo test").asJava)
+          ).asJava,
+          Nil.asJava,
+          Nil.asJava,
+          Nil.asJava,
+        ),
+      )
+      _ <- debugger.initialize
+      _ <- debugger.launch
+      _ <- debugger.configurationDone
+      _ <- debugger.shutdown
+      output <- debugger.allOutput
+    } yield {
+      assertContains(output, "foo test")
+      assert(!output.contains("bar test"), "unselected test must not have run")
+    }
   }
 
   test("bazel-mbt-test-breakpoint") {
@@ -334,6 +384,31 @@ class BazelDapMbtLspSuite
        |  public void testAddition() {
        |    assertEquals(4, 2 + 2);
        |  }
+       |}
+       |""".stripMargin
+
+  private def scalatestSelectionLayout: String =
+    """|/.bazelproject
+       |targets:
+       |    //...
+       |
+       |/test/BUILD
+       |load("@rules_scala//scala:scala.bzl", "scala_test")
+       |
+       |scala_test(
+       |    name = "FooSpec",
+       |    srcs = ["FooSpec.scala"],
+       |    deps = ["@maven//:org_scalatest_scalatest_2_13"],
+       |)
+       |
+       |/test/FooSpec.scala
+       |package test
+       |
+       |import org.scalatest.funsuite.AnyFunSuite
+       |
+       |class FooSpec extends AnyFunSuite {
+       |  test("foo test") { assert(true) }
+       |  test("bar test") { fail("bar test must not run") }
        |}
        |""".stripMargin
 

--- a/tests/unit/src/main/scala/tests/BuildServerLayout.scala
+++ b/tests/unit/src/main/scala/tests/BuildServerLayout.scala
@@ -135,6 +135,7 @@ object BazelBuildLayout extends BuildToolLayout {
       bazelVersion: String,
       mavenDeps: List[String],
       mavenHubName: Option[String] = None,
+      includeScalatest: Boolean = false,
   ): String =
     bazelLayout(
       sourceLayout,
@@ -142,6 +143,7 @@ object BazelBuildLayout extends BuildToolLayout {
       bazelVersion,
       mavenDeps,
       mavenHubName,
+      includeScalatest,
     )
 
   private def bazelLayout(
@@ -150,13 +152,14 @@ object BazelBuildLayout extends BuildToolLayout {
       bazelVersion: String,
       mavenDeps: List[String],
       mavenHubName: Option[String],
+      includeScalatest: Boolean,
   ): String =
     s"""|/.metals/txt.txt
         |initialize the project for metals
         |/.bazelversion
         |$bazelVersion
         |/MODULE.bazel
-        |${moduleFileLayout(scalaVersion, mavenDeps, mavenHubName)}
+        |${moduleFileLayout(scalaVersion, mavenDeps, mavenHubName, includeScalatest)}
         |/BUILD
         |
         |/WORKSPACE
@@ -168,6 +171,7 @@ object BazelBuildLayout extends BuildToolLayout {
       scalaVersion: String,
       mavenDeps: List[String] = Nil,
       mavenHubName: Option[String] = None,
+      includeScalatest: Boolean = false,
   ): String = {
     val hubName = mavenHubName.getOrElse("maven")
     val nameLine = mavenHubName.fold("")(n => s"""    name = "$n",\n""")
@@ -189,7 +193,7 @@ object BazelBuildLayout extends BuildToolLayout {
             |use_repo(maven, "$hubName")
             |""".stripMargin
       }
-    s"""|${scalaModulePrefix(scalaVersion)}
+    s"""|${scalaModulePrefix(scalaVersion, includeScalatest)}
         |
         |$mavenSection""".stripMargin
   }
@@ -249,7 +253,10 @@ object BazelBuildLayout extends BuildToolLayout {
         |""".stripMargin
   }
 
-  private def scalaModulePrefix(scalaVersion: String): String =
+  private def scalaModulePrefix(
+      scalaVersion: String,
+      includeScalatest: Boolean = false,
+  ): String =
     s"""|bazel_dep(name = "rules_scala", version = "7.2.4")
         |
         |scala_config = use_extension("@rules_scala//scala/extensions:config.bzl", "scala_config")
@@ -258,6 +265,7 @@ object BazelBuildLayout extends BuildToolLayout {
         |scala_deps = use_extension("@rules_scala//scala/extensions:deps.bzl", "scala_deps")
         |scala_deps.settings(fetch_sources = True)
         |scala_deps.scala()
+        |${if (includeScalatest) "scala_deps.scalatest()" else ""}
         |use_repo(scala_deps, "rules_scala_toolchains")
         |
         |register_toolchains("@rules_scala_toolchains//...:all")""".stripMargin


### PR DESCRIPTION
Two issues solved in individual commits:
1. For bazel's "scala_test", we would pass --test_filter= which would work for Suites, but would crash with ClassNotFoundException for anything else. We now special-case that and pass to ScalaTest directly (via --test_arg). Since we need to know which framework is used when we run the test, I also added confirmMbtTestClassCandidates (which resolves the framework) before the test is run.
2. The test results weren't reported correctly for Suites - looks like the client expected the individual test cases to be reported there instead, which we now do report. The bad part is that now, all of the test cases show up as failed if one fails, which I find distracting, but don't have a simple solution for. 
Also, since I noticed how we also measure test duration ourselves when debugging tests (in MbtTestResultAdapter), I also added something like this when running tests, for consistency.

I'm also stuck on a third issue with some test cases not being discovered, but I'll probably submit that one separately once I find the cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved MBT test selection for ScalaTest, including accurate individual test execution with Bazel.
  * Test results now include known test cases when entire suites are selected.
  * Added test-class confirmation before running build-target tests.
  * Improved test discovery and reporting across build targets.
* **Bug Fixes**
  * Corrected ScalaTest result reporting and preserved suite-level failures when details are unavailable.
* **Tests**
  * Added coverage for selective ScalaTest execution in Bazel projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->