### PR TITLE
A monad for representing a volatile in-memory value

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/utils/Vol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/Vol.scala
@@ -1,0 +1,65 @@
+package scala.meta.internal.metals.utils
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * This monad represents a volatile value that may change in real time (e.g. updated by another thread).
+ *
+ * The evaluation happens when the method snapshot() is called.
+ * However, within a single for-comprehension the value of each Vol is evaluated only once.
+ * As a result, a for-comprehension over Vol represents a consistent snapshot of some volatile set of variables,
+ * which has existed at some recent point in time.
+ *
+ * Instances of this trait are safe to pass across different threads, but its exposed methods are <b>not</b> thread safe.
+ *
+ * Unlike scala.concurrent.Future, the evaluation happens synchronously in the same thread that invokes it.
+ * Unlike scala.concurrent.Promise or a lazy val, the value may change more than once.
+ * Unlike cats.effect.IO, the evaluation is assumed to be fast and non-blocking.
+ * Unlike geny.Generator, the evaluation happens on demand.
+ */
+trait Vol[+T <: Any] {
+
+  protected def eval(): T
+
+  def snapshot(): T = {
+    val previousContext = Vol.context.get()
+    val cached = previousContext.get(this)
+    cached match {
+      case Some(x) => x.asInstanceOf[T]
+      case None =>
+        val value = eval()
+        val kvp: (Vol[Any], Any) = (this, value)
+        Vol.context.set(previousContext + kvp)
+        value
+    }
+  }
+
+  def map[U](f: T => U): Vol[U] = Vol.Mapped(this, f)
+
+  def flatMap[U](f: T => Vol[U]): Vol[U] = Vol.FlatMapped(this, f)
+
+}
+
+object Vol {
+
+  private val context: ThreadLocal[Map[Vol[Any], Any]] =
+    ThreadLocal.withInitial(() => Map.empty)
+
+  case class AtomicRef[T](value: AtomicReference[T]) extends Vol[T] {
+    override protected def eval(): T = value.get()
+  }
+
+  case class Function[T](f: () => T) extends Vol[T] {
+    override protected def eval(): T = f()
+  }
+
+  private case class Mapped[T, U](source: Vol[T], f: T => U) extends Vol[U] {
+    override protected def eval(): U = f(source.snapshot())
+  }
+
+  private case class FlatMapped[T, U](source: Vol[T], f: T => Vol[U])
+      extends Vol[U] {
+
+    override protected def eval(): U = f(source.snapshot()).eval()
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/Vol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/Vol.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals.utils
 
+import java.util.IdentityHashMap
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -22,15 +23,17 @@ trait Vol[+T <: Any] {
   protected def eval(): T
 
   def snapshot(): T = {
-    val previousContext = Vol.context.get()
-    val cached = previousContext.get(this)
-    cached match {
-      case Some(x) => x.asInstanceOf[T]
-      case None =>
-        val value = eval()
-        val kvp: (Vol[Any], Any) = (this, value)
-        Vol.context.set(previousContext + kvp)
-        value
+    val existing = Vol.context.get()
+    if (existing eq null) {
+      Vol.context.set(new IdentityHashMap[Vol[Any], Any]())
+      try snapshot()
+      finally Vol.context.remove()
+    } else if (existing.containsKey(this)) {
+      existing.get(this).asInstanceOf[T]
+    } else {
+      val value = eval()
+      existing.put(this, value)
+      value
     }
   }
 
@@ -42,8 +45,8 @@ trait Vol[+T <: Any] {
 
 object Vol {
 
-  private val context: ThreadLocal[Map[Vol[Any], Any]] =
-    ThreadLocal.withInitial(() => Map.empty)
+  private val context: ThreadLocal[IdentityHashMap[Vol[Any], Any]] =
+    new ThreadLocal()
 
   case class AtomicRef[T](value: AtomicReference[T]) extends Vol[T] {
     override protected def eval(): T = value.get()
@@ -60,6 +63,6 @@ object Vol {
   private case class FlatMapped[T, U](source: Vol[T], f: T => Vol[U])
       extends Vol[U] {
 
-    override protected def eval(): U = f(source.snapshot()).eval()
+    override protected def eval(): U = f(source.snapshot()).snapshot()
   }
 }

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/utils/VolSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/utils/VolSuite.scala
@@ -1,0 +1,74 @@
+package scala.meta.internal.metals.utils
+import java.util.concurrent.atomic.AtomicInteger
+import munit.FunSuite
+
+class VolSuite extends FunSuite {
+
+  import VolSuite._
+
+  test("flatmap-should-evaluate-repetitions-just-once") {
+    val x = new ReferenceCountingVol()
+    val y = for {
+      first <- x
+      second <- x
+      third <- x
+    } yield (first, second, third)
+    assertEquals(y.snapshot(), (1, 1, 1))
+  }
+
+  test("separate-flatmap-should-evaluate-from-scratch") {
+    val x = new ReferenceCountingVol()
+    val y = for {
+      first <- x
+      second <- x
+    } yield (first, second)
+    assertEquals(y.snapshot(), (1, 1))
+
+    val z = for {
+      first <- x
+      second <- x
+    } yield (first, second)
+    assertEquals(z.snapshot(), (2, 2))
+  }
+
+  test("separate-flatmap-should-evaluate-from-scratch-xxx") {
+    val y = for {
+      first <- Stopwatch
+      second <- Stopwatch
+    } yield (first, second)
+
+    val z = for {
+      first <- Stopwatch
+      second <- Stopwatch
+    } yield (first, second)
+    assertNotEquals(y.snapshot(), z.snapshot())
+  }
+
+  test("evaluation-in-the-same-thread-should-yield-the-same-value") {
+    val snapshot1 = Stopwatch.snapshot()
+    Thread.sleep(100)
+    val snapshot2 = Stopwatch.snapshot()
+    assertEquals(snapshot1, snapshot2)
+  }
+
+  test("evaluation-in-different-threads-should-allow-diferent-values") {
+    var snapshot1: Long = -1L
+    var snapshot2: Long = -1L
+    Thread.ofVirtual().start { () => snapshot1 = Stopwatch.snapshot() }
+    Thread.ofVirtual().start { () => snapshot2 = Stopwatch.snapshot() }
+    Thread.sleep(1000)
+
+    assertNotEquals(snapshot1 - snapshot2, 0L)
+  }
+
+}
+
+object VolSuite {
+  private class ReferenceCountingVol extends Vol[Int] {
+    val value = new AtomicInteger(0)
+    override def eval(): Int = value.incrementAndGet()
+
+  }
+
+  private val Stopwatch = Vol.Function[Long](() => System.nanoTime())
+}

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/utils/VolSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/utils/VolSuite.scala
@@ -45,6 +45,13 @@ class VolSuite extends FunSuite {
     assertNotEquals(y.snapshot(), z.snapshot())
   }
 
+  test("evaluation-in-the-same-thread-should-allow-different-values") {
+    val snapshot1 = Stopwatch.snapshot()
+    Thread.sleep(100)
+    val snapshot2 = Stopwatch.snapshot()
+    assertNotEquals(snapshot1, snapshot2)
+  }
+
   test("evaluation-in-different-threads-should-allow-diferent-values") {
     var snapshot1: Long = -1L
     var snapshot2: Long = -1L
@@ -55,9 +62,6 @@ class VolSuite extends FunSuite {
     assertNotEquals(snapshot1 - snapshot2, 0L)
   }
 
-  // Exposes: ThreadLocal cache is never cleared, so a top-level Vol is
-  // frozen forever on a thread after the first snapshot() — contradicting
-  // "the value may change more than once".
   test("atomic-ref-should-see-updates-across-separate-snapshots") {
     val ref = new AtomicReference(1)
     val vol = Vol.AtomicRef(ref)
@@ -66,9 +70,6 @@ class VolSuite extends FunSuite {
     assertEquals(vol.snapshot(), 2)
   }
 
-  // Exposes: FlatMapped.eval calls result.eval() instead of result.snapshot(),
-  // so a leaf Vol returned from flatMap is not entered into the snapshot cache
-  // and is re-evaluated when read again in the same comprehension.
   test("flatmap-to-leaf-vol-should-be-cached-in-enclosing-comprehension") {
     val b = new ReferenceCountingVol()
     val a = Vol.Function(() => 0)
@@ -79,8 +80,6 @@ class VolSuite extends FunSuite {
     assertEquals(result.snapshot(), (1, 1))
   }
 
-  // Exposes: Function/AtomicRef are case classes, so structurally equal Vols
-  // share a single cache entry even when they are distinct instances.
   test("distinct-function-vols-sharing-lambda-should-not-share-cache") {
     val counter = new AtomicInteger(0)
     val f = () => counter.incrementAndGet()

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/utils/VolSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/utils/VolSuite.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals.utils
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import munit.FunSuite
 
 class VolSuite extends FunSuite {
@@ -59,6 +60,41 @@ class VolSuite extends FunSuite {
     Thread.sleep(1000)
 
     assertNotEquals(snapshot1 - snapshot2, 0L)
+  }
+
+  // Exposes: ThreadLocal cache is never cleared, so a top-level Vol is
+  // frozen forever on a thread after the first snapshot() — contradicting
+  // "the value may change more than once".
+  test("atomic-ref-should-see-updates-across-separate-snapshots") {
+    val ref = new AtomicReference(1)
+    val vol = Vol.AtomicRef(ref)
+    assertEquals(vol.snapshot(), 1)
+    ref.set(2)
+    assertEquals(vol.snapshot(), 2)
+  }
+
+  // Exposes: FlatMapped.eval calls result.eval() instead of result.snapshot(),
+  // so a leaf Vol returned from flatMap is not entered into the snapshot cache
+  // and is re-evaluated when read again in the same comprehension.
+  test("flatmap-to-leaf-vol-should-be-cached-in-enclosing-comprehension") {
+    val b = new ReferenceCountingVol()
+    val a = Vol.Function(() => 0)
+    val result = for {
+      x <- a.flatMap(_ => b)
+      y <- b
+    } yield (x, y)
+    assertEquals(result.snapshot(), (1, 1))
+  }
+
+  // Exposes: Function/AtomicRef are case classes, so structurally equal Vols
+  // share a single cache entry even when they are distinct instances.
+  test("distinct-function-vols-sharing-lambda-should-not-share-cache") {
+    val counter = new AtomicInteger(0)
+    val f = () => counter.incrementAndGet()
+    val v1 = Vol.Function(f)
+    val v2 = Vol.Function(f)
+    assertEquals(v1.snapshot(), 1)
+    assertEquals(v2.snapshot(), 2)
   }
 
 }

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/utils/VolSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/utils/VolSuite.scala
@@ -45,13 +45,6 @@ class VolSuite extends FunSuite {
     assertNotEquals(y.snapshot(), z.snapshot())
   }
 
-  test("evaluation-in-the-same-thread-should-yield-the-same-value") {
-    val snapshot1 = Stopwatch.snapshot()
-    Thread.sleep(100)
-    val snapshot2 = Stopwatch.snapshot()
-    assertEquals(snapshot1, snapshot2)
-  }
-
   test("evaluation-in-different-threads-should-allow-diferent-values") {
     var snapshot1: Long = -1L
     var snapshot2: Long = -1L


### PR DESCRIPTION
This is related to #4788.