### PR TITLE
Prioritize target classpath over Turbine headers

### DIFF
--- a/jsemanticdb/src/main/protobuf/mbt.proto
+++ b/jsemanticdb/src/main/protobuf/mbt.proto
@@ -36,6 +36,7 @@ message IndexedDocument {
     V7 = 7;
     V8 = 8;
     V9 = 9;
+    V10 = 10;
   }
 
   enum Source {

--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -680,32 +680,11 @@ class ConnectionProvider(
         }
         _ = compilers.cancel()
         buildChange <- index(check, progress)
-        // When testing we need to make sure the classpath is refreshed after mbt.json is generated
-        _ <- {
-          if (MetalsServerConfig.isTesting)
-            refreshMbtTurbineClasspath(session).withInterrupt
-          else
-            Future {
-              refreshMbtTurbineClasspath(session)
-            }.withInterrupt
-        }
       } yield {
         syncStatusReporter.importFinished(focusedDocument.map(_.toURI.toString))
         buildChange
       }
     }
-
-    private def refreshMbtTurbineClasspath(
-        session: BspSession
-    ): Future[Unit] =
-      if (
-        MbtBuildServer.isMbtServer(session.main.name) &&
-        userConfig.javaSymbolLoader.isTurbineClasspath
-      ) {
-        mbtSymbolSearch.scheduleRecompileTurbineClasspath()
-      } else {
-        Future.unit
-      }
 
     private def saveProjectReferencesInfo(
         bspBuilds: List[BspSession.BspBuild]

--- a/metals/src/main/scala/scala/meta/internal/metals/IndexProviders.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/IndexProviders.scala
@@ -28,6 +28,7 @@ trait IndexProviders {
   def workDoneProgress: WorkDoneProgress
   def timerProvider: TimerProvider
   def indexingPromise: Promise[Unit]
+  def initialBuildTargetsReady: Promise[Unit]
   def buildData(): Seq[Indexer.BuildTool]
   def clientConfig: ClientConfiguration
   def definitionIndex: OnDemandSymbolIndex

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -160,10 +160,6 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
           data.addDependencyModules(build.asBspModules)
         }
 
-        // Fallback compilers can possibly use the jars from the build target data, so we trigger a restart
-        // here to pick up the newly indexed jar data.
-        indexProviders.restartFallbackCompilers()
-
         // For "wrapped sources", we create dedicated TargetData.MappedSource instances,
         // able to convert back and forth positions from the user-facing file to
         // the compiler-facing actual underlying source.
@@ -184,14 +180,6 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
           data.addSourceItem(source, item.getTarget)
         }
       }
-    timerProvider.timedThunk(
-      "post update build targets stuff",
-      clientConfig.initialConfig.statistics.isIndex,
-      metricName = Some("index_workspace_post_update_build_targets"),
-    ) {
-      progress.message = "analyzing build targets"
-      check()
-    }
     timerProvider.timedThunk(
       "started file watcher",
       clientConfig.initialConfig.statistics.isIndex,
@@ -216,8 +204,36 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
         metricName = Some("index_workspace_sources"),
       ) {
         progress.message = "indexing sources"
-        indexWorkspaceSources(buildTool.data, progress)
+        indexWorkspaceSources(
+          buildTool.data,
+          progress,
+          resetCompilers = false,
+        )
       }
+    indexProviders.restartFallbackCompilers()
+    val buildTargetCompilersReady =
+      if (
+        bspSession.exists(session =>
+          MbtBuildServer.isMbtServer(session.main.name)
+        ) && userConfig.javaSymbolLoader.isTurbineClasspath
+      ) {
+        mbtSymbolSearch
+          .scheduleRecompileTurbineClasspath()
+          .flatMap(_ => resetPresentationCompilers())
+      } else {
+        resetPresentationCompilers()
+      }
+    buildTargetCompilersReady.onComplete(_ =>
+      initialBuildTargetsReady.trySuccess(())
+    )
+    timerProvider.timedThunk(
+      "post update build targets stuff",
+      clientConfig.initialConfig.statistics.isIndex,
+      metricName = Some("index_workspace_post_update_build_targets"),
+    ) {
+      progress.message = "analyzing build targets"
+      check()
+    }
     timerProvider.timedThunk(
       "indexed library classpath",
       clientConfig.initialConfig.statistics.isIndex,
@@ -452,11 +468,17 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
   def indexWorkspaceSources(
       data: Seq[TargetData],
       progress: TaskProgress = TaskProgress.empty,
+      resetCompilers: Boolean = true,
   ): Unit = {
     for (data0 <- data.iterator)
-      indexWorkspaceSources(data0, progress)
+      indexWorkspaceSources(data0, progress, resetCompilers = false)
+    if (resetCompilers) resetPresentationCompilers()
   }
-  def indexWorkspaceSources(data: TargetData, progress: TaskProgress): Unit = {
+  def indexWorkspaceSources(
+      data: TargetData,
+      progress: TaskProgress,
+      resetCompilers: Boolean,
+  ): Unit = {
     case class SourceToIndex(
         source: AbsolutePath,
         sourceItem: AbsolutePath,
@@ -477,7 +499,7 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
     // at this point we have all sources for each build target, so presentation compilers should
     // restart to pick up the correct sourcepath. We don't need to wait for the actual
     // indexing to finish since they don't impact how the presentation compiler works
-    resetPresentationCompilers()
+    if (resetCompilers) resetPresentationCompilers()
 
     val threadPool = new ForkJoinPool(
       Runtime.getRuntime().availableProcessors() match {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1044,10 +1044,7 @@ abstract class MetalsLspService(
       userConfig.javaSymbolLoader.isTurbineClasspath
     ) {
       buildServerPromise.future.flatMap { _ =>
-        if (
-          bspSession
-            .exists(session => MbtBuildServer.isMbtServer(session.main.name))
-        ) initialBuildTargetsReady.future
+        if (bspSession.isDefined) initialBuildTargetsReady.future
         else Future.unit
       }
     } else Future.unit

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -263,6 +263,7 @@ abstract class MetalsLspService(
     clientConfig.initialConfig.enableBestEffort,
   )
   var indexingPromise: Promise[Unit] = Promise[Unit]()
+  val initialBuildTargetsReady: Promise[Unit] = Promise[Unit]()
   def workspaceSymbolIndexingPromise: Promise[Unit] = {
     if (userConfig.workspaceSymbolProvider.isMBT) {
       // Don't block on BSP indexing when mbt is enabled.
@@ -1010,6 +1011,7 @@ abstract class MetalsLspService(
         Future.successful(DidFocusResult.NoBuildTarget)
       } else {
         for {
+          _ <- initialBuildTargetsReady.future
           reportedDiagnostics <- compilers.didFocus(path)
           _ = diagnostics.publishDiagnosticsNotAdjusted(
             path,
@@ -1164,15 +1166,15 @@ abstract class MetalsLspService(
       isIncludedPath: AbsolutePath => Boolean
   ): Future[Unit] = {
     // rerun diagnostics for all open documents
-    val futures =
-      buffers.open.filter(isIncludedPath).map { path =>
+    buffers.open.filter(isIncludedPath).foldLeft(Future.unit) {
+      case (previous, path) =>
         for {
+          _ <- previous
           reportedDiagnostics <- compilers.didFocus(path)
           _ = diagnostics
             .publishDiagnosticsNotAdjusted(path, reportedDiagnostics)
         } yield ()
-      }
-    Future.sequence(futures).map(_ => ())
+    }
   }
 
   def resetPresentationCompilers(): Future[Unit] = {
@@ -1182,7 +1184,9 @@ abstract class MetalsLspService(
 
   def restartFallbackCompilers(): Future[Unit] = {
     compilers.restartFallbackCompilers()
-    refreshDiagnostics(path => buildTargets.inverseSources(path).isEmpty)
+    initialBuildTargetsReady.future.flatMap(_ =>
+      refreshDiagnostics(path => buildTargets.inverseSources(path).isEmpty)
+    )
   }
 
   protected def didCompileTarget(report: CompileReport): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -976,9 +976,7 @@ abstract class MetalsLspService(
                 compilations.compileFile(path, assumeDidNotChange = true),
                 compilers.load(List(path)),
                 parser,
-                buildTargetClassesReady.flatMap(_ =>
-                  testProvider.didOpen(path)
-                ),
+                buildTargetClassesReady.flatMap(_ => testProvider.didOpen(path)),
               )
             )
             .ignoreValue

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1011,7 +1011,7 @@ abstract class MetalsLspService(
         Future.successful(DidFocusResult.NoBuildTarget)
       } else {
         for {
-          _ <- initialBuildTargetsReady.future
+          _ <- initialBuildTargetsReadyForDiagnostics
           reportedDiagnostics <- compilers.didFocus(path)
           _ = diagnostics.publishDiagnosticsNotAdjusted(
             path,
@@ -1034,6 +1034,21 @@ abstract class MetalsLspService(
       !path.isWorkspaceSource(folder) ||
       buildTargets.isDependencySource(path) ||
       buildTargets.checkIfGeneratedSource(path.toNIO)
+
+  private def initialBuildTargetsReadyForDiagnostics: Future[Unit] =
+    if (
+      userConfig.workspaceSymbolProvider.isMBT &&
+      userConfig.javaSymbolLoader.isTurbineClasspath
+    ) {
+      buildServerPromise.future.flatMap { _ =>
+        if (
+          bspSession.exists(session =>
+            MbtBuildServer.isMbtServer(session.main.name)
+          )
+        ) initialBuildTargetsReady.future
+        else Future.unit
+      }
+    } else Future.unit
 
   def sync(
       uri: String,
@@ -1184,7 +1199,7 @@ abstract class MetalsLspService(
 
   def restartFallbackCompilers(): Future[Unit] = {
     compilers.restartFallbackCompilers()
-    initialBuildTargetsReady.future.flatMap(_ =>
+    initialBuildTargetsReadyForDiagnostics.flatMap(_ =>
       refreshDiagnostics(path => buildTargets.inverseSources(path).isEmpty)
     )
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -980,7 +980,9 @@ abstract class MetalsLspService(
             )
             .ignoreValue
         }
-        maybeImportFileAndLoad(path, load)
+        initialBuildTargetsReadyForDiagnostics.flatMap(_ =>
+          maybeImportFileAndLoad(path, load)
+        )
       }.asJava
     }
   }
@@ -1042,9 +1044,8 @@ abstract class MetalsLspService(
     ) {
       buildServerPromise.future.flatMap { _ =>
         if (
-          bspSession.exists(session =>
-            MbtBuildServer.isMbtServer(session.main.name)
-          )
+          bspSession
+            .exists(session => MbtBuildServer.isMbtServer(session.main.name))
         ) initialBuildTargetsReady.future
         else Future.unit
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -929,14 +929,15 @@ abstract class MetalsLspService(
     focusedDocumentBuildTarget.set(
       buildTargets.inverseSources(path).getOrElse(null)
     )
-    buildTargets
+    val buildTargetClassesReady = buildTargets
       .inverseSources(path)
       .flatMap(buildTargets.activatePlatformForTarget)
-      .foreach { platform =>
+      .map { platform =>
         buildTargetClasses.rebuildIndex(
           buildTargets.targetsByPlatform(platform)
         )
       }
+      .getOrElse(Future.unit)
 
     // Update md5 fingerprint from file contents on disk
     fingerprints.add(path, FileIO.slurp(path, charset))
@@ -975,7 +976,9 @@ abstract class MetalsLspService(
                 compilations.compileFile(path, assumeDidNotChange = true),
                 compilers.load(List(path)),
                 parser,
-                testProvider.didOpen(path),
+                buildTargetClassesReady.flatMap(_ =>
+                  testProvider.didOpen(path)
+                ),
               )
             )
             .ignoreValue

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1180,15 +1180,15 @@ abstract class MetalsLspService(
       isIncludedPath: AbsolutePath => Boolean
   ): Future[Unit] = {
     // rerun diagnostics for all open documents
-    buffers.open.filter(isIncludedPath).foldLeft(Future.unit) {
-      case (previous, path) =>
+    val futures =
+      buffers.open.filter(isIncludedPath).map { path =>
         for {
-          _ <- previous
           reportedDiagnostics <- compilers.didFocus(path)
           _ = diagnostics
             .publishDiagnosticsNotAdjusted(path, reportedDiagnostics)
         } yield ()
-    }
+      }
+    Future.sequence(futures).map(_ => ())
   }
 
   def resetPresentationCompilers(): Future[Unit] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/IndexedDocument.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/IndexedDocument.scala
@@ -96,7 +96,7 @@ case class IndexedDocument(
   def toProto(): Mbt.IndexedDocument.Builder = {
     val bloomFilterVersion = language match {
       case Language.JAVA => Mbt.IndexedDocument.BloomFilterVersion.V7
-      case Language.PROTOBUF => Mbt.IndexedDocument.BloomFilterVersion.V9
+      case Language.PROTOBUF => Mbt.IndexedDocument.BloomFilterVersion.V10
       case _ => Mbt.IndexedDocument.BloomFilterVersion.V6
     }
     Mbt.IndexedDocument
@@ -271,8 +271,8 @@ object IndexedDocument {
     doc.getBloomFilterVersion().getNumber >= (doc.getLanguage() match {
       case Language.JAVA => Mbt.IndexedDocument.BloomFilterVersion.V7
       case Language.SCALA => Mbt.IndexedDocument.BloomFilterVersion.V6
-      // V9: Proto bloom filters include scanner fixes for option blocks.
-      case Language.PROTOBUF => Mbt.IndexedDocument.BloomFilterVersion.V9
+      // V10: Includes V9 option-block scanner fixes and Java packages for Turbine.
+      case Language.PROTOBUF => Mbt.IndexedDocument.BloomFilterVersion.V10
       case _ => Mbt.IndexedDocument.BloomFilterVersion.V1
     }).getNumber()
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -136,6 +136,10 @@ class MbtWorkspaceSymbolProvider(
     clearAllProtobufCaches,
   )
 
+  private def isProtoJavaPackageIndexingEnabled: Boolean =
+    protobufWorkspace.isJavaPackageIndexingEnabled ||
+      javaSymbolLoader().isTurbineClasspath
+
   /**
    * The Java outlines synthesized from the given `.proto` file (one per
    * generated top-level class). Empty when the file isn't an indexed proto or
@@ -202,10 +206,7 @@ class MbtWorkspaceSymbolProvider(
               )
             )
             .toList
-        } else if (
-          file.isProtoFilename &&
-          protobufWorkspace.isJavaPackageIndexingEnabled
-        ) {
+        } else if (file.isProtoFilename && isProtoJavaPackageIndexingEnabled) {
           // Include the Java outlines generated from proto files so that
           // turbine can resolve references to proto-generated classes when it
           // header-compiles the workspace. Without these, a Java method
@@ -547,7 +548,7 @@ class MbtWorkspaceSymbolProvider(
   ): Future[Unit] = try {
     if (MbtIndexFilter.included(indexFilters, MbtFileCandidate(file))) {
       val enableProtoJavaPackage =
-        file.isProtoFilename && protobufWorkspace.isJavaPackageIndexingEnabled
+        file.isProtoFilename && isProtoJavaPackageIndexingEnabled
       val mdoc =
         IndexedDocument.fromFile(
           file,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -206,7 +206,10 @@ class MbtWorkspaceSymbolProvider(
               )
             )
             .toList
-        } else if (file.isProtoFilename && isProtoJavaPackageIndexingEnabled) {
+        } else if (
+          file.isProtoFilename &&
+          protobufWorkspace.isJavaPackageIndexingEnabled
+        ) {
           // Include the Java outlines generated from proto files so that
           // turbine can resolve references to proto-generated classes when it
           // header-compiles the workspace. Without these, a Java method

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineClasspathFileManager.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineClasspathFileManager.scala
@@ -22,7 +22,6 @@ class TurbineClasspathFileManager(
     workspaceClasspath: () => TurbineCompileResult,
     listSourcepath: String => java.lang.Iterable[JavaFileObject],
     isDeleted: String => Boolean,
-    projectClasspath: ClassPath,
 ) extends ForwardingJavaFileManager[JavaFileManager](delegate) {
 
   override def contains(
@@ -83,6 +82,13 @@ class TurbineClasspathFileManager(
         val turbinePackageName = packageNames.mkString("/")
         val objects = new ju.ArrayList[JavaFileObject]()
         val cp = workspaceClasspath()
+        val isAddedBinaryName = new ju.HashSet[String]()
+        super.list(location, packageName, kinds, recurse).forEach { obj =>
+          val binaryName = inferBinaryName(location, obj).replace('.', '/')
+          if (isAddedBinaryName.add(binaryName)) {
+            objects.add(obj)
+          }
+        }
         cp.symbolsByPackage.get(turbinePackageName) match {
           case None =>
           case Some(values) =>
@@ -92,7 +98,9 @@ class TurbineClasspathFileManager(
               val binaryName = sym.binaryName()
               // Skip classes that have been deleted but not yet recompiled,
               // or have a pending source on SOURCE_PATH (so javac uses the updated source)
-              if (!isDeleted(binaryName)) {
+              if (
+                !isDeleted(binaryName) && isAddedBinaryName.add(binaryName)
+              ) {
                 val bytes = cp.lowered.bytes().get(binaryName)
                 if (bytes != null) {
                   val obj = new TurbineClassfileObject(
@@ -104,14 +112,11 @@ class TurbineClasspathFileManager(
               }
             }
         }
-        val isAddedBinaryName = new ju.HashSet[String]()
-        for {
-          cp <- List(
-            // Prioritize the project classpath over the fallback classpath
-            projectClasspath,
-            cp.classpath,
-          )
-        } listPackageClasspath(cp, packageNames, isAddedBinaryName) { obj =>
+        listPackageClasspath(
+          cp.classpath,
+          packageNames,
+          isAddedBinaryName,
+        ) { obj =>
           objects.add(obj)
         }
         objects

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineClasspathFileManager.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineClasspathFileManager.scala
@@ -22,6 +22,7 @@ class TurbineClasspathFileManager(
     workspaceClasspath: () => TurbineCompileResult,
     listSourcepath: String => java.lang.Iterable[JavaFileObject],
     isDeleted: String => Boolean,
+    projectClasspath: ClassPath,
 ) extends ForwardingJavaFileManager[JavaFileManager](delegate) {
 
   override def contains(
@@ -83,11 +84,12 @@ class TurbineClasspathFileManager(
         val objects = new ju.ArrayList[JavaFileObject]()
         val cp = workspaceClasspath()
         val isAddedBinaryName = new ju.HashSet[String]()
-        super.list(location, packageName, kinds, recurse).forEach { obj =>
-          val binaryName = inferBinaryName(location, obj).replace('.', '/')
-          if (isAddedBinaryName.add(binaryName)) {
-            objects.add(obj)
-          }
+        listPackageClasspath(
+          projectClasspath,
+          packageNames,
+          isAddedBinaryName,
+        ) { obj =>
+          objects.add(obj)
         }
         cp.symbolsByPackage.get(turbinePackageName) match {
           case None =>

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineClasspathFileManager.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineClasspathFileManager.scala
@@ -98,9 +98,7 @@ class TurbineClasspathFileManager(
               val binaryName = sym.binaryName()
               // Skip classes that have been deleted but not yet recompiled,
               // or have a pending source on SOURCE_PATH (so javac uses the updated source)
-              if (
-                !isDeleted(binaryName) && isAddedBinaryName.add(binaryName)
-              ) {
+              if (!isDeleted(binaryName) && isAddedBinaryName.add(binaryName)) {
                 val bytes = cp.lowered.bytes().get(binaryName)
                 if (bytes != null) {
                   val obj = new TurbineClassfileObject(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineClasspathFileManager.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineClasspathFileManager.scala
@@ -21,7 +21,6 @@ class TurbineClasspathFileManager(
     delegate: JavaFileManager,
     workspaceClasspath: () => TurbineCompileResult,
     listSourcepath: String => java.lang.Iterable[JavaFileObject],
-    listProtoBinaryNames: String => Set[String],
     isDeleted: String => Boolean,
     projectClasspath: ClassPath,
 ) extends ForwardingJavaFileManager[JavaFileManager](delegate) {
@@ -85,18 +84,12 @@ class TurbineClasspathFileManager(
         val objects = new ju.ArrayList[JavaFileObject]()
         val cp = workspaceClasspath()
         val isAddedBinaryName = new ju.HashSet[String]()
-        val protoBinaryNames = listProtoBinaryNames(packageName)
-        if (protoBinaryNames.nonEmpty) {
-          super.list(location, packageName, kinds, recurse).forEach { obj =>
-            val binaryName = inferBinaryName(location, obj).replace('.', '/')
-            val topLevelBinaryName = binaryName.takeWhile(_ != '$')
-            if (
-              protoBinaryNames.contains(topLevelBinaryName) &&
-              isAddedBinaryName.add(binaryName)
-            ) {
-              objects.add(obj)
-            }
-          }
+        listPackageClasspath(
+          projectClasspath,
+          packageNames,
+          isAddedBinaryName,
+        ) { obj =>
+          objects.add(obj)
         }
         cp.symbolsByPackage.get(turbinePackageName) match {
           case None =>
@@ -119,10 +112,8 @@ class TurbineClasspathFileManager(
               }
             }
         }
-        for {
-          classpath <- List(projectClasspath, cp.classpath)
-        } listPackageClasspath(
-          classpath,
+        listPackageClasspath(
+          cp.classpath,
           packageNames,
           isAddedBinaryName,
         ) { obj =>

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineClasspathFileManager.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineClasspathFileManager.scala
@@ -21,6 +21,7 @@ class TurbineClasspathFileManager(
     delegate: JavaFileManager,
     workspaceClasspath: () => TurbineCompileResult,
     listSourcepath: String => java.lang.Iterable[JavaFileObject],
+    listProtoBinaryNames: String => Set[String],
     isDeleted: String => Boolean,
     projectClasspath: ClassPath,
 ) extends ForwardingJavaFileManager[JavaFileManager](delegate) {
@@ -84,12 +85,18 @@ class TurbineClasspathFileManager(
         val objects = new ju.ArrayList[JavaFileObject]()
         val cp = workspaceClasspath()
         val isAddedBinaryName = new ju.HashSet[String]()
-        listPackageClasspath(
-          projectClasspath,
-          packageNames,
-          isAddedBinaryName,
-        ) { obj =>
-          objects.add(obj)
+        val protoBinaryNames = listProtoBinaryNames(packageName)
+        if (protoBinaryNames.nonEmpty) {
+          super.list(location, packageName, kinds, recurse).forEach { obj =>
+            val binaryName = inferBinaryName(location, obj).replace('.', '/')
+            val topLevelBinaryName = binaryName.takeWhile(_ != '$')
+            if (
+              protoBinaryNames.contains(topLevelBinaryName) &&
+              isAddedBinaryName.add(binaryName)
+            ) {
+              objects.add(obj)
+            }
+          }
         }
         cp.symbolsByPackage.get(turbinePackageName) match {
           case None =>
@@ -100,9 +107,9 @@ class TurbineClasspathFileManager(
               val binaryName = sym.binaryName()
               // Skip classes that have been deleted but not yet recompiled,
               // or have a pending source on SOURCE_PATH (so javac uses the updated source)
-              if (!isDeleted(binaryName) && isAddedBinaryName.add(binaryName)) {
+              if (!isDeleted(binaryName)) {
                 val bytes = cp.lowered.bytes().get(binaryName)
-                if (bytes != null) {
+                if (bytes != null && isAddedBinaryName.add(binaryName)) {
                   val obj = new TurbineClassfileObject(
                     binaryName,
                     () => bytes,
@@ -112,8 +119,10 @@ class TurbineClasspathFileManager(
               }
             }
         }
-        listPackageClasspath(
-          cp.classpath,
+        for {
+          classpath <- List(projectClasspath, cp.classpath)
+        } listPackageClasspath(
+          classpath,
           packageNames,
           isAddedBinaryName,
         ) { obj =>

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
@@ -24,6 +24,7 @@ import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.Sleeper
 import scala.meta.pc.ProgressBars
+import scala.meta.pc.SemanticdbCompilationUnit
 
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
@@ -33,6 +34,7 @@ import com.google.turbine.binder.ClassPath
 import com.google.turbine.binder.ClassPathBinder
 import com.google.turbine.binder.JimageClassBinder
 import com.google.turbine.binder.Processing
+import com.google.turbine.binder.sym.ClassSymbol
 import com.google.turbine.diag.SourceFile
 import com.google.turbine.diag.TurbineLog
 import com.google.turbine.lower.Lower
@@ -339,7 +341,8 @@ class TurbineCompiler[T](
     new TurbineClasspathFileManager(
       underlying,
       () => result,
-      listSourcepath = listCombinedSourcepath,
+      listSourcepath = packageName =>
+        listCombinedSourcepath(packageName, projectClasspath),
       isDeleted,
       projectClasspath,
     )
@@ -347,11 +350,17 @@ class TurbineCompiler[T](
 
   // Combines normal Scala/Java files with on-the-fly generated Protobuf outlines.
   private def listCombinedSourcepath(
-      packageName: String
+      packageName: String,
+      projectClasspath: ClassPath,
   ): java.lang.Iterable[JavaFileObject] = {
     val turbineFiles = listSourcepath(packageName)
     val protoPackage = packageName.replace('.', '/') + "/"
-    val protoFiles = listProtoJavaOutlinesForPackage(protoPackage)
+    val protoFiles = listProtoJavaOutlinesForPackage(protoPackage).filterNot {
+      case file: SemanticdbCompilationUnit =>
+        val symbol = new ClassSymbol(file.binaryName().replace('.', '/'))
+        projectClasspath.env().get(symbol) != null
+      case _ => false
+    }
     if (protoFiles.isEmpty) {
       turbineFiles
     } else {

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
@@ -328,20 +328,17 @@ class TurbineCompiler[T](
       underlying: StandardJavaFileManager,
       projectClasspathJars: ju.List[Path],
   ): JavaFileManager = {
-    val isGlobalClasspathEntry = this.classpath().toSet
-    val filteredProjectClasspath =
-      projectClasspathJars.asScala.filter(file =>
-        !isGlobalClasspathEntry(file) && TurbineCompiler.isJarFile(file)
-      )
+    val projectClasspathEntries = projectClasspathJars.asScala.filter(
+      TurbineCompiler.isJarFile
+    )
     val projectClasspath =
-      ClassPathBinder.bindClasspath(filteredProjectClasspath.asJava)
+      ClassPathBinder.bindClasspath(projectClasspathEntries.asJava)
     onNewProjectClasspath(projectClasspath)
     new TurbineClasspathFileManager(
       underlying,
       () => result,
       listSourcepath = listCombinedSourcepath,
       isDeleted,
-      projectClasspath,
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
@@ -24,7 +24,6 @@ import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.Sleeper
 import scala.meta.pc.ProgressBars
-import scala.meta.pc.SemanticdbCompilationUnit
 
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
@@ -341,7 +340,6 @@ class TurbineCompiler[T](
       underlying,
       () => result,
       listSourcepath = listCombinedSourcepath,
-      listProtoBinaryNames,
       isDeleted,
       projectClasspath,
     )
@@ -362,14 +360,6 @@ class TurbineCompiler[T](
       protoFiles.foreach(combined.add(_))
       combined
     }
-  }
-
-  private def listProtoBinaryNames(packageName: String): Set[String] = {
-    val protoPackage = packageName.replace('.', '/') + "/"
-    listProtoJavaOutlinesForPackage(protoPackage).collect {
-      case file: SemanticdbCompilationUnit =>
-        file.binaryName().replace('.', '/')
-    }.toSet
   }
 
   private[mbt] def listSourcepath(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
@@ -24,6 +24,7 @@ import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.Sleeper
 import scala.meta.pc.ProgressBars
+import scala.meta.pc.SemanticdbCompilationUnit
 
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
@@ -328,9 +329,11 @@ class TurbineCompiler[T](
       underlying: StandardJavaFileManager,
       projectClasspathJars: ju.List[Path],
   ): JavaFileManager = {
-    val projectClasspathEntries = projectClasspathJars.asScala.filter(
-      TurbineCompiler.isJarFile
-    )
+    val isGlobalClasspathEntry = this.classpath().toSet
+    val projectClasspathEntries =
+      projectClasspathJars.asScala.filter(file =>
+        !isGlobalClasspathEntry(file) && TurbineCompiler.isJarFile(file)
+      )
     val projectClasspath =
       ClassPathBinder.bindClasspath(projectClasspathEntries.asJava)
     onNewProjectClasspath(projectClasspath)
@@ -338,6 +341,7 @@ class TurbineCompiler[T](
       underlying,
       () => result,
       listSourcepath = listCombinedSourcepath,
+      listProtoBinaryNames,
       isDeleted,
       projectClasspath,
     )
@@ -358,6 +362,14 @@ class TurbineCompiler[T](
       protoFiles.foreach(combined.add(_))
       combined
     }
+  }
+
+  private def listProtoBinaryNames(packageName: String): Set[String] = {
+    val protoPackage = packageName.replace('.', '/') + "/"
+    listProtoJavaOutlinesForPackage(protoPackage).collect {
+      case file: SemanticdbCompilationUnit =>
+        file.binaryName().replace('.', '/')
+    }.toSet
   }
 
   private[mbt] def listSourcepath(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompiler.scala
@@ -339,6 +339,7 @@ class TurbineCompiler[T](
       () => result,
       listSourcepath = listCombinedSourcepath,
       isDeleted,
+      projectClasspath,
     )
   }
 

--- a/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
@@ -296,6 +296,46 @@ class MbtBuildServerLspSuite
     }
   }
 
+  test("mbt-initial-focus-waits-for-targets") {
+    cleanWorkspace()
+    val source = "src/Main.java"
+    val mbtJson = new MbtJsonBuilder(BuildInfo.scalaVersion)
+      .addJavaDependency("com.google.guava", "guava", "33.5.0-jre")
+      .addNamespace("main", List("src/**"))
+      .build()
+    writeLayout(
+      s"""|/.metals/mbt.json
+          |$mbtJson
+          |/$source
+          |package example;
+          |
+          |import com.google.common.collect.ImmutableList;
+          |
+          |public class Main {
+          |  public static ImmutableList<String> names = ImmutableList.of("Alice");
+          |}
+          |""".stripMargin
+    )
+
+    for {
+      _ <- server.initialize()
+      didOpen = server.didOpen(source)
+      didFocus = server.didFocus(source)
+      unexpectedDiagnostics = client.nextDiagnosticsFor(
+        workspace.resolve(source),
+        _.nonEmpty,
+      )
+      _ = assert(!didFocus.isCompleted)
+      _ <- server.initialized()
+      _ <- server.didChangeConfiguration(userConfig.toString)
+      _ <- didOpen
+      _ <- didFocus
+      _ = server.assertBuildServerConnection()
+      _ = assert(!unexpectedDiagnostics.isCompleted)
+      _ = assertNoDiagnostics()
+    } yield ()
+  }
+
   test("two-targets-hover-definition-completion") {
     cleanWorkspace()
     val scalaLibJarUri =
@@ -490,6 +530,66 @@ class MbtBuildServerLspSuite
         targetIds,
         Set("mbt://namespace/core", "mbt://namespace/extra"),
       )
+    } yield ()
+  }
+
+  test("mbt-target-update-refreshes-java-diagnostics") {
+    cleanWorkspace()
+    val source = "src/Main.java"
+    val otherSource = "src/Other.java"
+    val initialMbtJson = new MbtJsonBuilder(BuildInfo.scalaVersion)
+      .addNamespace("main", List("src/**"))
+      .build()
+    val updatedMbtJson = new MbtJsonBuilder(BuildInfo.scalaVersion)
+      .addJavaDependency("com.google.guava", "guava", "33.5.0-jre")
+      .addNamespace("main", List("src/**"))
+      .build()
+
+    for {
+      _ <- initialize(
+        s"""|/.metals/mbt.json
+            |$initialMbtJson
+            |/$source
+            |package example;
+            |
+            |import com.google.common.collect.ImmutableList;
+            |
+            |public class Main {
+            |  public static ImmutableList<String> names = ImmutableList.of("Alice");
+            |}
+            |/$otherSource
+            |package example;
+            |
+            |import com.google.common.collect.ImmutableList;
+            |
+            |public class Other {
+            |  public static ImmutableList<String> names = ImmutableList.of("Bob");
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen(source)
+      _ <- server.didFocus(source)
+      _ <- server.didOpen(otherSource)
+      _ <- server.didFocus(otherSource)
+      _ = assert(
+        client.workspaceDiagnostics.nonEmpty,
+        "Expected diagnostics before the target classpath update",
+      )
+      _ = Files.writeString(
+        workspace.resolve(".metals").resolve("mbt.json").toNIO,
+        updatedMbtJson,
+      )
+      diagnosticsCleared = Future.sequence(
+        List(source, otherSource).map(path =>
+          client.nextDiagnosticsFor(
+            workspace.resolve(path),
+            _.isEmpty,
+          )
+        )
+      )
+      _ <- server.didChangeWatchedFiles(".metals/mbt.json")
+      _ <- diagnosticsCleared
+      _ = assertNoDiagnostics()
     } yield ()
   }
 

--- a/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
@@ -6,20 +6,26 @@ import java.nio.file.Files
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
+import scala.collection.parallel.mutable.ParArray
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.util.Properties
 
 import scala.meta.internal.metals.AutoImportBuildKind
+import scala.meta.internal.metals.Configs.FallbackClasspathConfig
 import scala.meta.internal.metals.Configs.FallbackSourcepathConfig
 import scala.meta.internal.metals.Configs.ReferenceProviderConfig
 import scala.meta.internal.metals.Configs.WorkspaceSymbolProviderConfig
+import scala.meta.internal.metals.EmptyWorkDoneProgress
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.TestUserInterfaceKind
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.mbt.MbtBuildServer
+import scala.meta.internal.metals.mbt.MbtDependencyModule
+import scala.meta.internal.metals.mbt.TurbineCompiler
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 
+import com.google.turbine.diag.SourceFile
 import coursierapi.Dependency
 import coursierapi.Fetch
 import org.eclipse.lsp4j.FileChangeType
@@ -1076,6 +1082,95 @@ class MbtBuildServerLspSuite
            |```
            |""".stripMargin.hover,
       )
+    } yield ()
+  }
+}
+
+class MbtTargetClasspathLspSuite
+    extends BaseCompletionLspSuite("mbt-target-classpath") {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(
+      fallbackScalaVersion = Some(BuildInfo.scalaVersion),
+      presentationCompilerDiagnostics = true,
+      buildOnChange = false,
+      buildOnFocus = false,
+      workspaceSymbolProvider = WorkspaceSymbolProviderConfig.mbt,
+      referenceProvider = ReferenceProviderConfig.mbt,
+      fallbackClasspath = FallbackClasspathConfig(Nil),
+      fallbackSourcepath = FallbackSourcepathConfig("all-sources"),
+      preferredBuildServer = Some(MbtBuildServer.name),
+      automaticImportBuild = AutoImportBuildKind.All,
+    )
+
+  override def initializeGitRepo: Boolean = true
+
+  test("target-classpath-before-protobuf-outline") {
+    cleanWorkspace()
+    val jar = workspace.resolve("dependency.jar")
+    val result = TurbineCompiler.compileClassfiles(
+      ParArray(
+        """|package generated.example;
+           |
+           |public final class Dependency {
+           |  public static Builder newBuilder() { return new Builder(); }
+           |
+           |  public static final class Builder {
+           |    public Builder project() { return this; }
+           |  }
+           |}
+           |""".stripMargin
+      ),
+      (text: String) => Seq(new SourceFile("Dependency.java", text)),
+      Nil,
+      EmptyWorkDoneProgress,
+    )(server.reports)
+    val output = new ZipOutputStream(Files.newOutputStream(jar.toNIO))
+    try {
+      for ((name, bytes) <- result.lowered.bytes().asScala) {
+        output.putNextEntry(new ZipEntry(s"$name.class"))
+        output.write(bytes)
+        output.closeEntry()
+      }
+    } finally output.close()
+
+    val mbtJson = new MbtJsonBuilder(
+      BuildInfo.scalaVersion,
+      dependencyModules = List(
+        MbtDependencyModule(
+          "com.example:dependency:1.0.0",
+          jar.toURI.toString,
+          null,
+        )
+      ),
+    ).addNamespace("main", List("src/**")).build()
+    val source = "src/Main.java"
+
+    for {
+      _ <- initialize(
+        s"""|/.metals/mbt.json
+            |$mbtJson
+            |/src/dependency.proto
+            |syntax = "proto3";
+            |package example;
+            |option java_package = "generated.example";
+            |option java_multiple_files = true;
+            |message Dependency {}
+            |/$source
+            |package example;
+            |
+            |import generated.example.Dependency;
+            |
+            |public class Main {
+            |  public void test() {
+            |    Dependency.newBuilder().project();
+            |  }
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen(source)
+      _ <- server.didFocus(source)
+      _ = assertNoDiagnostics()
     } yield ()
   }
 }

--- a/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
@@ -1,6 +1,5 @@
 package tests.mbt
 
-import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.EnumSet
@@ -25,9 +24,7 @@ import scala.meta.internal.metals.mbt.IndexingStats
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
 import scala.meta.internal.metals.mbt.TurbineCompileResult
 import scala.meta.internal.metals.mbt.TurbineCompiler
-import scala.meta.internal.metals.mbt.VirtualTextDocument
 import scala.meta.io.AbsolutePath
-import scala.meta.pc
 
 import com.google.turbine.diag.SourceFile
 import munit.AnyFixture
@@ -287,7 +284,9 @@ class TurbineClasspathFileManagerSuite extends munit.FunSuite {
       EmptyWorkDoneProgress,
     )
 
-  private def checkTargetClasspathPrecedence(isProtobuf: Boolean): Unit = {
+  private def checkTargetClasspathPrecedence(
+      isGlobalClasspathEntry: Boolean
+  ): Unit = {
     val projectResult = compile(projectSource)
     val jar = Files.createTempFile("metals-project-classpath", ".jar")
     val output = new ZipOutputStream(Files.newOutputStream(jar))
@@ -300,29 +299,20 @@ class TurbineClasspathFileManagerSuite extends munit.FunSuite {
     } finally output.close()
 
     var fallbackClasspath = Seq.empty[java.nio.file.Path]
-    val protoOutline = VirtualTextDocument(
-      URI.create("file:///Dependency.java"),
-      pc.Language.JAVA,
-      workspaceSource,
-      Seq("example"),
-      Seq("example/Dependency#"),
-    )
     val compiler = new TurbineCompiler[String](
       () => ParArray(workspaceSource),
       text => Seq(new SourceFile("Dependency.java", text)),
       () => fallbackClasspath,
       EmptyWorkDoneProgress,
       () => Configs.TurbineRecompileDelayConfig.testing,
-      packageName =>
-        if (isProtobuf && packageName == "example/") Iterator(protoOutline)
-        else Iterator.empty,
+      _ => Iterator.empty,
       Sleeper.TestingSleeper,
       () => (),
       _ => (),
     )
     compiler.doCompileNow()
     val workspaceResult = compiler.result
-    fallbackClasspath = Seq(jar)
+    if (isGlobalClasspathEntry) fallbackClasspath = Seq(jar)
 
     val standardFileManager = ToolProvider
       .getSystemJavaCompiler()
@@ -354,8 +344,8 @@ class TurbineClasspathFileManagerSuite extends munit.FunSuite {
         )
       }.toMap
       val expectedResult =
-        if (isProtobuf) projectResult
-        else workspaceResult
+        if (isGlobalClasspathEntry) workspaceResult
+        else projectResult
       val expected = expectedResult.lowered
         .bytes()
         .asScala
@@ -370,11 +360,11 @@ class TurbineClasspathFileManagerSuite extends munit.FunSuite {
     }
   }
 
-  test("target-protobuf-classpath-before-workspace-headers") {
-    checkTargetClasspathPrecedence(isProtobuf = true)
+  test("target-classpath-before-workspace-headers") {
+    checkTargetClasspathPrecedence(isGlobalClasspathEntry = false)
   }
 
-  test("workspace-headers-before-non-protobuf-target-classpath") {
-    checkTargetClasspathPrecedence(isProtobuf = false)
+  test("workspace-headers-before-global-fallback-classpath") {
+    checkTargetClasspathPrecedence(isGlobalClasspathEntry = true)
   }
 }

--- a/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
@@ -1,5 +1,6 @@
 package tests.mbt
 
+import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.EnumSet
@@ -14,18 +15,20 @@ import scala.collection.parallel.mutable.ParArray
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import scala.util.Using
 
 import scala.meta.internal.metals.Configs
 import scala.meta.internal.metals.EmptyWorkDoneProgress
 import scala.meta.internal.metals.LoggerReportContext
+import scala.meta.internal.metals.Sleeper
 import scala.meta.internal.metals.mbt.IndexingStats
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
-import scala.meta.internal.metals.mbt.TurbineClasspathFileManager
 import scala.meta.internal.metals.mbt.TurbineCompileResult
 import scala.meta.internal.metals.mbt.TurbineCompiler
+import scala.meta.internal.metals.mbt.VirtualTextDocument
 import scala.meta.io.AbsolutePath
+import scala.meta.pc
 
-import com.google.turbine.binder.ClassPathBinder
 import com.google.turbine.diag.SourceFile
 import munit.AnyFixture
 import munit.TestOptions
@@ -245,6 +248,12 @@ module com.example {
 
 class TurbineClasspathFileManagerSuite extends munit.FunSuite {
   implicit val reportContext: LoggerReportContext.type = LoggerReportContext
+  implicit val executionContext: ExecutionContext = ExecutionContext.global
+
+  private val workspaceSource =
+    "package example; public class Dependency { public static class Builder { public void workspace() {} } }"
+  private val projectSource =
+    "package example; public class Dependency { public static class Builder { public void project() {} } }"
 
   private def compile(source: String): TurbineCompileResult =
     TurbineCompiler.compileClassfiles(
@@ -254,13 +263,8 @@ class TurbineClasspathFileManagerSuite extends munit.FunSuite {
       EmptyWorkDoneProgress,
     )
 
-  test("target-classpath-before-workspace-headers") {
-    val workspaceResult = compile(
-      "package example; public class Dependency { public static void workspace() {} }"
-    )
-    val projectResult = compile(
-      "package example; public class Dependency { public static void project() {} }"
-    )
+  private def checkTargetClasspathPrecedence(isProtobuf: Boolean): Unit = {
+    val projectResult = compile(projectSource)
     val jar = Files.createTempFile("metals-project-classpath", ".jar")
     val output = new ZipOutputStream(Files.newOutputStream(jar))
     try {
@@ -271,29 +275,82 @@ class TurbineClasspathFileManagerSuite extends munit.FunSuite {
       }
     } finally output.close()
 
+    var fallbackClasspath = Seq.empty[java.nio.file.Path]
+    val protoOutline = VirtualTextDocument(
+      URI.create("file:///Dependency.java"),
+      pc.Language.JAVA,
+      workspaceSource,
+      Seq("example"),
+      Seq("example/Dependency#"),
+    )
+    val compiler = new TurbineCompiler[String](
+      () => ParArray(workspaceSource),
+      text => Seq(new SourceFile("Dependency.java", text)),
+      () => fallbackClasspath,
+      EmptyWorkDoneProgress,
+      () => Configs.TurbineRecompileDelayConfig.testing,
+      packageName =>
+        if (isProtobuf && packageName == "example/") Iterator(protoOutline)
+        else Iterator.empty,
+      Sleeper.TestingSleeper,
+      () => (),
+      _ => (),
+    )
+    compiler.doCompileNow()
+    val workspaceResult = compiler.result
+    fallbackClasspath = Seq(jar)
+
     val standardFileManager = ToolProvider
       .getSystemJavaCompiler()
       .getStandardFileManager(null, null, null)
-    val fileManager = new TurbineClasspathFileManager(
+    standardFileManager.setLocationFromPaths(
+      StandardLocation.CLASS_PATH,
+      List(jar).asJava,
+    )
+    val fileManager = compiler.createFileManager(
       standardFileManager,
-      () => workspaceResult,
-      _ => java.util.Collections.emptyList(),
-      _ => false,
-      ClassPathBinder.bindClasspath(List(jar).asJava),
+      List(jar).asJava,
     )
-    val classfiles = fileManager
-      .list(
-        StandardLocation.CLASS_PATH,
-        "example",
-        EnumSet.of(JavaFileObject.Kind.CLASS),
-        false,
-      )
-      .asScala
-      .toList
-    assertEquals(classfiles.size, 1)
-    assertEquals(
-      classfiles.head.openInputStream().readAllBytes().toSeq,
-      projectResult.lowered.bytes().get("example/Dependency").toSeq,
-    )
+    try {
+      val classfiles = fileManager
+        .list(
+          StandardLocation.CLASS_PATH,
+          "example",
+          EnumSet.of(JavaFileObject.Kind.CLASS),
+          false,
+        )
+        .asScala
+        .toList
+      val obtained = classfiles.map { classfile =>
+        val binaryName = fileManager
+          .inferBinaryName(StandardLocation.CLASS_PATH, classfile)
+          .replace('.', '/')
+        binaryName -> Using.resource(classfile.openInputStream())(
+          _.readAllBytes().toSeq
+        )
+      }.toMap
+      val expectedResult =
+        if (isProtobuf) projectResult
+        else workspaceResult
+      val expected = expectedResult.lowered
+        .bytes()
+        .asScala
+        .map { case (name, bytes) =>
+          name -> bytes.toSeq
+        }
+        .toMap
+      assertEquals(obtained, expected)
+    } finally {
+      fileManager.close()
+      Files.deleteIfExists(jar)
+    }
+  }
+
+  test("target-protobuf-classpath-before-workspace-headers") {
+    checkTargetClasspathPrecedence(isProtobuf = true)
+  }
+
+  test("workspace-headers-before-non-protobuf-target-classpath") {
+    checkTargetClasspathPrecedence(isProtobuf = false)
   }
 }

--- a/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
@@ -2,16 +2,30 @@ package tests.mbt
 
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.util.EnumSet
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.tools.JavaFileObject
+import javax.tools.StandardLocation
+import javax.tools.ToolProvider
 
+import scala.collection.JavaConverters._
+import scala.collection.parallel.mutable.ParArray
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 import scala.meta.internal.metals.Configs
+import scala.meta.internal.metals.EmptyWorkDoneProgress
+import scala.meta.internal.metals.LoggerReportContext
 import scala.meta.internal.metals.mbt.IndexingStats
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
+import scala.meta.internal.metals.mbt.TurbineClasspathFileManager
+import scala.meta.internal.metals.mbt.TurbineCompileResult
+import scala.meta.internal.metals.mbt.TurbineCompiler
 import scala.meta.io.AbsolutePath
 
+import com.google.turbine.diag.SourceFile
 import munit.AnyFixture
 import munit.TestOptions
 import org.eclipse.{lsp4j => l}
@@ -226,4 +240,62 @@ module com.example {
     assertResultIncludes = "Object TestProjectEnum ",
   )
 
+}
+
+class TurbineClasspathFileManagerSuite extends munit.FunSuite {
+  implicit val reportContext: LoggerReportContext.type = LoggerReportContext
+
+  private def compile(source: String): TurbineCompileResult =
+    TurbineCompiler.compileClassfiles(
+      ParArray(source),
+      (text: String) => Seq(new SourceFile("Dependency.java", text)),
+      Nil,
+      EmptyWorkDoneProgress,
+    )
+
+  test("target-classpath-before-workspace-headers") {
+    val workspaceResult = compile(
+      "package example; public class Dependency { public static void workspace() {} }"
+    )
+    val projectResult = compile(
+      "package example; public class Dependency { public static void project() {} }"
+    )
+    val jar = Files.createTempFile("metals-project-classpath", ".jar")
+    val output = new ZipOutputStream(Files.newOutputStream(jar))
+    try {
+      for ((name, bytes) <- projectResult.lowered.bytes().asScala) {
+        output.putNextEntry(new ZipEntry(s"$name.class"))
+        output.write(bytes)
+        output.closeEntry()
+      }
+    } finally output.close()
+
+    val standardFileManager = ToolProvider
+      .getSystemJavaCompiler()
+      .getStandardFileManager(null, null, null)
+    standardFileManager.setLocationFromPaths(
+      StandardLocation.CLASS_PATH,
+      List(jar).asJava,
+    )
+    val fileManager = new TurbineClasspathFileManager(
+      standardFileManager,
+      () => workspaceResult,
+      _ => java.util.Collections.emptyList(),
+      _ => false,
+    )
+    val classfiles = fileManager
+      .list(
+        StandardLocation.CLASS_PATH,
+        "example",
+        EnumSet.of(JavaFileObject.Kind.CLASS),
+        false,
+      )
+      .asScala
+      .toList
+    assertEquals(classfiles.size, 1)
+    assertEquals(
+      classfiles.head.openInputStream().readAllBytes().toSeq,
+      projectResult.lowered.bytes().get("example/Dependency").toSeq,
+    )
+  }
 }

--- a/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
@@ -172,6 +172,27 @@ object Hello2 {
     )
   }
 
+  test("turbine-indexes-proto-java-package-with-protobuf-lsp-disabled") {
+    FileLayout.fromString(
+      """
+/example/Dependency.proto
+syntax = "proto3";
+package example;
+option java_package = "generated.example";
+message Dependency {}
+""",
+      root = workspace(),
+    )
+    val provider = newProvider()
+    workspace.executeCommand("git init -b main")
+    workspace.gitCommitAllChanges()
+    assertEquals(
+      provider.onReindex().awaitBackgroundJobs(),
+      IndexingStats(totalFiles = 1, updatedFiles = 1),
+    )
+    assert(provider.listAllPackages().containsKey("generated/example/"))
+  }
+
   test("exclude-module-info-java") {
     FileLayout.fromString(
       """

--- a/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
@@ -1,11 +1,15 @@
 package tests.mbt
 
+import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.EnumSet
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import javax.tools.Diagnostic
+import javax.tools.DiagnosticCollector
 import javax.tools.JavaFileObject
+import javax.tools.SimpleJavaFileObject
 import javax.tools.StandardLocation
 import javax.tools.ToolProvider
 
@@ -24,9 +28,12 @@ import scala.meta.internal.metals.mbt.IndexingStats
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
 import scala.meta.internal.metals.mbt.TurbineCompileResult
 import scala.meta.internal.metals.mbt.TurbineCompiler
+import scala.meta.internal.metals.mbt.VirtualTextDocument
 import scala.meta.io.AbsolutePath
+import scala.meta.pc
 
 import com.google.turbine.diag.SourceFile
+import com.sun.source.util.JavacTask
 import munit.AnyFixture
 import munit.TestOptions
 import org.eclipse.{lsp4j => l}
@@ -299,13 +306,22 @@ class TurbineClasspathFileManagerSuite extends munit.FunSuite {
     } finally output.close()
 
     var fallbackClasspath = Seq.empty[java.nio.file.Path]
+    val protoOutline = VirtualTextDocument(
+      URI.create("file:///Dependency.java"),
+      pc.Language.JAVA,
+      workspaceSource,
+      Seq("example/"),
+      Seq("example/Dependency#"),
+    )
     val compiler = new TurbineCompiler[String](
       () => ParArray(workspaceSource),
       text => Seq(new SourceFile("Dependency.java", text)),
       () => fallbackClasspath,
       EmptyWorkDoneProgress,
       () => Configs.TurbineRecompileDelayConfig.testing,
-      _ => Iterator.empty,
+      packageName =>
+        if (packageName == "example/") Iterator(protoOutline)
+        else Iterator.empty,
       Sleeper.TestingSleeper,
       () => (),
       _ => (),
@@ -354,6 +370,47 @@ class TurbineClasspathFileManagerSuite extends munit.FunSuite {
         }
         .toMap
       assertEquals(obtained, expected)
+      val sourcepath = fileManager
+        .list(
+          StandardLocation.SOURCE_PATH,
+          "example",
+          EnumSet.of(JavaFileObject.Kind.SOURCE),
+          false,
+        )
+        .asScala
+        .toList
+      assertEquals(
+        sourcepath.map(_.toUri()),
+        if (isGlobalClasspathEntry) List(protoOutline.toUri()) else Nil,
+      )
+      val diagnostics = new DiagnosticCollector[JavaFileObject]()
+      val method = if (isGlobalClasspathEntry) "workspace" else "project"
+      val source = new SimpleJavaFileObject(
+        URI.create("string:///example/Main.java"),
+        JavaFileObject.Kind.SOURCE,
+      ) {
+        override def getCharContent(
+            ignoreEncodingErrors: Boolean
+        ): CharSequence =
+          s"package example; public class Main { void test() { new Dependency.Builder().$method(); } }"
+      }
+      val task = ToolProvider
+        .getSystemJavaCompiler()
+        .getTask(
+          null,
+          fileManager,
+          diagnostics,
+          List("-Xprefer:source", "-proc:none", "-sourcepath", "").asJava,
+          null,
+          List(source).asJava,
+        )
+        .asInstanceOf[JavacTask]
+      task.parse()
+      task.analyze()
+      val errors = diagnostics.getDiagnostics().asScala.filter { diagnostic =>
+        diagnostic.getKind() == Diagnostic.Kind.ERROR
+      }
+      assertEquals(errors.map(_.toString()).toList, List.empty[String])
     } finally {
       fileManager.close()
       Files.deleteIfExists(jar)

--- a/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
@@ -183,6 +183,7 @@ message Dependency {}
 """,
       root = workspace(),
     )
+    val proto = workspace.resolve("example/Dependency.proto")
     val provider = newProvider()
     workspace.executeCommand("git init -b main")
     workspace.gitCommitAllChanges()
@@ -191,6 +192,8 @@ message Dependency {}
       IndexingStats(totalFiles = 1, updatedFiles = 1),
     )
     assert(provider.listAllPackages().containsKey("generated/example/"))
+    assert(provider.document(proto).exists(_.cachedJavaOutlines.isEmpty))
+    assert(provider.protoJavaOutlines(proto).nonEmpty)
   }
 
   test("exclude-module-info-java") {

--- a/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
@@ -25,6 +25,7 @@ import scala.meta.internal.metals.mbt.TurbineCompileResult
 import scala.meta.internal.metals.mbt.TurbineCompiler
 import scala.meta.io.AbsolutePath
 
+import com.google.turbine.binder.ClassPathBinder
 import com.google.turbine.diag.SourceFile
 import munit.AnyFixture
 import munit.TestOptions
@@ -273,15 +274,12 @@ class TurbineClasspathFileManagerSuite extends munit.FunSuite {
     val standardFileManager = ToolProvider
       .getSystemJavaCompiler()
       .getStandardFileManager(null, null, null)
-    standardFileManager.setLocationFromPaths(
-      StandardLocation.CLASS_PATH,
-      List(jar).asJava,
-    )
     val fileManager = new TurbineClasspathFileManager(
       standardFileManager,
       () => workspaceResult,
       _ => java.util.Collections.emptyList(),
       _ => false,
+      ClassPathBinder.bindClasspath(List(jar).asJava),
     )
     val classfiles = fileManager
       .list(

--- a/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
@@ -183,7 +183,7 @@ message Dependency {}
 """,
       root = workspace(),
     )
-    val proto = workspace.resolve("example/Dependency.proto")
+    val proto = workspace().resolve("example/Dependency.proto")
     val provider = newProvider()
     workspace.executeCommand("git init -b main")
     workspace.gitCommitAllChanges()

--- a/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtWorkspaceSymbolProviderSuite.scala
@@ -1,39 +1,17 @@
 package tests.mbt
 
-import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.util.EnumSet
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
-import javax.tools.Diagnostic
-import javax.tools.DiagnosticCollector
-import javax.tools.JavaFileObject
-import javax.tools.SimpleJavaFileObject
-import javax.tools.StandardLocation
-import javax.tools.ToolProvider
 
-import scala.collection.JavaConverters._
-import scala.collection.parallel.mutable.ParArray
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.Using
 
 import scala.meta.internal.metals.Configs
-import scala.meta.internal.metals.EmptyWorkDoneProgress
-import scala.meta.internal.metals.LoggerReportContext
-import scala.meta.internal.metals.Sleeper
 import scala.meta.internal.metals.mbt.IndexingStats
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
-import scala.meta.internal.metals.mbt.TurbineCompileResult
-import scala.meta.internal.metals.mbt.TurbineCompiler
-import scala.meta.internal.metals.mbt.VirtualTextDocument
 import scala.meta.io.AbsolutePath
-import scala.meta.pc
 
-import com.google.turbine.diag.SourceFile
-import com.sun.source.util.JavacTask
 import munit.AnyFixture
 import munit.TestOptions
 import org.eclipse.{lsp4j => l}
@@ -272,156 +250,4 @@ module com.example {
     assertResultIncludes = "Object TestProjectEnum ",
   )
 
-}
-
-class TurbineClasspathFileManagerSuite extends munit.FunSuite {
-  implicit val reportContext: LoggerReportContext.type = LoggerReportContext
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
-
-  private val workspaceSource =
-    "package example; public class Dependency { public static class Builder { public void workspace() {} } }"
-  private val projectSource =
-    "package example; public class Dependency { public static class Builder { public void project() {} } }"
-
-  private def compile(source: String): TurbineCompileResult =
-    TurbineCompiler.compileClassfiles(
-      ParArray(source),
-      (text: String) => Seq(new SourceFile("Dependency.java", text)),
-      Nil,
-      EmptyWorkDoneProgress,
-    )
-
-  private def checkTargetClasspathPrecedence(
-      isGlobalClasspathEntry: Boolean
-  ): Unit = {
-    val projectResult = compile(projectSource)
-    val jar = Files.createTempFile("metals-project-classpath", ".jar")
-    val output = new ZipOutputStream(Files.newOutputStream(jar))
-    try {
-      for ((name, bytes) <- projectResult.lowered.bytes().asScala) {
-        output.putNextEntry(new ZipEntry(s"$name.class"))
-        output.write(bytes)
-        output.closeEntry()
-      }
-    } finally output.close()
-
-    var fallbackClasspath = Seq.empty[java.nio.file.Path]
-    val protoOutline = VirtualTextDocument(
-      URI.create("file:///Dependency.java"),
-      pc.Language.JAVA,
-      workspaceSource,
-      Seq("example/"),
-      Seq("example/Dependency#"),
-    )
-    val compiler = new TurbineCompiler[String](
-      () => ParArray(workspaceSource),
-      text => Seq(new SourceFile("Dependency.java", text)),
-      () => fallbackClasspath,
-      EmptyWorkDoneProgress,
-      () => Configs.TurbineRecompileDelayConfig.testing,
-      packageName =>
-        if (packageName == "example/") Iterator(protoOutline)
-        else Iterator.empty,
-      Sleeper.TestingSleeper,
-      () => (),
-      _ => (),
-    )
-    compiler.doCompileNow()
-    val workspaceResult = compiler.result
-    if (isGlobalClasspathEntry) fallbackClasspath = Seq(jar)
-
-    val standardFileManager = ToolProvider
-      .getSystemJavaCompiler()
-      .getStandardFileManager(null, null, null)
-    standardFileManager.setLocationFromPaths(
-      StandardLocation.CLASS_PATH,
-      List(jar).asJava,
-    )
-    val fileManager = compiler.createFileManager(
-      standardFileManager,
-      List(jar).asJava,
-    )
-    try {
-      val classfiles = fileManager
-        .list(
-          StandardLocation.CLASS_PATH,
-          "example",
-          EnumSet.of(JavaFileObject.Kind.CLASS),
-          false,
-        )
-        .asScala
-        .toList
-      val obtained = classfiles.map { classfile =>
-        val binaryName = fileManager
-          .inferBinaryName(StandardLocation.CLASS_PATH, classfile)
-          .replace('.', '/')
-        binaryName -> Using.resource(classfile.openInputStream())(
-          _.readAllBytes().toSeq
-        )
-      }.toMap
-      val expectedResult =
-        if (isGlobalClasspathEntry) workspaceResult
-        else projectResult
-      val expected = expectedResult.lowered
-        .bytes()
-        .asScala
-        .map { case (name, bytes) =>
-          name -> bytes.toSeq
-        }
-        .toMap
-      assertEquals(obtained, expected)
-      val sourcepath = fileManager
-        .list(
-          StandardLocation.SOURCE_PATH,
-          "example",
-          EnumSet.of(JavaFileObject.Kind.SOURCE),
-          false,
-        )
-        .asScala
-        .toList
-      assertEquals(
-        sourcepath.map(_.toUri()),
-        if (isGlobalClasspathEntry) List(protoOutline.toUri()) else Nil,
-      )
-      val diagnostics = new DiagnosticCollector[JavaFileObject]()
-      val method = if (isGlobalClasspathEntry) "workspace" else "project"
-      val source = new SimpleJavaFileObject(
-        URI.create("string:///example/Main.java"),
-        JavaFileObject.Kind.SOURCE,
-      ) {
-        override def getCharContent(
-            ignoreEncodingErrors: Boolean
-        ): CharSequence =
-          s"package example; public class Main { void test() { new Dependency.Builder().$method(); } }"
-      }
-      val task = ToolProvider
-        .getSystemJavaCompiler()
-        .getTask(
-          null,
-          fileManager,
-          diagnostics,
-          List("-Xprefer:source", "-proc:none", "-sourcepath", "").asJava,
-          null,
-          List(source).asJava,
-        )
-        .asInstanceOf[JavacTask]
-      task.parse()
-      task.analyze()
-      val errors = diagnostics.getDiagnostics().asScala.filter { diagnostic =>
-        diagnostic.getKind() == Diagnostic.Kind.ERROR
-      }
-      assertEquals(errors.map(_.toString()).toList, List.empty[String])
-    } finally {
-      fileManager.close()
-      Files.deleteIfExists(jar)
-    }
-  }
-
-  test("target-classpath-before-workspace-headers") {
-    checkTargetClasspathPrecedence(isGlobalClasspathEntry = false)
-  }
-
-  test("workspace-headers-before-global-fallback-classpath") {
-    checkTargetClasspathPrecedence(isGlobalClasspathEntry = true)
-  }
 }


### PR DESCRIPTION
## Summary

- prefer build-target classpath entries over Turbine-generated headers when both provide the same class
- keep Turbine headers as the fallback for dependency symbols
- add regression coverage for generated protobuf builder methods resolving from the target classpath
- Also uses a new (V10) version of the Bloom Filter (really this is just a one-time protobuf reindex) to include V9's logic + a fix for Turbine Java headers. Previously, cached protobuf entries only stored the proto package. The new lazy lookup also needs option `java_package`. V10 causes old V9 protobuf entries in .metals/index.mbt to be skipped and rebuilt with that Java package

## Test plan

- `TurbineClasspathFileManagerSuite`
- manual BSP import with Metals `2.0.0-TEST` against `compartmentsgraph`; generated protobuf builder methods resolve without false Java diagnostics (red squiggles).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved classpath resolution when workspace sources and project JARs contain overlapping classes.
- Ensured correct class definitions are selected, including generated protobuf classes.
- Removed duplicate classpath entries for more reliable compilation and navigation.
- Improved handling of unavailable workspace symbols and preserved required fallback entries.
- Improved protobuf Java package discovery and navigation.
- Prevented premature diagnostics during initial build loading and refreshed Java diagnostics after build target changes.
- Updated indexed-document compatibility for the latest indexing format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->