### PR TITLE
MBT: Fix test cases missing when indirectly overriding test library traits

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -421,6 +421,7 @@ abstract class MetalsLspService(
     getVisibleName,
     folder,
     workDoneProgress,
+    () => compilers,
   )
 
   protected lazy val codeLensProvider: CodeLensProvider = {

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -29,6 +29,7 @@ import scala.meta.internal.metals.testProvider.TestExplorerEvent._
 import scala.meta.internal.metals.testProvider.frameworks.JunitTestFinder
 import scala.meta.internal.metals.testProvider.frameworks.MunitTestFinder
 import scala.meta.internal.metals.testProvider.frameworks.ScalatestTestFinder
+import scala.meta.internal.metals.testProvider.frameworks.SemanticdbsWithMbtFallback
 import scala.meta.internal.metals.testProvider.frameworks.TestNGTestFinder
 import scala.meta.internal.metals.testProvider.frameworks.WeaverCatsEffectTestFinder
 import scala.meta.internal.metals.testProvider.frameworks.ZioTestFinder
@@ -66,14 +67,20 @@ final class TestSuitesProvider(
     with CodeLens {
 
   private val index = new TestSuitesIndex
+  private val semanticdbsWithMbtFallback =
+    new SemanticdbsWithMbtFallback(semanticdbs, buildTargets, compilers)
   private val junitTestFinder = new JunitTestFinder
   private val testNGTestFinder = new TestNGTestFinder
   private val munitTestFinder =
-    new MunitTestFinder(trees, symbolIndex, semanticdbs)
+    new MunitTestFinder(trees, symbolIndex, semanticdbsWithMbtFallback)
   private val scalatestTestFinder =
-    new ScalatestTestFinder(trees, symbolIndex, semanticdbs, compilers)
+    new ScalatestTestFinder(trees, symbolIndex, semanticdbsWithMbtFallback)
   private val weaverCatsEffect =
-    new WeaverCatsEffectTestFinder(trees, symbolIndex, semanticdbs)
+    new WeaverCatsEffectTestFinder(
+      trees,
+      symbolIndex,
+      semanticdbsWithMbtFallback,
+    )
   private val zioTestFinder = new ZioTestFinder(trees)
 
   private def isExplorerEnabled = clientConfig.isTestExplorerProvider() &&

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.ClientConfiguration
+import scala.meta.internal.metals.Compilers
 import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaTestSuiteSelection
@@ -59,6 +60,7 @@ final class TestSuitesProvider(
     folderName: String,
     folderUri: AbsolutePath,
     workDoneProgress: WorkDoneProgress,
+    compilers: () => Compilers,
 )(implicit ec: ExecutionContext)
     extends SemanticdbFeatureProvider
     with CodeLens {
@@ -69,7 +71,7 @@ final class TestSuitesProvider(
   private val munitTestFinder =
     new MunitTestFinder(trees, symbolIndex, semanticdbs)
   private val scalatestTestFinder =
-    new ScalatestTestFinder(trees, symbolIndex, semanticdbs)
+    new ScalatestTestFinder(trees, symbolIndex, semanticdbs, compilers)
   private val weaverCatsEffect =
     new WeaverCatsEffectTestFinder(trees, symbolIndex, semanticdbs)
   private val zioTestFinder = new ZioTestFinder(trees)

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/MunitTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/MunitTestFinder.scala
@@ -15,7 +15,6 @@ import scala.meta.internal.metals.testProvider.TestCaseEntry
 import scala.meta.internal.metals.testProvider.frameworks.TreeUtils._
 import scala.meta.internal.mtags
 import scala.meta.internal.mtags.GlobalSymbolIndex
-import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.parsing.Trees
 import scala.meta.internal.semanticdb.ClassSignature
 import scala.meta.internal.semanticdb.SymbolInformation
@@ -27,7 +26,7 @@ import scala.meta.io.AbsolutePath
 class MunitTestFinder(
     trees: Trees,
     symbolIndex: GlobalSymbolIndex,
-    semanticdbs: () => Semanticdbs,
+    semanticdbs: SemanticdbsWithMbtFallback,
 ) {
 
   protected val baseParentClasses: Set[String] =
@@ -132,9 +131,7 @@ class MunitTestFinder(
       val methods = for {
         definition <- symbolIndex.definition(mtags.Symbol(parentSymbol))
         tree <- trees.get(definition.path)
-        doc <- semanticdbs()
-          .textDocument(definition.path)
-          .documentIncludingStale
+        doc <- semanticdbs.textDocumentWithMbtFallback(definition.path)
         parentClassName = parentSymbol
           .stripPrefix("_empty_/")
           .stripSuffix("#")

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
@@ -1,10 +1,16 @@
 package scala.meta.internal.metals.testProvider.frameworks
 
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
 import scala.meta.Lit
 import scala.meta.Stat
 import scala.meta.Template
 import scala.meta.Term
 import scala.meta.Tree
+import scala.meta.internal.metals.Compilers
+import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.testProvider.FullyQualifiedName
 import scala.meta.internal.metals.testProvider.TestCaseEntry
@@ -26,7 +32,35 @@ class ScalatestTestFinder(
     trees: Trees,
     symbolIndex: mtags.GlobalSymbolIndex,
     semanticdbs: () => mtags.Semanticdbs,
+    compilers: () => Compilers,
 ) {
+
+  /**
+   * Temporary, blocking fallback: `semanticdbs().textDocument(...)` only
+   * ever reads whatever semanticdb already happens to exist on disk, which
+   * is never the case for a base class belonging to a different MBT
+   * namespace/target that nothing has asked about yet. This forces
+   * generation via the PC, the same way MBT test-class confirmation does,
+   * so the cross-namespace inheritance chain can actually be followed.
+   */
+  private def generateSemanticdbSync(path: AbsolutePath): Option[TextDocument] =
+    try {
+      val documents = Await.result(
+        compilers().batchSemanticdbTextDocuments(
+          Seq(path),
+          EmptyCancelToken,
+          timeout = java.time.Duration.ofSeconds(20),
+          useFallbackCompiler = true,
+          shouldPruneSemanticdb = true,
+        ),
+        20.seconds,
+      )
+      documents.documents.find(_.uri.toAbsolutePath == path)
+    } catch {
+      case NonFatal(e) =>
+        scribe.warn(s"Failed to generate semanticdb on demand for $path", e)
+        None
+    }
 
   def findTests(
       doc: TextDocument,
@@ -68,6 +102,7 @@ class ScalatestTestFinder(
           doc <- semanticdbs()
             .textDocument(definition.path)
             .documentIncludingStale
+            .orElse(generateSemanticdbSync(definition.path))
           style <- inferScalatestStyle(doc, mtags.Symbol(parentSymbol))
         } yield style
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
@@ -1,16 +1,10 @@
 package scala.meta.internal.metals.testProvider.frameworks
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-import scala.util.control.NonFatal
-
 import scala.meta.Lit
 import scala.meta.Stat
 import scala.meta.Template
 import scala.meta.Term
 import scala.meta.Tree
-import scala.meta.internal.metals.Compilers
-import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.testProvider.FullyQualifiedName
 import scala.meta.internal.metals.testProvider.TestCaseEntry
@@ -31,36 +25,8 @@ import scala.meta.io.AbsolutePath
 class ScalatestTestFinder(
     trees: Trees,
     symbolIndex: mtags.GlobalSymbolIndex,
-    semanticdbs: () => mtags.Semanticdbs,
-    compilers: () => Compilers,
+    semanticdbs: SemanticdbsWithMbtFallback,
 ) {
-
-  /**
-   * Temporary, blocking fallback: `semanticdbs().textDocument(...)` only
-   * ever reads whatever semanticdb already happens to exist on disk, which
-   * is never the case for a base class belonging to a different MBT
-   * namespace/target that nothing has asked about yet. This forces
-   * generation via the PC, the same way MBT test-class confirmation does,
-   * so the cross-namespace inheritance chain can actually be followed.
-   */
-  private def generateSemanticdbSync(path: AbsolutePath): Option[TextDocument] =
-    try {
-      val documents = Await.result(
-        compilers().batchSemanticdbTextDocuments(
-          Seq(path),
-          EmptyCancelToken,
-          timeout = java.time.Duration.ofSeconds(20),
-          useFallbackCompiler = true,
-          shouldPruneSemanticdb = true,
-        ),
-        20.seconds,
-      )
-      documents.documents.find(_.uri.toAbsolutePath == path)
-    } catch {
-      case NonFatal(e) =>
-        scribe.warn(s"Failed to generate semanticdb on demand for $path", e)
-        None
-    }
 
   def findTests(
       doc: TextDocument,
@@ -99,10 +65,7 @@ class ScalatestTestFinder(
       case parentSymbol if !ScalatestStyle.baseSymbols.contains(parentSymbol) =>
         for {
           definition <- symbolIndex.definition(mtags.Symbol(parentSymbol))
-          doc <- semanticdbs()
-            .textDocument(definition.path)
-            .documentIncludingStale
-            .orElse(generateSemanticdbSync(definition.path))
+          doc <- semanticdbs.textDocumentWithMbtFallback(definition.path)
           style <- inferScalatestStyle(doc, mtags.Symbol(parentSymbol))
         } yield style
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/SemanticdbsWithMbtFallback.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/SemanticdbsWithMbtFallback.scala
@@ -1,0 +1,56 @@
+package scala.meta.internal.metals.testProvider.frameworks
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.Compilers
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.mbt.MbtBuildServer
+import scala.meta.internal.mtags.Semanticdbs
+import scala.meta.internal.semanticdb.TextDocument
+import scala.meta.io.AbsolutePath
+
+/**
+ * Wraps [[() => Semanticdbs]] with a blocking, on-demand presentation-compiler
+ * fallback for MBT, since we don't have access to any SemanticDb files on disk
+ */
+class SemanticdbsWithMbtFallback(
+    semanticdbs: () => Semanticdbs,
+    buildTargets: BuildTargets,
+    compilers: () => Compilers,
+) {
+
+  def textDocumentWithMbtFallback(path: AbsolutePath): Option[TextDocument] =
+    semanticdbs()
+      .textDocument(path)
+      .documentIncludingStale
+      .orElse(if (isMbt(path)) generateSemanticdbSync(path) else None)
+
+  private def isMbt(path: AbsolutePath): Boolean =
+    buildTargets
+      .inverseSources(path)
+      .flatMap(buildTargets.buildServerOf)
+      .exists(connection => MbtBuildServer.isMbtServer(connection.name))
+
+  private def generateSemanticdbSync(path: AbsolutePath): Option[TextDocument] =
+    try {
+      val documents = Await.result(
+        compilers().batchSemanticdbTextDocuments(
+          Seq(path),
+          EmptyCancelToken,
+          timeout = java.time.Duration.ofSeconds(20),
+          useFallbackCompiler = true,
+          shouldPruneSemanticdb = true,
+        ),
+        20.seconds,
+      )
+      documents.documents.find(_.uri.toAbsolutePath == path)
+    } catch {
+      case NonFatal(e) =>
+        scribe.warn(s"Failed to generate semanticdb on demand for $path", e)
+        None
+    }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/WeaverCatsEffectTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/WeaverCatsEffectTestFinder.scala
@@ -1,13 +1,12 @@
 package scala.meta.internal.metals.testProvider.frameworks
 
 import scala.meta.internal.mtags.GlobalSymbolIndex
-import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.parsing.Trees
 
 class WeaverCatsEffectTestFinder(
     trees: Trees,
     symbolIndex: GlobalSymbolIndex,
-    semanticdbs: () => Semanticdbs,
+    semanticdbs: SemanticdbsWithMbtFallback,
 ) extends MunitTestFinder(trees, symbolIndex, semanticdbs) {
   override protected val baseParentClasses: Set[String] =
     WeaverCatsEffectTestFinder.baseParentClasses

--- a/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
@@ -19,6 +19,7 @@ import scala.meta.internal.metals.ScalaTestSuites
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.debug.DebugWorkspaceLayout
 import scala.meta.internal.metals.mbt.MbtBuildServer
+import scala.meta.internal.metals.testProvider.TestExplorerEvent
 import scala.meta.internal.metals.{BuildInfo => V}
 import scala.meta.io.AbsolutePath
 
@@ -170,6 +171,47 @@ class BazelDapMbtLspSuite
     } yield {
       assertContains(output, "foo test")
       assert(!output.contains("bar test"), "unselected test must not have run")
+    }
+  }
+
+  test("bazel-mbt-scalatest-cross-namespace-fixture", maxRetry = 3) {
+    client.selectedServer = Messages.ChooseBuildServer.mbt
+    cleanWorkspace()
+
+    for {
+      _ <- initialize(
+        BazelBuildLayout(
+          crossFileFixtureLayout,
+          V.scala213,
+          bazelVersion,
+          List("org.scalatest:scalatest_2.13:3.2.19"),
+          includeScalatest = true,
+        ),
+        runAdditionalCommands = pinMaven,
+      )
+      _ <- server.headServer.connectionProvider.buildServerPromise.future
+      // Only the spec is opened here. `IndirectFixture` lives in a
+      // different file, whose semanticdb is never generated ahead of time.
+      // This reproduces the MBT bug where scalatest style inference couldn't
+      // follow inheritance across file boundaries.
+      _ <- server.didOpen("test/FooFixtureSpec.scala")
+      _ <- awaitMbtTestClassDiscovery("test/FooFixtureSpec.scala")
+      updates <- server.discoverTestSuites(
+        List("test/FooFixtureSpec.scala"),
+        uri = Some(server.toPath("test/FooFixtureSpec.scala").toURI.toString),
+      )
+    } yield {
+      val testCaseNames = for {
+        update <- updates
+        addTestCases <- update.events.asScala.collect {
+          case add: TestExplorerEvent.AddTestCases => add
+        }
+        testCase <- addTestCases.testCases.asScala
+      } yield testCase.name
+      assert(
+        testCaseNames.contains("A Foo should do foo test"),
+        s"expected test case not found, got: $testCaseNames",
+      )
     }
   }
 
@@ -409,6 +451,58 @@ class BazelDapMbtLspSuite
        |class FooSpec extends AnyFunSuite {
        |  test("foo test") { assert(true) }
        |  test("bar test") { fail("bar test must not run") }
+       |}
+       |""".stripMargin
+
+  private def crossFileFixtureLayout: String =
+    """|/.bazelproject
+       |targets:
+       |    //...
+       |
+       |/fixture/BUILD
+       |load("@rules_scala//scala:scala.bzl", "scala_library")
+       |
+       |scala_library(
+       |    name = "indirect_fixture",
+       |    srcs = ["IndirectFixture.scala"],
+       |    visibility = ["//visibility:public"],
+       |    deps = ["@maven//:org_scalatest_scalatest_2_13"],
+       |)
+       |
+       |/fixture/IndirectFixture.scala
+       |package fixture
+       |
+       |import org.scalatest.Outcome
+       |import org.scalatest.wordspec.FixtureAnyWordSpecLike
+       |
+       |trait IndirectFixture extends FixtureAnyWordSpecLike {
+       |  type FixtureParam = Unit
+       |  override def withFixture(test: OneArgTest): Outcome = test(())
+       |}
+       |
+       |/test/BUILD
+       |load("@rules_scala//scala:scala.bzl", "scala_test")
+       |
+       |scala_test(
+       |    name = "FooFixtureSpec",
+       |    srcs = ["FooFixtureSpec.scala"],
+       |    deps = [
+       |        "//fixture:indirect_fixture",
+       |        "@maven//:org_scalatest_scalatest_2_13",
+       |    ],
+       |)
+       |
+       |/test/FooFixtureSpec.scala
+       |package test
+       |
+       |import fixture.IndirectFixture
+       |
+       |class FooFixtureSpec extends IndirectFixture {
+       |  "A Foo" should {
+       |    "do foo test" in { _ =>
+       |      assert(true)
+       |    }
+       |  }
        |}
        |""".stripMargin
 


### PR DESCRIPTION
Previously for cases with indirect inheritance of ScalaTest style traits, individual test cases would not be found. This was because of the missing semanticDBs, which for MBT exist only for the file currently worked on by Metals (supplied via InteractiveSemanticDBs). This fixes it somewhat naively by generating the needed semanticDB's on demand. 

It works when I test manually , but I suspect it might be somewhat inperformant when exploring the whole repo to fill out TestExplorer. One improvement I could make it to walk through parents and batch the semanticDB compilations that way, but I don't really have any good ideas beyond that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test discovery for build configurations where semantic information is unavailable or stale.
  * Test suites can now be detected more reliably when they inherit fixtures across files or namespaces.
  * Enhanced support for ScalaTest, MUnit, and Weaver test frameworks in these scenarios.

* **Tests**
  * Added integration coverage for discovering ScalaTest cases with cross-file fixture inheritance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->