### PR TITLE
improvement: Only log warn when plugin jar doesn't exist

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerPlugins.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerPlugins.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals
 
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 
 import scala.collection.concurrent.TrieMap
 import scala.util.control.NonFatal
@@ -72,6 +73,9 @@ class CompilerPlugins {
             }
           }
         } catch {
+          case _: NoSuchFileException =>
+            scribe.warn(s"Could not find compiler plugin: $path")
+            false
           case NonFatal(e) =>
             scribe.error(path.toString(), e)
             false


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/8797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when compiler plugin files are unavailable.
  * Displays a warning and safely continues instead of failing during plugin support checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->