### PR TITLE
Lower javac release options to the metals JDK version

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
@@ -642,12 +642,9 @@ class CompilerConfiguration(
           _ <-
             if (jvmVersion.major < metalsJavaVersion.major) Some(())
             else if (metalsJavaVersion.major > jvmVersion.major) {
-              scribe.warn(
-                s"""|Your project uses JDK version ${jvmVersion.major} and
-                    |Metals server is running on JDK version ${metalsJavaVersion.major}.
-                    |This might cause incorrect completions, since
-                    |Metals JDK version should be greater or equal the project's JDK version.
-                    |""".stripMargin
+              CompilerConfiguration.warnJdkVersionMismatch(
+                jvmVersion.major,
+                metalsJavaVersion.major,
               )
               None
             } else None
@@ -688,8 +685,65 @@ object CompilerConfiguration {
     "-proc:",
   )
 
+  private val javaReleaseFlags =
+    Set("-source", "--source", "-target", "--target", "--release")
+  private val inlineJavaReleaseOption =
+    "(--(?:source|target|release)=)(.*)".r
+
   private[metals] def filterJavaPcOptions(options: List[String]): List[String] =
-    options.filterNot(option =>
-      excludedJavaPcOptionPrefixes.exists(option.startsWith)
+    clampJavaReleaseOptions(
+      options.filterNot(option =>
+        excludedJavaPcOptionPrefixes.exists(option.startsWith)
+      ),
+      Runtime.version().feature(),
+    )
+
+  private[metals] def clampJavaReleaseOptions(
+      options: List[String],
+      runtimeMajor: Int,
+  ): List[String] = {
+    val previousOptions = None :: options.map(Some(_))
+    val (clampedOptions, unsupportedVersions) =
+      options
+        .zip(previousOptions)
+        .map {
+          case (inlineJavaReleaseOption(flag, version), _) =>
+            val (clampedVersion, unsupportedVersion) =
+              clampJavaReleaseVersion(version, runtimeMajor)
+            (s"$flag$clampedVersion", unsupportedVersion)
+          case (version, Some(flag)) if javaReleaseFlags.contains(flag) =>
+            clampJavaReleaseVersion(version, runtimeMajor)
+          case (option, _) =>
+            (option, None)
+        }
+        .unzip
+
+    for (highest <- unsupportedVersions.flatten.maxOption) {
+      warnJdkVersionMismatch(highest, runtimeMajor)
+    }
+    clampedOptions
+  }
+
+  private def clampJavaReleaseVersion(
+      version: String,
+      runtimeMajor: Int,
+  ): (String, Option[Int]) =
+    JdkVersion.parse(version) match {
+      case Some(jdkVersion) if jdkVersion.major > runtimeMajor =>
+        (runtimeMajor.toString(), Some(jdkVersion.major))
+      case _ =>
+        (version, None)
+    }
+
+  private def warnJdkVersionMismatch(
+      projectJdk: Int,
+      metalsJdk: Int,
+  ): Unit =
+    scribe.warn(
+      s"""|Your project uses JDK version $projectJdk and
+          |Metals server is running on JDK version $metalsJdk.
+          |This might cause incorrect completions, since
+          |Metals JDK version should be greater than or equal to the project's JDK version.
+          |""".stripMargin
     )
 }

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/JavaPcOptionsSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/JavaPcOptionsSuite.scala
@@ -1,0 +1,63 @@
+package scala.meta.internal.metals
+
+import munit.TestOptions
+import tests.BaseSuite
+
+class JavaPcOptionsSuite extends BaseSuite {
+
+  private def check(
+      name: TestOptions,
+      options: List[String],
+      expected: List[String],
+      runtimeMajor: Int = 21,
+  ): Unit = {
+    test(name) {
+      assertEquals(
+        CompilerConfiguration.clampJavaReleaseOptions(options, runtimeMajor),
+        expected,
+      )
+    }
+  }
+
+  check(
+    "lower-source-and-target",
+    List("-source", "25", "-target", "25", "-encoding", "UTF-8"),
+    List("-source", "21", "-target", "21", "-encoding", "UTF-8"),
+  )
+  check("lower-release", List("--release", "25"), List("--release", "21"))
+  check(
+    "lower-gnu-style-flags",
+    List("--source", "25", "--target", "25"),
+    List("--source", "21", "--target", "21"),
+  )
+  check(
+    "lower-inline-flags",
+    List("--source=25", "--target=17", "--release=24"),
+    List("--source=21", "--target=17", "--release=21"),
+  )
+  check(
+    "lower-each-flag-independently",
+    List("-source", "17", "-target", "25"),
+    List("-source", "17", "-target", "21"),
+  )
+  check(
+    "lower-every-occurrence",
+    List("--release", "25", "-source", "17", "--release", "24"),
+    List("--release", "21", "-source", "17", "--release", "21"),
+  )
+  check(
+    "keep-older-release",
+    List("-source", "17", "-target", "17"),
+    List("-source", "17", "-target", "17"),
+  )
+  check(
+    "keep-matching-release",
+    List("--release", "21"),
+    List("--release", "21"),
+  )
+  check(
+    "keep-paths-containing-a-version",
+    List("-processorpath", "/tmp/errorprone-25.jar", "-source", "25"),
+    List("-processorpath", "/tmp/errorprone-25.jar", "-source", "21"),
+  )
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Java compiler options when configured versions exceed the running JDK.
  * Unsupported Java versions are now adjusted automatically, with a warning shown once for the highest affected version.
  * Improved warnings when the project JDK and running Metals JDK versions differ.
  * Matching project and runtime JDK versions are now handled correctly.

* **Tests**
  * Added coverage for Java source, target, and release options across supported and unsupported versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->