### PR TITLE
Filter Error Prone options from Java PC

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
@@ -679,10 +679,7 @@ class CompilerConfiguration(
 
 object CompilerConfiguration {
   private val excludedJavaPcOptionPrefixes = List(
-    "-J",
-    "@",
-    "-Xplugin:",
-    "-proc:",
+    "-J", "@", "-Xplugin:", "-Xep", "-proc:",
   )
 
   private val javaReleaseFlags =


### PR DESCRIPTION
```scala
2026-08-25 12:16:46.027 [info] 2026.08.25 12:16:45 WARN  compiler crashed due to an error in the Java compiler: java.lang.IllegalArgumentException: error: invalid flag: -Xep:NullAway:WARN, retrying with new compiler instance.
java.lang.IllegalArgumentException: error: invalid flag: -Xep:NullAway:WARN
	at com.sun.tools.javac.main.Arguments.reportDiag(Arguments.java:886)
	at com.sun.tools.javac.main.Arguments.doProcessArgs(Arguments.java:396)
	at com.sun.tools.javac.main.Arguments.processArgs(Arguments.java:348)
	at com.sun.tools.javac.main.Arguments.init(Arguments.java:247)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Java compiler options by excluding `-Xep` options from presentation compiler configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->