### PR TITLE
bugfix: fix selecting single test cases in MBT build tools

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -262,7 +262,7 @@ case class BazelBuildTool(
       } else {
         val testFilter = suites.flatMap { suite =>
           val className = suite.getClassName
-          val tests = MbtDebugLauncher.listOrNil(suite.getTests)
+          val tests = MbtDebugLauncher.testFilterNames(suite, framework)
           if (tests.isEmpty) List(className)
           else tests.map(test => s"$className#$test")
         }

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -269,7 +269,7 @@ case class GradleBuildTool(
       framework: Option[TestFramework] = None,
   ): Future[List[String]] =
     Future.successful(
-      gradleTestCommand(target, testSuites, debugAgentFlag = None)
+      gradleTestCommand(target, testSuites, debugAgentFlag = None, framework)
     )
 
   override def mbtTestDebugCommand(
@@ -281,7 +281,7 @@ case class GradleBuildTool(
       framework: Option[TestFramework] = None,
   ): Future[List[String]] =
     Future.successful(
-      gradleTestCommand(target, testSuites, Some(debugAgentFlag))
+      gradleTestCommand(target, testSuites, Some(debugAgentFlag), framework)
     )
 
   override def supportsForkedTestDebug: Boolean = true
@@ -296,7 +296,7 @@ case class GradleBuildTool(
     val debugAgentFlag =
       s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$port"
     Future.successful(
-      gradleTestCommand(target, testSuites, Some(debugAgentFlag))
+      gradleTestCommand(target, testSuites, Some(debugAgentFlag), framework)
     )
   }
 
@@ -304,6 +304,7 @@ case class GradleBuildTool(
       target: MbtTarget,
       testSuites: ScalaTestSuites,
       debugAgentFlag: Option[String],
+      framework: Option[TestFramework],
   ): List[String] = {
     val jvmOptions =
       debugAgentFlag.toList ::: MbtDebugLauncher.listOrNil(
@@ -316,16 +317,17 @@ case class GradleBuildTool(
       "--console=plain"
     ) ::: initScriptArgs ::: List(
       gradleTask(target, "test")
-    ) ::: gradleTestFilterArgs(testSuites)
+    ) ::: gradleTestFilterArgs(testSuites, framework)
   }
 
   private def gradleTestFilterArgs(
-      testSuites: ScalaTestSuites
+      testSuites: ScalaTestSuites,
+      framework: Option[TestFramework],
   ): List[String] = {
     val filters =
       MbtDebugLauncher.listOrNil(testSuites.getSuites).flatMap { suite =>
         val className = suite.getClassName
-        val tests = MbtDebugLauncher.listOrNil(suite.getTests)
+        val tests = MbtDebugLauncher.testFilterNames(suite, framework)
         if (tests.isEmpty) List(className)
         else tests.map(test => s"$className.$test")
       }

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -269,7 +269,12 @@ case class GradleBuildTool(
       framework: Option[TestFramework] = None,
   ): Future[List[String]] =
     Future.successful(
-      gradleTestCommand(target, testSuites, debugAgentFlag = None, framework)
+      gradleTestCommand(
+        target,
+        testSuites,
+        debugAgentFlag = None,
+        framework = framework,
+      )
     )
 
   override def mbtTestDebugCommand(

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -179,6 +179,7 @@ case class MavenBuildTool(
         mbtMavenBaseCommand(workspace),
         target,
         testSuites,
+        framework,
       )
     )
 
@@ -190,9 +191,13 @@ case class MavenBuildTool(
       sourceFiles: Seq[AbsolutePath],
       framework: Option[TestFramework] = None,
   ): Future[List[String]] =
-    mbtTestDebugCommandWithPort(workspace, target, testSuites, sourceFiles)(
-      5005
-    )
+    mbtTestDebugCommandWithPort(
+      workspace,
+      target,
+      testSuites,
+      sourceFiles,
+      framework,
+    )(5005)
 
   override def supportsForkedTestDebug: Boolean = true
 
@@ -212,6 +217,7 @@ case class MavenBuildTool(
         mbtMavenBaseCommand(workspace),
         target,
         testSuites,
+        framework,
         forkedDebugAgentFlag = Some(debugAgentFlag),
       )
     )
@@ -221,6 +227,7 @@ case class MavenBuildTool(
       baseCommand: List[String],
       target: MbtTarget,
       testSuites: ScalaTestSuites,
+      framework: Option[TestFramework],
       forkedDebugAgentFlag: Option[String] = None,
   ): List[String] = {
     val moduleArgs =
@@ -234,7 +241,7 @@ case class MavenBuildTool(
     val suites = MbtDebugLauncher.listOrNil(testSuites.getSuites)
     val testFilter = suites.flatMap { suite =>
       val className = suite.getClassName
-      val tests = MbtDebugLauncher.listOrNil(suite.getTests)
+      val tests = MbtDebugLauncher.testFilterNames(suite, framework)
       if (tests.isEmpty) List(className)
       else tests.map(test => s"$className#$test")
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -805,14 +805,16 @@ class DebugProvider(
   )(implicit ec: ExecutionContext): Future[DebugSessionParams] = {
     def makeDebugSession() = {
       val jvmOpts = JvmOpts.fromWorkspaceOrEnvForTest(workspace).getOrElse(Nil)
+      val escapesTestNames =
+        !buildTargets.buildServerOf(request.target).exists(_.isMbt)
       val debugSession =
         if (supportsTestSelection(request.target)) {
           val testSuites =
             request.requestData.copy(
               suites = request.requestData.suites.map { suite =>
                 testProvider.getFramework(buildTarget, suite) match {
-                  case Config.TestFramework.JUnit |
-                      Config.TestFramework.munit =>
+                  case Config.TestFramework.JUnit | Config.TestFramework.munit
+                      if escapesTestNames =>
                     suite.copy(tests = suite.tests.map(escapeTestName))
                   case _ => suite
                 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugLauncher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugLauncher.scala
@@ -8,6 +8,7 @@ import scala.meta.io.AbsolutePath
 
 import bloop.config.Config.TestFramework
 import ch.epfl.scala.bsp4j.ScalaMainClass
+import ch.epfl.scala.bsp4j.ScalaTestSuiteSelection
 import ch.epfl.scala.bsp4j.ScalaTestSuites
 
 trait MbtDebugLauncher { self: BuildTool =>
@@ -84,4 +85,23 @@ object MbtDebugLauncher {
 
   def listOrNil[A](l: java.util.List[A]): List[A] =
     if (l == null) Nil else l.asScala.toList
+
+  /**
+   * Test case names of a suite, ready to be put into a build tool's test filter.
+   *
+   * JUnit 5 cases are discovered as `method()`, because that is how
+   * jupiter-interface reports them and how the client identifies them. Build
+   * tool filters (bazel `--test_filter`, gradle `--tests`, maven `-Dtest`) all
+   * match the bare method name, so the parentheses have to be dropped. Only for
+   * JUnit, since test names of the other frameworks are free-form strings that
+   * may legitimately end with `()`.
+   */
+  def testFilterNames(
+      suite: ScalaTestSuiteSelection,
+      framework: Option[TestFramework],
+  ): List[String] = {
+    val tests = listOrNil(suite.getTests)
+    if (framework.contains(TestFramework.JUnit)) tests.map(_.stripSuffix("()"))
+    else tests
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test filtering for Bazel, Gradle, and Maven projects by applying framework-specific test names.
  * Fixed JUnit test selection by removing unnecessary trailing `()` where appropriate.
  * Preserved original test names for supported frameworks and build-server targets.
  * Improved test selection consistency across normal and debug test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->