### PR TITLE
improvement: Reuse Turbine to confirm Java test classes

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -854,15 +854,19 @@ final class BuildTargetClasses(
     if (!hasCandidates) {
       Future.unit
     } else {
-      foreachMbtSemanticdbDocument(Seq(path)) { doc =>
-        processMbtTestSemanticdb(doc.uri.toAbsolutePath, doc, targetIds)
-      }
+      confirmMbtTestClassCandidatePaths(
+        Seq(path),
+        _ => targetIds,
+      )
     }
   }
 
   /**
    * Confirms candidate test classes for specific targets.
    * This is useful when the user opens the test explorer and wants to discover all tests.
+   *
+   * Java candidates are confirmed from Turbine class info. Scala candidates still
+   * go through semanticdb.
    *
    * @param targetIds The build targets to confirm candidates for
    * @return Future that completes when confirmation is done
@@ -881,16 +885,39 @@ final class BuildTargetClasses(
     if (distinctPaths.isEmpty) {
       Future.unit
     } else {
-      foreachMbtSemanticdbDocument(distinctPaths) { doc =>
-        val docPath = doc.uri.toAbsolutePath
-        val docTargetIds = buildTargets.inverseSourcesAll(docPath)
-        processMbtTestSemanticdb(
-          docPath,
-          doc,
-          docTargetIds.filter(targetIds.contains),
+      confirmMbtTestClassCandidatePaths(
+        distinctPaths,
+        path => buildTargets.inverseSourcesAll(path).filter(targetIds.contains),
+      )
+    }
+  }
+
+  private def confirmMbtTestClassCandidatePaths(
+      paths: Seq[AbsolutePath],
+      targetsForPath: AbsolutePath => Seq[b.BuildTargetIdentifier],
+  ): Future[Unit] = {
+    val (javaPaths, otherPaths) = paths.partition(_.isJava)
+    val javaConfirmation = Future {
+      for (path <- javaPaths) {
+        storeConfirmedTestClasses(
+          path,
+          extractTestClassesFromTurbine(path),
+          targetsForPath(path),
         )
       }
     }
+    val otherConfirmation =
+      if (otherPaths.isEmpty) Future.unit
+      else
+        foreachMbtSemanticdbDocument(otherPaths) { doc =>
+          val docPath = doc.uri.toAbsolutePath
+          processMbtTestSemanticdb(
+            docPath,
+            doc,
+            targetsForPath(docPath),
+          )
+        }
+    javaConfirmation.flatMap(_ => otherConfirmation)
   }
 
   /**
@@ -903,17 +930,45 @@ final class BuildTargetClasses(
       targetIds: Seq[b.BuildTargetIdentifier],
   ): Future[Unit] = {
     extractTestClassesFromDocument(doc, docPath).map { testClasses =>
-      for {
-        tid <- targetIds
-        classes <- index.get(tid)
-      } {
-        // Remove candidates for this path
-        classes.clearCandidateTestClasses(docPath)
+      storeConfirmedTestClasses(docPath, testClasses, targetIds)
+    }
+  }
 
-        // Extract and store confirmed test classes
-        for ((symbol, testInfo) <- testClasses) {
-          classes.putTestClass(symbol, testInfo, docPath)
+  private def extractTestClassesFromTurbine(
+      path: AbsolutePath
+  ): List[(String, TestSymbolInfo)] =
+    mbt() match {
+      case None => Nil
+      case Some(mbtProvider) =>
+        val result = mutable.LinkedHashMap.empty[String, TestSymbolInfo]
+        for {
+          info <- mbtProvider.classInfo(path)
+          annotation <- info.memberDefsAnnotations
+          framework <- TestFrameworkDetector.fromSymbol(annotation)
+        } {
+          result.put(
+            info.symbol,
+            TestSymbolInfo(
+              symbolToClassName(info.symbol),
+              framework,
+            ),
+          )
         }
+        result.toList
+    }
+
+  private def storeConfirmedTestClasses(
+      path: AbsolutePath,
+      testClasses: List[(String, TestSymbolInfo)],
+      targetIds: Seq[b.BuildTargetIdentifier],
+  ): Unit = {
+    for {
+      tid <- targetIds
+      classes <- index.get(tid)
+    } {
+      classes.clearCandidateTestClasses(path)
+      for ((symbol, testInfo) <- testClasses) {
+        classes.putTestClass(symbol, testInfo, path)
       }
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -943,7 +943,7 @@ final class BuildTargetClasses(
         val result = mutable.LinkedHashMap.empty[String, TestSymbolInfo]
         for {
           info <- mbtProvider.classInfo(path)
-          annotation <- info.memberDefsAnnotations
+          annotation <- info.memberDefsAnnotations ++ info.annotations
           framework <- TestFrameworkDetector.fromSymbol(annotation)
         } {
           result.put(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -56,6 +56,7 @@ import scala.meta.internal.metals.WorkspaceSymbolQuery
 import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.Symbol
+import scala.meta.internal.pc.PcSymbolInformation
 import scala.meta.internal.tokenizers.UnexpectedInputEndException
 import scala.meta.io.AbsolutePath
 import scala.meta.metals.MetalsLanguageServer
@@ -814,6 +815,58 @@ class MbtWorkspaceSymbolProvider(
 
     allMatchedPaths.toSet
   }
+
+  /**
+   * Turbine-backed class information for Java types declared in `path`.
+   * Empty for non-Java files, files that are not in the index, or classes
+   * that have not been header-compiled yet.
+   *
+   * Returned [[PcSymbolInformation]] uses SemanticDB symbol strings for
+   * `annotations`, including both class-level and method-level annotations
+   * (e.g. `org/junit/Test#`).
+   */
+  def classInfo(path: AbsolutePath): Seq[PcSymbolInformation] = {
+    if (!path.isJava) {
+      scribe.warn(s"mbt-v2: classInfo not supported for non-Java files: $path")
+      Nil
+    } else {
+      documents.get(path) match {
+        case None =>
+          scribe.warn(s"mbt-v2: classInfo not found in index: $path")
+          Nil
+        case Some(doc) =>
+          val result = turbineCompiler.result
+          doc.symbols.flatMap { symbolInfo =>
+            if (!isClassLikeKind(symbolInfo.getKind())) Nil
+            else {
+              val symbol = symbolInfo.getSymbol()
+              try {
+                result
+                  .boundClass(Symbol(symbol).binaryName)
+                  .map { bound =>
+                    TurbineSymbolInfo.fromBoundClass(symbol, bound)
+                  }
+                  .toSeq
+              } catch {
+                case NonFatal(e) =>
+                  scribe.debug(
+                    s"turbine classInfo failed for $symbol in $path: ${e.getMessage}"
+                  )
+                  Nil
+              }
+            }
+          }.toSeq
+      }
+    }
+  }
+
+  private def isClassLikeKind(
+      kind: Semanticdb.SymbolInformation.Kind
+  ): Boolean =
+    kind == Semanticdb.SymbolInformation.Kind.CLASS ||
+      kind == Semanticdb.SymbolInformation.Kind.INTERFACE ||
+      kind == Semanticdb.SymbolInformation.Kind.OBJECT ||
+      kind == Semanticdb.SymbolInformation.Kind.TRAIT
 
   /**
    * Extracts potential test class candidates from the MBT index without loading semanticdb.

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompileResult.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineCompileResult.scala
@@ -3,12 +3,20 @@ package scala.meta.internal.metals.mbt
 import java.nio.file.Files
 import java.util.ArrayList
 import java.util.HashMap
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.util.control.NonFatal
 
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.MetalsEnrichments.XtensionAbsolutePathBuffers
 import scala.meta.io.AbsolutePath
 
+import com.google.common.collect.ImmutableMap
 import com.google.turbine.binder.ClassPath
+import com.google.turbine.binder.JimageClassBinder
+import com.google.turbine.binder.bytecode.BytecodeBoundClass
+import com.google.turbine.binder.env.CompoundEnv
+import com.google.turbine.binder.env.Env
 import com.google.turbine.binder.sym.ClassSymbol
 import com.google.turbine.lower.Lower
 
@@ -16,6 +24,26 @@ case class TurbineCompileResult(
     classpath: ClassPath,
     lowered: Lower.Lowered,
 ) {
+
+  /**
+   * Environment over workspace classfiles produced by Turbine, then the
+   * compilation classpath, then the JDK. Used to look up [[BytecodeBoundClass]]
+   * for a binary name.
+   */
+  lazy val boundEnv: Env[ClassSymbol, BytecodeBoundClass] = {
+    val loweredEnv = new TurbineCompileResult.LoweredBytesEnv(lowered.bytes())
+    val env: Env[ClassSymbol, BytecodeBoundClass] =
+      CompoundEnv
+        .of(TurbineCompileResult.jimageEnv)
+        .append(classpath.env())
+        .append(loweredEnv)
+    loweredEnv.setParent(env)
+    env
+  }
+
+  def boundClass(binaryName: String): Option[BytecodeBoundClass] =
+    Option(boundEnv.get(new ClassSymbol(binaryName)))
+
   val symbolsByPackage: collection.Map[String, ArrayList[ClassSymbol]] = {
     val x = new HashMap[String, ArrayList[ClassSymbol]]()
     lowered.symbols().forEach { sym =>
@@ -48,6 +76,55 @@ case class TurbineCompileResult(
       javapOutput
     } finally {
       AbsolutePath(tmp).deleteRecursively()
+    }
+  }
+}
+
+object TurbineCompileResult {
+  private lazy val jimageEnv: Env[ClassSymbol, BytecodeBoundClass] =
+    try JimageClassBinder.bindDefault().env()
+    catch {
+      case NonFatal(e) =>
+        scribe.warn(
+          s"turbine: failed to bind jimage classpath: ${e.getMessage}"
+        )
+        emptyEnv
+    }
+
+  private val emptyEnv: Env[ClassSymbol, BytecodeBoundClass] =
+    new Env[ClassSymbol, BytecodeBoundClass] {
+      override def get(sym: ClassSymbol): BytecodeBoundClass = null
+    }
+
+  /**
+   * Looks up workspace classes from Turbine's lowered classfile bytes. Parent
+   * env (JDK + jars + this env) is set after construction so [[BytecodeBoundClass]]
+   * can resolve supertypes.
+   */
+  private class LoweredBytesEnv(
+      bytes: ImmutableMap[String, Array[Byte]]
+  ) extends Env[ClassSymbol, BytecodeBoundClass] {
+    private var parent: Env[ClassSymbol, BytecodeBoundClass] = emptyEnv
+    private val cache =
+      new ConcurrentHashMap[ClassSymbol, BytecodeBoundClass]()
+
+    def setParent(env: Env[ClassSymbol, BytecodeBoundClass]): Unit =
+      parent = env
+
+    override def get(sym: ClassSymbol): BytecodeBoundClass = {
+      val classBytes = bytes.get(sym.binaryName())
+      if (classBytes == null) null
+      else
+        cache.computeIfAbsent(
+          sym,
+          s =>
+            new BytecodeBoundClass(
+              s,
+              () => classBytes,
+              parent,
+              /* jarFile = */ null,
+            ),
+        )
     }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineSymbolInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/TurbineSymbolInfo.scala
@@ -1,0 +1,87 @@
+package scala.meta.internal.metals.mbt
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+import scala.meta.internal.pc.PcSymbolInformation
+import scala.meta.pc.PcSymbolKind
+import scala.meta.pc.PcSymbolProperty
+
+import com.google.turbine.`type`.AnnoInfo
+import com.google.turbine.binder.bound.TypeBoundClass
+import com.google.turbine.binder.sym.ClassSymbol
+import com.google.turbine.model.TurbineFlag
+import com.google.turbine.model.TurbineTyKind
+
+object TurbineSymbolInfo {
+
+  /**
+   * SemanticDB class symbol for a JVMS binary name.
+   * `com/foo/Bar` -> `com/foo/Bar#`, `com/foo/Outer$Inner` -> `com/foo/Outer#Inner#`.
+   */
+  def classSymbolToSemanticdb(binaryName: String): String = {
+    val slash = binaryName.lastIndexOf('/')
+    val pkg = if (slash < 0) "" else binaryName.substring(0, slash + 1)
+    val simple =
+      if (slash < 0) binaryName else binaryName.substring(slash + 1)
+    pkg + simple.replace('$', '#') + "#"
+  }
+
+  def fromBoundClass(
+      symbol: String,
+      cls: TypeBoundClass,
+  ): PcSymbolInformation = {
+    val parentSemanticdb =
+      directParents(cls).map(s => classSymbolToSemanticdb(s.binaryName()))
+    PcSymbolInformation(
+      symbol = symbol,
+      kind = pcKind(cls),
+      parents = parentSemanticdb,
+      dealiasedSymbol = symbol,
+      classOwner =
+        Option(cls.owner()).map(o => classSymbolToSemanticdb(o.binaryName())),
+      overriddenSymbols = Nil,
+      alternativeSymbols = Nil,
+      properties =
+        if ((cls.access() & TurbineFlag.ACC_ABSTRACT) != 0)
+          List(PcSymbolProperty.ABSTRACT)
+        else Nil,
+      recursiveParents = Nil,
+      annotations = annotationSymbols(
+        cls.annotations().asScala
+      ),
+      memberDefsAnnotations = annotationSymbols(
+        cls.methods().asScala.flatMap(_.annotations().asScala)
+      ),
+      typeParameters = cls
+        .typeParameters()
+        .keySet()
+        .asScala
+        .map(name => s"$symbol[$name]")
+        .toList,
+    )
+  }
+
+  private def pcKind(cls: TypeBoundClass): PcSymbolKind =
+    cls.kind() match {
+      case TurbineTyKind.INTERFACE | TurbineTyKind.ANNOTATION =>
+        PcSymbolKind.INTERFACE
+      case TurbineTyKind.CLASS | TurbineTyKind.ENUM | TurbineTyKind.RECORD =>
+        PcSymbolKind.CLASS
+    }
+
+  private def annotationSymbols(
+      annotations: Iterable[AnnoInfo]
+  ): List[String] =
+    annotations
+      .map(anno => classSymbolToSemanticdb(anno.sym().binaryName()))
+      .toList
+      .distinct
+
+  private def directParents(cls: TypeBoundClass): List[ClassSymbol] = {
+    val result = mutable.ArrayBuffer.empty[ClassSymbol]
+    Option(cls.superclass()).foreach(result += _)
+    cls.interfaces().asScala.foreach(result += _)
+    result.toList
+  }
+}

--- a/tests/unit/src/test/scala/tests/mbt/TurbineClassInfoSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/TurbineClassInfoSuite.scala
@@ -1,0 +1,213 @@
+package tests.mbt
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+import scala.meta.internal.metals.Configs
+import scala.meta.internal.metals.mbt.IndexingStats
+import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
+import scala.meta.internal.metals.mbt.TurbineSymbolInfo
+import scala.meta.internal.pc.PcSymbolInformation
+import scala.meta.pc.PcSymbolKind
+
+import munit.AnyFixture
+import tests.FileLayout
+import tests.TemporaryDirectoryFixture
+
+class TurbineClassInfoSuite extends munit.FunSuite {
+  val workspace = new TemporaryDirectoryFixture()
+  override def munitFixtures: Seq[AnyFixture[_]] = List(workspace)
+  override def munitExecutionContext: ExecutionContext = ExecutionContext.global
+
+  def newProvider(): MbtWorkspaceSymbolProvider =
+    new MbtWorkspaceSymbolProvider(
+      workspace(),
+      config = () => Configs.WorkspaceSymbolProviderConfig.mbt,
+    )(munitExecutionContext)
+
+  def reindex(provider: MbtWorkspaceSymbolProvider): IndexingStats = {
+    workspace.executeCommand("git init -b main")
+    workspace.gitCommitAllChanges()
+    provider.onReindex().awaitBackgroundJobs(30.seconds)
+  }
+
+  def infoFor(
+      provider: MbtWorkspaceSymbolProvider,
+      relativePath: String,
+      symbol: String,
+  ): PcSymbolInformation = {
+    val infos = provider.classInfo(workspace().resolve(relativePath))
+    infos.find(_.symbol == symbol).getOrElse {
+      fail(
+        s"no classInfo for $symbol in $relativePath, found: ${infos.map(_.symbol).mkString(", ")}"
+      )
+    }
+  }
+
+  test("class-symbol-to-semanticdb") {
+    assertEquals(
+      TurbineSymbolInfo.classSymbolToSemanticdb("com/foo/Bar"),
+      "com/foo/Bar#",
+    )
+    assertEquals(
+      TurbineSymbolInfo.classSymbolToSemanticdb("com/foo/Outer$Inner"),
+      "com/foo/Outer#Inner#",
+    )
+    assertEquals(
+      TurbineSymbolInfo.classSymbolToSemanticdb("org/junit/Test"),
+      "org/junit/Test#",
+    )
+  }
+
+  test("java-class-parents-and-kind") {
+    FileLayout.fromString(
+      """|/com/Hello.java
+         |package com;
+         |public class Hello {}
+         |""".stripMargin,
+      root = workspace(),
+    )
+    val provider = newProvider()
+    reindex(provider)
+    val info = infoFor(provider, "com/Hello.java", "com/Hello#")
+    assertEquals(info.kind, PcSymbolKind.CLASS)
+    assertEquals(info.dealiasedSymbol, "com/Hello#")
+    assert(info.parents.contains("java/lang/Object#"))
+    assertEquals(info.recursiveParents, Nil)
+    assertEquals(info.annotations, Nil)
+    assertEquals(info.memberDefsAnnotations, Nil)
+  }
+
+  test("java-interface-is-abstract") {
+    FileLayout.fromString(
+      """|
+         |/com/Named.java
+         |package com;
+         |public interface Named {
+         |  String name();
+         |}
+         |""".stripMargin,
+      root = workspace(),
+    )
+    val provider = newProvider()
+    reindex(provider)
+    val info = infoFor(provider, "com/Named.java", "com/Named#")
+    assertEquals(info.kind, PcSymbolKind.INTERFACE)
+    assertNoDiff(
+      info.properties.mkString("\n"),
+      """|
+         |ABSTRACT
+         |""".stripMargin,
+    )
+  }
+
+  test("nested-class-and-type-parameters") {
+    FileLayout.fromString(
+      """|
+         |/com/Box.java
+         |package com;
+         |public class Box<T> {
+         |  public static class Inner {}
+         |}
+         |""".stripMargin,
+      root = workspace(),
+    )
+    val provider = newProvider()
+    reindex(provider)
+    val box = infoFor(provider, "com/Box.java", "com/Box#")
+    assertNoDiff(
+      box.typeParameters.mkString("\n"),
+      """|
+         |com/Box#[T]
+         |""".stripMargin,
+    )
+    val inner = infoFor(provider, "com/Box.java", "com/Box#Inner#")
+    assertNoDiff(
+      inner.classOwner.getOrElse(""),
+      "com/Box#",
+    )
+  }
+
+  test("extends-workspace-class") {
+    FileLayout.fromString(
+      """|
+         |/com/Base.java
+         |package com;
+         |public class Base {}
+         |/com/Child.java
+         |package com;
+         |public class Child extends Base {}
+         |""".stripMargin,
+      root = workspace(),
+    )
+    val provider = newProvider()
+    reindex(provider)
+    val info = infoFor(provider, "com/Child.java", "com/Child#")
+    assertNoDiff(
+      info.parents.mkString("\n"),
+      """|
+         |com/Base#
+         |""".stripMargin,
+    )
+    assertNoDiff(
+      info.recursiveParents.mkString("\n"),
+      "",
+    )
+  }
+
+  test("junit-test-method-annotation") {
+    FileLayout.fromString(
+      """|
+         |/org/junit/Test.java
+         |package org.junit;
+         |import java.lang.annotation.ElementType;
+         |import java.lang.annotation.Retention;
+         |import java.lang.annotation.RetentionPolicy;
+         |import java.lang.annotation.Target;
+         |@Retention(RetentionPolicy.RUNTIME)
+         |@Target(ElementType.METHOD)
+         |public @interface Test {}
+         |/com/MyTest.java
+         |package com;
+         |import org.junit.Test;
+         |@Deprecated
+         |public class MyTest {
+         |  @Test
+         |  public void runs() {}
+         |}""".stripMargin,
+      root = workspace(),
+    )
+    val provider = newProvider()
+    reindex(provider)
+    val info = infoFor(provider, "com/MyTest.java", "com/MyTest#")
+    assertNoDiff(
+      info.annotations.mkString("\n"),
+      """|
+         |java/lang/Deprecated#
+         |""".stripMargin,
+    )
+    assertNoDiff(
+      info.memberDefsAnnotations.mkString("\n"),
+      """|
+         |org/junit/Test#
+         |""".stripMargin,
+    )
+  }
+
+  test("scala-file-returns-empty") {
+    FileLayout.fromString(
+      """|
+         |/com/Hello.scala
+         |package com
+         |class Hello
+         |""".stripMargin,
+      root = workspace(),
+    )
+    val provider = newProvider()
+    reindex(provider)
+    assertEquals(
+      provider.classInfo(workspace().resolve("com/Hello.scala")),
+      Nil,
+    )
+  }
+}


### PR DESCRIPTION
This makes it much faster. On trino codebase it now takse a few seconds instead of a minute.

This is based on the same concept as getting .info from the ScalaPresentationCompiler, but instead I decided to implement it for Java with Turbine.

This is complementary to https://github.com/scalameta/metals/pull/8814 and we can probably make the detection in Bazel have less false positives at least for Java.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Java class and interface indexing, including inheritance, nested classes, type parameters, and annotations.
  * Enhanced workspace symbol information for indexed Java sources.
  * Improved recognition and confirmation of Java test classes.

* **Bug Fixes**
  * Java symbols are now resolved more reliably across workspace, dependency, and JDK classes.
  * Non-Java files continue using existing semantic information.

* **Tests**
  * Added coverage for Java symbol metadata, reindexing, inheritance, and Scala-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->