### PR TITLE
improvement: support for kyo-test

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -539,6 +539,11 @@ object TestFrameworkSymbolRegistry {
       .map(_ -> TestFrameworkUtils.ZioTestFramework)
       .toMap
 
+  private lazy val kyoTestSymbols: Map[String, TestFramework] =
+    TestFrameworkUtils.kyoTestBaseClasses
+      .map(_ -> TestFrameworkUtils.KyoTestFramework)
+      .toMap
+
   private lazy val junitSymbols: Map[String, TestFramework] = Set(
     JunitTestFinder.junitBaseClassSymbol,
     JunitTestFinder.junitAnnotationSymbol,
@@ -557,6 +562,7 @@ object TestFrameworkSymbolRegistry {
       munitSymbols ++
       weaverSymbols ++
       zioTestSymbols ++
+      kyoTestSymbols ++
       junitSymbols ++
       testngSymbols
 
@@ -572,6 +578,18 @@ object TestFrameworkUtils {
 
   val ZioTestFramework: TestFramework = TestFramework(
     List("zio.test.sbt.ZTestFramework")
+  )
+
+  val KyoTestFramework: TestFramework = TestFramework(
+    List("kyo.test.runner.SbtFramework")
+  )
+
+  /** `SuiteFingerprintMarker` is what kyo-test's own sbt fingerprint matches. */
+  val kyoTestBaseClasses: Set[String] = Set(
+    "kyo/test/SuiteFingerprintMarker#",
+    "kyo/test/Test#",
+    "kyo/test/prop/PropertyTest#",
+    "kyo/test/snapshot/SnapshotTest#",
   )
 
   private lazy val supportedFrameworks = Set(
@@ -591,6 +609,7 @@ object TestFrameworkUtils {
       case "weaver-cats-effect" => WeaverTestFramework
       case "TestNG" => TestFramework.TestNG
       case x if x.contains("ZIO Test") => ZioTestFramework
+      case "kyo-test" => KyoTestFramework
       case _ => TestFramework(Nil)
     }
     .getOrElse(TestFramework(Nil))

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -328,7 +328,7 @@ object QuickBuild {
    * Bump up this version in case the JSON generation algorithm changes
    * A new version triggers re-generation of QuickBuild files.
    */
-  val version = "v3"
+  val version = "v4"
   def toDependency(
       module: String,
       scalaVersion: String,

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -319,6 +319,9 @@ object QuickBuild {
     "dev.zio::zio-test-sbt" -> Config.TestFramework(
       List("zio.test.sbt.ZTestFramework")
     ),
+    "io.getkyo::kyo-test-runner" -> Config.TestFramework(
+      List("kyo.test.runner.SbtFramework")
+    ),
   )
 
   /**

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -2,6 +2,7 @@ package tests.testProvider
 
 import scala.concurrent.Future
 
+import scala.meta.internal.metals.{BuildInfo => V}
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
@@ -141,6 +142,47 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       )
     },
   )
+
+  // kyo-test ships JDK 25 bytecode, so the build server must run on JDK 25+.
+  if (isJava25)
+    testDiscover(
+      "single-kyo-test",
+      List(
+        "io.getkyo::kyo-test-api:1.0.0-RC6",
+        "io.getkyo::kyo-test-runner:1.0.0-RC6",
+        "io.getkyo::kyo-core:1.0.0-RC6",
+      ),
+      s"""|
+          |/app/src/main/scala/a/b/KyoTestSuite.scala
+          |package a.b
+          |
+          |import kyo.test.Test
+          |
+          |class KyoTestSuite extends Test[Any]
+          |""".stripMargin,
+      List("app/src/main/scala/a/b/KyoTestSuite.scala"),
+      () => {
+        List(
+          rootBuildTargetUpdate(
+            "app",
+            targetUri,
+            List[TestExplorerEvent](
+              AddTestSuite(
+                "a.b.KyoTestSuite",
+                "KyoTestSuite",
+                "a/b/KyoTestSuite#",
+                QuickLocation(
+                  classUriFor("app/src/main/scala/a/b/KyoTestSuite.scala"),
+                  (4, 6, 4, 18),
+                ).toLsp,
+                canResolveChildren = false,
+              )
+            ).asJava,
+          )
+        )
+      },
+      scalaVersion = V.latestScala3Next,
+    )
 
   testDiscover(
     "multiple-suites",
@@ -1230,6 +1272,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       files: List[String],
       expected: () => List[BuildTargetUpdate],
       uri: () => Option[String] = () => None,
+      scalaVersion: String = BuildInfo.scalaVersion,
   )(implicit
       loc: munit.Location
   ): Unit = {
@@ -1238,7 +1281,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
           |{
           |  "app": {
           |    "libraryDependencies" : ${getDependenciesArray(dependencies)},
-          |    "scalaVersion": "${BuildInfo.scalaVersion}"
+          |    "scalaVersion": "$scalaVersion"
           |  }
           |}
           |$layout

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -2,7 +2,6 @@ package tests.testProvider
 
 import scala.concurrent.Future
 
-import scala.meta.internal.metals.{BuildInfo => V}
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
@@ -12,6 +11,7 @@ import scala.meta.internal.metals.testProvider.BuildTargetUpdate
 import scala.meta.internal.metals.testProvider.TestCaseEntry
 import scala.meta.internal.metals.testProvider.TestExplorerEvent
 import scala.meta.internal.metals.testProvider.TestExplorerEvent._
+import scala.meta.internal.metals.{BuildInfo => V}
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder


### PR DESCRIPTION
I've only manually tested it with a locally published mcp binary, but I guess it should also work for editors as well. Implemented against the latest `kyo-test 1.0.0-RC6` version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the kyo-test framework in Scala test debugging.
  * kyo-test builds are now recognized automatically, including their test base classes and runner configuration.
  * Added test discovery support for kyo-test suites on compatible Java and Scala versions.
  * Existing workspaces automatically refresh their build configuration to enable kyo-test support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->