### PR TITLE
feat(mcp): add test-repeated tool for detecting flaky tests

### DIFF
--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -124,9 +124,10 @@ Metals provides a comprehensive set of tools through MCP:
 
 ### Testing
 
-| Tool   | Description                                                                                                                                            |
-| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `test` | Run Scala test suites. Supports running specific test classes or individual test methods. Works with ScalaTest, MUnit, ZIO Test, and other frameworks. |
+| Tool            | Description                                                                                                                                            |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `test`          | Run Scala test suites. Supports running specific test classes or individual test methods. Works with ScalaTest, MUnit, ZIO Test, and other frameworks. |
+| `test-repeated` | Run a test suite (or a single test) repeatedly, up to 100 times, to detect or confirm flaky tests. Reports an aggregate summary with the failing run indices and details from the first failing run; can stop on the first failure. |
 
 ### Symbol Search and Inspection
 
@@ -195,6 +196,10 @@ Using MCP, show the documentation for scala.collection.immutable.List
 
 ```
 Using MCP, run the test class com.example.MyServiceSpec
+```
+
+```
+Using MCP, run com.example.MyServiceSpec 20 times to check whether it is flaky
 ```
 
 ### Finding Dependencies

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
@@ -5,6 +5,7 @@ import java.net.InetSocketAddress
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import scala.util.control.NonFatal
 
 import scala.meta.internal.ansi.AnsiFilter
 import scala.meta.internal.metals.BuildTargets
@@ -28,11 +29,69 @@ class McpTestRunner(
     userConfig: () => UserConfiguration,
     mcpSearch: McpSymbolSearch,
 )(implicit ec: ExecutionContext) {
+  import McpTestRunner._
+
   def runTests(
       testClass: String,
       optPath: Option[AbsolutePath],
       testName: Option[String],
       verbose: Boolean,
+  ): Either[String, Future[String]] =
+    withTestRun(testClass, optPath, testName, verbose) { runOnce =>
+      runOnce().map(_.report)
+    }
+
+  def runTestsRepeated(
+      testClass: String,
+      optPath: Option[AbsolutePath],
+      testName: Option[String],
+      times: Long,
+      stopOnFirstFailure: Boolean,
+  ): Either[String, Future[String]] =
+    if (times < 1 || times > maxRepeatTimes)
+      Left(s"times must be between 1 and $maxRepeatTimes, got: $times")
+    else {
+      val requestedTimes = times.toInt
+      withTestRun(testClass, optPath, testName, verbose = false) { runOnce =>
+        def loop(
+            runIndex: Int,
+            acc: List[RunOutcome],
+        ): Future[List[RunOutcome]] =
+          if (runIndex > requestedTimes) Future.successful(acc.reverse)
+          else
+            runOnce()
+              .recover {
+                // A non-zero exit of the forked JVM (e.g. System.exit, OOM)
+                // fails the run future; count it as a failed run instead of
+                // aborting the whole sequence.
+                case NonFatal(error) =>
+                  RunOutcome(
+                    failed = true,
+                    s"The test run crashed: ${error.getMessage}",
+                  )
+              }
+              .flatMap { outcome =>
+                // Only the first failing run's report is ever emitted, so drop
+                // the others to keep at most one report in memory.
+                val keepReport = outcome.failed && !acc.exists(_.failed)
+                val compact =
+                  if (keepReport) outcome else outcome.copy(report = "")
+                val results = compact :: acc
+                if (stopOnFirstFailure && outcome.failed)
+                  Future.successful(results.reverse)
+                else loop(runIndex + 1, results)
+              }
+        loop(1, Nil).map(formatRepeatedRuns(testClass, requestedTimes, _))
+      }
+    }
+
+  private def withTestRun(
+      testClass: String,
+      optPath: Option[AbsolutePath],
+      testName: Option[String],
+      verbose: Boolean,
+  )(
+      body: (() => Future[RunOutcome]) => Future[String]
   ): Either[String, Future[String]] = {
     val testSelection = testName match {
       case Some(name) =>
@@ -66,27 +125,77 @@ class McpTestRunner(
         )
         discovered <- debugProvider.discoverTests(id, testSuites)
         project <- projectFut
-        listener = new McpDebuggeeListener(verbose)
-        adapter = new TestSuiteDebugAdapter(
-          workspace,
-          testSuites,
-          project,
-          userConfig().javaHome,
-          discovered,
-          isDebug = false,
-        )
-        _ <- adapter.run(listener).future
-      } yield listener.result
+        runOnce = { () =>
+          val listener = new McpDebuggeeListener(verbose)
+          val adapter = new TestSuiteDebugAdapter(
+            workspace,
+            testSuites,
+            project,
+            userConfig().javaHome,
+            discovered,
+            isDebug = false,
+          )
+          adapter
+            .run(listener)
+            .future
+            .map(_ => RunOutcome(listener.runFailed, listener.result))
+        }
+        result <- body(runOnce)
+      } yield result
     }
   }
+
+  private def formatRepeatedRuns(
+      testClass: String,
+      requestedTimes: Int,
+      outcomes: List[RunOutcome],
+  ): String = {
+    val indexed = outcomes.zipWithIndex.map { case (outcome, i) =>
+      (i + 1, outcome)
+    }
+    val failed = indexed.filter { case (_, outcome) => outcome.failed }
+    val passedCount = indexed.size - failed.size
+    val timesWord =
+      if (indexed.size == 1) "once" else s"${indexed.size} times"
+    val failedPart =
+      if (failed.isEmpty) "0 runs failed"
+      else {
+        val indices = failed.map { case (i, _) => i }
+        val runsLabel = if (indices.size == 1) "run" else "runs"
+        s"${countRuns(failed.size)} failed ($runsLabel ${indices.mkString(", ")})"
+      }
+    val header =
+      s"Ran $testClass $timesWord: ${countRuns(passedCount)} passed, $failedPart"
+    val earlyStop =
+      if (indexed.size < requestedTimes)
+        s"\nStopped after first failure (run ${indexed.size} of $requestedTimes)"
+      else ""
+    val detail = failed.headOption
+      .map { case (i, outcome) =>
+        s"\n--- failing run $i ---\n${outcome.report}"
+      }
+      .getOrElse("")
+    header + earlyStop + detail
+  }
+
+  private def countRuns(n: Int): String =
+    if (n == 1) "1 run" else s"$n runs"
 
   private def resolvePath(fqcn: String): Option[AbsolutePath] = {
     mcpSearch.exactSearch(fqcn, None).flatMap(_.definitionPath).headOption
   }
 }
 
+object McpTestRunner {
+  val maxRepeatTimes: Int = 100
+  private case class RunOutcome(failed: Boolean, report: String)
+}
+
 class McpDebuggeeListener(verbose: Boolean) extends DebuggeeListener {
   private val buffer = new StringBuffer()
+  @volatile private var failedTestCount = 0
+  @volatile private var summaryReceived = false
+
   override def onListening(address: InetSocketAddress): Unit = {}
 
   override def out(line: String): Unit =
@@ -94,7 +203,12 @@ class McpDebuggeeListener(verbose: Boolean) extends DebuggeeListener {
 
   override def err(line: String): Unit = buffer.append(line).append("\n")
 
-  override def testResult(data: TestSuiteSummary): Unit =
+  override def testResult(data: TestSuiteSummary): Unit = {
+    summaryReceived = true
+    failedTestCount += data.tests.asScala.count {
+      case _: SingleTestResult.Failed => true
+      case _ => false
+    }
     if (!verbose) {
       val testCases = data.tests.asScala
       val grouped = testCases
@@ -125,5 +239,13 @@ class McpDebuggeeListener(verbose: Boolean) extends DebuggeeListener {
             |""".stripMargin
       )
     }
+  }
+
+  /**
+   * A run counts as failed when any test failed or when the suite never
+   * reported a summary (e.g. it crashed before running).
+   */
+  def runFailed: Boolean = failedTestCount > 0 || !summaryReceived
+
   def result: String = AnsiFilter()(buffer.toString())
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpTools.scala
@@ -460,6 +460,92 @@ trait MetalsMcpTools extends Cancelable {
     )
   }
 
+  protected def createTestRepeatedTool(): AsyncToolSpecification = {
+    val schema =
+      """|{
+         |  "type": "object",
+         |  "properties": {
+         |    "testFile": {
+         |      "type": "string",
+         |      "description": "The file containing the test suite, if empty we will try to detect it"
+         |    },
+         |    "testClass": {
+         |      "type": "string",
+         |      "description": "Fully qualified name of the test class to run"
+         |    },
+         |    "testName": {
+         |      "type": "string",
+         |      "description": "Name of the specific test to run within the test class, if empty runs all tests in the class"
+         |    },
+         |    "times": {
+         |      "type": "integer",
+         |      "description": "Number of times to run the tests, between 1 and 100",
+         |      "default": 10,
+         |      "minimum": 1,
+         |      "maximum": 100
+         |    },
+         |    "stopOnFirstFailure": {
+         |      "type": "boolean",
+         |      "description": "Stop as soon as a run fails instead of completing all runs",
+         |      "default": false
+         |    }
+         |  },
+         |  "required": ["testClass"]
+         |}""".stripMargin
+    val tool = Tool
+      .builder()
+      .name("test-repeated")
+      .description(
+        """|Run a Scala test suite repeatedly to detect or confirm flaky tests.
+           |Executes the tests the given number of times sequentially and reports
+           |an aggregate summary with details from failing runs.""".stripMargin
+      )
+      .inputSchema(jsonMapper, schema)
+      .build()
+    new AsyncToolSpecification(
+      tool,
+      withErrorHandling { (exchange, arguments) =>
+        val testClass = arguments.getAs[String]("testClass")
+        val optPath = arguments
+          .getOptAs[String]("testFile")
+          .map(path => AbsolutePath(Path.of(path))(projectPath))
+        val testName = arguments.getOptAs[String]("testName")
+        val times = arguments
+          .getOptAs[Number]("times")
+          .map(_.longValue)
+          .getOrElse(10L)
+        val stopOnFirstFailure = arguments
+          .getOptAs[Boolean]("stopOnFirstFailure")
+          .getOrElse(false)
+        val result = mcpTestRunner.runTestsRepeated(
+          testClass,
+          optPath,
+          testName,
+          times,
+          stopOnFirstFailure,
+        )
+        (result match {
+          case Right(value) =>
+            value.map(content =>
+              CallToolResult
+                .builder()
+                .content(createContent(content))
+                .isError(false)
+                .build()
+            )
+          case Left(error) =>
+            Future.successful(
+              CallToolResult
+                .builder()
+                .content(createContent(s"Error: $error"))
+                .isError(true)
+                .build()
+            )
+        }).toMono
+      },
+    )
+  }
+
   protected def createGlobSearchTool(): AsyncToolSpecification = {
     val schema = """
       {
@@ -1280,6 +1366,7 @@ trait MetalsMcpTools extends Cancelable {
     asyncServer.addTool(createCompileModuleTool()).subscribe()
     asyncServer.addTool(createCompileTool()).subscribe()
     asyncServer.addTool(createTestTool()).subscribe()
+    asyncServer.addTool(createTestRepeatedTool()).subscribe()
     asyncServer.addTool(createGlobSearchTool()).subscribe()
     asyncServer.addTool(createTypedGlobSearchTool()).subscribe()
     asyncServer.addTool(createInspectTool()).subscribe()

--- a/tests/unit/src/test/scala/tests/mcp/McpRunTestSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpRunTestSuite.scala
@@ -1,5 +1,7 @@
 package tests.mcp
 
+import java.nio.file.Files
+
 import scala.meta.internal.metals.MetalsServerConfig
 
 import tests.BaseLspSuite
@@ -412,6 +414,203 @@ class McpRunTestSuite extends BaseLspSuite("mcp-test") {
         nonExistentResult.contains("3 tests, 0 passed, 0 failed, 3 skipped"),
         s"Non-existent test should skip all tests: $nonExistentResult",
       )
+    } yield ()
+  }
+
+  test("repeated", maxRetry = 3) {
+    cleanWorkspace()
+    // Counter files let the forked test JVMs communicate how often they ran,
+    // which both makes flakiness deterministic (fail only on the first run)
+    // and proves stopOnFirstFailure runs the JVM exactly once.
+    val flakyCounter = workspace.resolve("flaky-counter.txt")
+    val failCounter = workspace.resolve("fail-counter.txt")
+    val crashCounter = workspace.resolve("crash-counter.txt")
+    // Interpolated into Scala string literals in the generated source, so the
+    // Windows path separator must be replaced to keep the literal valid.
+    val flakyCounterPath = flakyCounter.toString.replace('\\', '/')
+    val failCounterPath = failCounter.toString.replace('\\', '/')
+    val crashCounterPath = crashCounter.toString.replace('\\', '/')
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "libraryDependencies" : ["org.scalameta::munit:1.0.0-M4"]
+           |  }
+           |}
+           |/a/src/test/scala/a/RepeatedSuites.scala
+           |package a
+           |
+           |import java.nio.file.Files
+           |import java.nio.file.Paths
+           |import java.nio.file.StandardOpenOption
+           |
+           |object RunCounter {
+           |  def increment(path: String): Long = {
+           |    val counter = Paths.get(path)
+           |    Files.write(
+           |      counter,
+           |      "x".getBytes(),
+           |      StandardOpenOption.CREATE,
+           |      StandardOpenOption.APPEND,
+           |    )
+           |    Files.size(counter)
+           |  }
+           |}
+           |
+           |class FlakyOnFirstRunSuite extends munit.FunSuite {
+           |  test("flaky") {
+           |    val runs = RunCounter.increment("$flakyCounterPath")
+           |    assert(runs > 1, "fails on first run")
+           |  }
+           |}
+           |
+           |class GreenSuite extends munit.FunSuite {
+           |  test("green") {
+           |    assert(1 == 1)
+           |  }
+           |}
+           |
+           |class AlwaysFailingSuite extends munit.FunSuite {
+           |  test("always fails") {
+           |    RunCounter.increment("$failCounterPath")
+           |    assert(1 == 2)
+           |  }
+           |}
+           |
+           |class CrashingSuite extends munit.FunSuite {
+           |  test("crash") {
+           |    RunCounter.increment("$crashCounterPath")
+           |    sys.exit(1)
+           |  }
+           |}
+           |
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/test/scala/a/RepeatedSuites.scala")
+      _ = assertNoDiagnostics()
+      _ <- server.server.indexingPromise.future
+      path = server.toPath("a/src/test/scala/a/RepeatedSuites.scala")
+      _ = Files.deleteIfExists(flakyCounter.toNIO)
+      _ = Files.deleteIfExists(failCounter.toNIO)
+      _ = Files.deleteIfExists(crashCounter.toNIO)
+
+      // A suite failing only on the first run reports the split and details
+      flakyResult <- server.headServer.mcpTestRunner
+        .runTestsRepeated(
+          "a.FlakyOnFirstRunSuite",
+          Some(path),
+          None,
+          times = 3,
+          stopOnFirstFailure = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        flakyResult.contains(
+          "Ran a.FlakyOnFirstRunSuite 3 times: 2 runs passed, 1 run failed (run 1)"
+        ),
+        s"Flaky result: $flakyResult",
+      )
+      _ = assert(
+        flakyResult.contains("--- failing run 1 ---"),
+        s"Should contain the failing run's report: $flakyResult",
+      )
+      _ = assert(
+        flakyResult.contains("flaky failed"),
+        s"Should contain the failed test: $flakyResult",
+      )
+
+      // A stable suite reports all runs passed and no failure section
+      greenResult <- server.headServer.mcpTestRunner
+        .runTestsRepeated(
+          "a.GreenSuite",
+          Some(path),
+          None,
+          times = 2,
+          stopOnFirstFailure = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        greenResult.contains(
+          "Ran a.GreenSuite 2 times: 2 runs passed, 0 runs failed"
+        ),
+        s"Green result: $greenResult",
+      )
+      _ = assert(
+        !greenResult.contains("--- failing run"),
+        s"Green result should have no failure section: $greenResult",
+      )
+
+      // stopOnFirstFailure stops after the first failing run
+      stopResult <- server.headServer.mcpTestRunner
+        .runTestsRepeated(
+          "a.AlwaysFailingSuite",
+          Some(path),
+          None,
+          times = 5,
+          stopOnFirstFailure = true,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        stopResult.contains("0 runs passed, 1 run failed (run 1)"),
+        s"Stop result: $stopResult",
+      )
+      _ = assert(
+        stopResult.contains("Stopped after first failure (run 1 of 5)"),
+        s"Stop result should mention early stop: $stopResult",
+      )
+      _ = assert(
+        Files.size(failCounter.toNIO) == 1,
+        s"Expected exactly one run, got ${Files.size(failCounter.toNIO)}",
+      )
+
+      // A run whose JVM exits non-zero counts as a failed run instead of
+      // aborting the aggregate
+      crashResult <- server.headServer.mcpTestRunner
+        .runTestsRepeated(
+          "a.CrashingSuite",
+          Some(path),
+          None,
+          times = 2,
+          stopOnFirstFailure = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        crashResult.contains("0 runs passed, 2 runs failed (runs 1, 2)"),
+        s"Crash result: $crashResult",
+      )
+      _ = assert(
+        crashResult.contains("The test run crashed"),
+        s"Crash result should mention the crash: $crashResult",
+      )
+      _ = assert(
+        Files.size(crashCounter.toNIO) == 2,
+        s"Expected two runs, got ${Files.size(crashCounter.toNIO)}",
+      )
+
+      // times outside 1-100 is rejected without running anything
+      _ = List(0, 101).foreach { invalidTimes =>
+        server.headServer.mcpTestRunner.runTestsRepeated(
+          "a.GreenSuite",
+          Some(path),
+          None,
+          times = invalidTimes,
+          stopOnFirstFailure = false,
+        ) match {
+          case Left(error) =>
+            assert(error.contains("between 1 and 100"), error)
+          case Right(_) => fail(s"Expected an error for times = $invalidTimes")
+        }
+      }
     } yield ()
   }
 }


### PR DESCRIPTION
To check if a test is flaky over MCP, an agent currently has to call `test` many times and combine the outputs itself, which fills its context with repeated reports.

This adds a `test-repeated` tool that runs a test class (or a single test) 1–100 times in a row (default 10) and returns one short summary: how many runs passed and failed, which runs failed, and the report of the first failing run only. With `stopOnFirstFailure` it stops at the first failing run.

Notes:
- Reuses the single-run pipeline (shared `withTestRun` helper): compile and test discovery happen once, each run gets a fresh JVM. The `test` tool is unchanged.
- A run whose JVM exits non-zero (e.g. `System.exit`, OOM) counts as a failed run instead of breaking the whole sequence.
- New `repeated` test case uses counter files to make flakiness deterministic and to prove `stopOnFirstFailure` runs the JVM exactly once; also covers crashed runs and `times` validation.

Known limitations, both inherited from the `test` tool:
- No cancellation or timeout: a hanging suite blocks the call, and cancelling the MCP request does not stop the runs. The 100-run cap is the only mitigation; a proper fix needs changes in the debug-adapter code, so it is left for a follow-up.
- Boolean args sent as strings (`"true"`) silently fall back to the default, same as `verbose` on `test`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `test-repeated` tool for running Scala tests multiple times to identify flaky behavior.
  * Supports 1–100 runs, optional stop-on-first-failure behavior, and configurable test selection.
  * Reports successful runs, failures, crashes, and the first failure details.

* **Documentation**
  * Added usage guidance and an example for checking test flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->