### PR TITLE
Do not import source files from targets which don't belong to the project scope

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtBuildSupport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtBuildSupport.scala
@@ -155,7 +155,8 @@ object BazelMbtBuildSupport {
           )
         }
       } else {
-        val allSrcs = srcFilesByTarget.values.flatten.toSet
+        val allSrcs =
+          targetLabels.flatMap(srcFilesByTarget.getOrElse(_, Nil)).toSet
         val allExtDeps = externalDepsByTarget.values.flatten.toSet
         val allGenSrcOutputs = genSrcOutputsByTarget.values.flatten.toSeq
         putNamespace(

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/mbt/importer/BazelMbtBuildSupportSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/mbt/importer/BazelMbtBuildSupportSuite.scala
@@ -1,0 +1,104 @@
+package scala.meta.internal.metals.mbt.importer
+
+import scala.meta.internal.metals.mbt.MbtBuild
+import scala.meta.internal.metals.mbt.MbtDependencyModule
+
+import munit.FunSuite
+
+class BazelMbtBuildSupportSuite extends FunSuite {
+
+  test("redundant-targets-for-workspace-mode") {
+
+    val mbtBuild = fromDiscovery(
+      BazelMbtNamespaceMode.Workspace,
+      targetLabels = List("//:foo"),
+      srcsByTarget = Map(
+        "//:foo" -> List("//:Source.java"),
+        "//:bar" -> List("//:BadSource.js"),
+      ),
+    )
+
+    val expectedMbtJson: String =
+      """|{
+         |  "dependencyModules": [],
+         |  "namespaces": {
+         |    "bazel-workspace": {
+         |      "sources": [
+         |        "Source.java"
+         |      ],
+         |      "scalacOptions": [],
+         |      "javacOptions": [],
+         |      "dependencyModules": [],
+         |      "dependsOn": [],
+         |      "classDirectories": []
+         |    }
+         |  },
+         |  "uncheckedSources": []
+         |}
+         |""".stripMargin
+
+    assertEquals(MbtBuild.toJson(mbtBuild).trim(), expectedMbtJson.trim())
+  }
+
+  test("compiler-options-for-workspace-mode") {
+    val mbtBuild = fromDiscovery(
+      BazelMbtNamespaceMode.Workspace,
+      targetLabels = List("foo"),
+      scalacOptionsByTarget = Map(
+        "foo" -> List("-opt")
+      ),
+      javacOptionsByTarget = Map(
+        "foo" -> List("-opt2")
+      ),
+    )
+
+    val expectedMbtJson: String =
+      """|{
+         |  "dependencyModules": [],
+         |  "namespaces": {
+         |    "bazel-workspace": {
+         |      "sources": [],
+         |      "scalacOptions": [],
+         |      "javacOptions": [],
+         |      "dependencyModules": [],
+         |      "dependsOn": [],
+         |      "classDirectories": []
+         |    }
+         |  },
+         |  "uncheckedSources": []
+         |}
+         |""".stripMargin
+
+    assertEquals(MbtBuild.toJson(mbtBuild).trim(), expectedMbtJson.trim())
+  }
+
+  private def fromDiscovery(
+      granularity: BazelMbtNamespaceMode,
+      targetLabels: List[String] = Nil,
+      srcsByTarget: Map[String, List[String]] = Map.empty,
+      scalacOptionsByTarget: Map[String, List[String]] = Map.empty,
+      javacOptionsByTarget: Map[String, List[String]] = Map.empty,
+      directDepRules: Map[String, List[String]] = Map.empty,
+      externalDepsByTarget: Map[String, List[String]] = Map.empty,
+      runTargets: Set[String] = Set.empty,
+      classDirectoriesByTarget: Map[String, String] = Map.empty,
+      dependencyModules: Seq[MbtDependencyModule] = Seq.empty,
+      scalaVersion: Option[String] = None,
+      genSrcOutputsByTarget: Map[String, List[String]] = Map.empty,
+  ): MbtBuild =
+    BazelMbtBuildSupport.fromDiscovery(
+      granularity,
+      targetLabels,
+      srcsByTarget,
+      scalacOptionsByTarget,
+      javacOptionsByTarget,
+      directDepRules,
+      externalDepsByTarget,
+      runTargets,
+      classDirectoriesByTarget,
+      dependencyModules,
+      scalaVersion,
+      genSrcOutputsByTarget,
+    )
+
+}


### PR DESCRIPTION
Also added some unit tests for BazelMbtBuildSupport.

One of the new tests fails on the current main-v2 head:
```
=> Diff (- expected, + obtained)
     "bazel-workspace": {
-      "sources": [
-        "Source.java"
-      ],
+      "sources": [],
       "scalacOptions": [],
    at munit.FunSuite.assertEquals(FunSuite.scala:12)
    at scala.meta.internal.metals.mbt.importer.BazelMbtBuildSupportSuite.$anonfun$new$1(BazelMbtBuildSupportSuite.scala:40)
```

This is related to #8663.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace imports now include source files only from selected targets, preventing unrelated target sources from appearing in the workspace.
  - Workspace-level build output no longer reports target-specific Scala or Java compiler options, providing more accurate workspace configuration.

- **Tests**
  - Added coverage for filtering sources to selected targets.
  - Added coverage confirming workspace compiler options remain empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->