### PR TITLE
improvement: Adjust sources when using diagnostics or semanticdb

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -486,8 +486,10 @@ object SbtBuildTool {
       position.getCharacter(),
     )
     val adjustLspData = AdjustedLspData.create(
-      pos => {
-        new Position(pos.getLine() - appendLineSize, pos.getCharacter())
+      {
+        case (line, column) => {
+          (line - appendLineSize, column)
+        }
       },
       filterOutLocations = { loc => !loc.getUri().isSbt },
     )

--- a/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
@@ -2,7 +2,10 @@ package scala.meta.internal.metals
 
 import java.{util => ju}
 
+import scala.meta.internal.metals.AdjustedLspData.LineColumn
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.mtags.MD5
+import scala.meta.internal.{semanticdb => s}
 import scala.meta.pc
 import scala.meta.pc.AutoImportsResult
 import scala.meta.pc.HoverSignature
@@ -18,12 +21,75 @@ import org.eclipse.lsp4j.{Range => LspRange}
 
 trait AdjustLspData {
 
-  def adjustPos(pos: Position, adjustToZero: Boolean = true): Position
+  def adjust(pos: LineColumn): LineColumn
+
+  def adjustPosition(
+      position: Position,
+      adjustToZero: Boolean = true,
+  ): Position = {
+    val lineColumn = (position.getLine(), position.getCharacter())
+    val (adjustedLine, adjustedCharacter) = adjust(lineColumn)
+    val finalAdjustedCharacter =
+      if (adjustToZero && adjustedCharacter < 0) 0 else adjustedCharacter
+    val finalAdjustedLine =
+      if (adjustToZero && adjustedLine < 0) 0 else adjustedLine
+    new Position(finalAdjustedLine, finalAdjustedCharacter)
+  }
+
+  def adjustTextDocument(
+      document: s.TextDocument,
+      originalText: String,
+  ): s.TextDocument = {
+
+    def adjustSemanticdbRange(range: s.Range): s.Range = {
+      val (adjustedStartLine, adjustedStartCharacter) = adjust(
+        (range.startLine, range.startCharacter)
+      )
+      val (adjustedEndLine, adjustedEndCharacter) = adjust(
+        (range.endLine, range.endCharacter)
+      )
+      new s.Range(
+        adjustedStartLine,
+        adjustedStartCharacter,
+        adjustedEndLine.toShort,
+        adjustedEndCharacter.toShort,
+      )
+    }
+    val adjustedOccurences =
+      document.occurrences.flatMap { occurence =>
+        occurence.range
+          .map(r => occurence.copy(range = Some(adjustSemanticdbRange(r))))
+      }
+
+    val adjustedDiagnostic =
+      document.diagnostics.flatMap { diagnostic =>
+        diagnostic.range
+          .map(r => diagnostic.copy(range = Some(adjustSemanticdbRange(r))))
+      }
+
+    val adjustedSynthetic =
+      document.synthetics.flatMap { synthetic =>
+        synthetic.range
+          .map(r => synthetic.copy(range = Some(adjustSemanticdbRange(r))))
+      }
+
+    s.TextDocument(
+      schema = document.schema,
+      uri = document.uri,
+      text = originalText,
+      md5 = MD5.compute(originalText),
+      language = document.language,
+      symbols = document.symbols,
+      occurrences = adjustedOccurences,
+      diagnostics = adjustedDiagnostic,
+      synthetics = adjustedSynthetic,
+    )
+  }
 
   def adjustRange(range: LspRange): LspRange =
     new LspRange(
-      adjustPos(range.getStart),
-      adjustPos(range.getEnd),
+      adjustPosition(range.getStart),
+      adjustPosition(range.getEnd),
     )
 
   def adjustTextEdits(
@@ -108,7 +174,7 @@ trait AdjustLspData {
 }
 
 case class AdjustedLspData(
-    adjustPosition: Position => Position,
+    adjustLineColumn: LineColumn => LineColumn,
     filterOutLocations: Location => Boolean,
     adjustUri: String => String = identity,
 ) extends AdjustLspData {
@@ -123,26 +189,24 @@ case class AdjustedLspData(
         loc
     }.asJava
   }
-  override def adjustPos(
-      pos: Position,
-      adjustToZero: Boolean = true,
-  ): Position = {
-    val adjusted = adjustPosition(pos)
-    if (adjustToZero && adjusted.getCharacter() < 0) adjusted.setCharacter(0)
-    if (adjustToZero && adjusted.getLine() < 0) adjusted.setLine(0)
-    adjusted
-  }
+  override def adjust(
+      pos: LineColumn
+  ): LineColumn = adjustLineColumn(pos)
 
 }
 
 object DefaultAdjustedData extends AdjustLspData {
 
-  override def adjustPos(
-      pos: Position,
-      adjustToZero: Boolean = true,
-  ): Position = identity(pos)
+  override def adjust(
+      pos: LineColumn
+  ): LineColumn = identity(pos)
 
   override def adjustRange(range: LspRange): LspRange = identity(range)
+
+  override def adjustTextDocument(
+      document: s.TextDocument,
+      originalText: String,
+  ): s.TextDocument = identity(document)
 
   override def adjustTextEdits(
       edits: java.util.List[TextEdit]
@@ -168,15 +232,17 @@ object DefaultAdjustedData extends AdjustLspData {
 object AdjustedLspData {
 
   def create(
-      f: Position => Position,
+      f: LineColumn => LineColumn,
       filterOutLocations: Location => Boolean = _ => false,
       adjustUri: String => String = identity,
   ): AdjustLspData =
     AdjustedLspData(
-      pos => f(pos),
+      f,
       filterOutLocations,
       adjustUri,
     )
 
   val default: AdjustLspData = DefaultAdjustedData
+
+  type LineColumn = (Int, Int)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals
 
-import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Duration
@@ -25,7 +24,6 @@ import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal
 import scala.meta.internal.async.CompletableCancelToken
-import scala.meta.internal.builds.SbtBuildTool
 import scala.meta.internal.metals.CompilerOffsetParamsUtils
 import scala.meta.internal.metals.CompilerRangeParamsUtils
 import scala.meta.internal.metals.Compilers.PresentationCompilerKey
@@ -34,7 +32,6 @@ import scala.meta.internal.metals.decompile.DecompileBytecode
 import scala.meta.internal.metals.mbt.MbtBuild
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
 import scala.meta.internal.metals.mbt.ProtoGeneratedJavaFiles
-import scala.meta.internal.mtags.MD5
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.parsing.Trees
 import scala.meta.internal.pc.LogMessages
@@ -355,7 +352,7 @@ class Compilers(
 
   def didFocus(path: AbsolutePath): Future[List[Diagnostic]] = {
     val maybeDiagnostics =
-      for (pc <- loadCompiler(path); contents <- buffers.get(path))
+      for (pc <- loadCompiler(path))
         yield {
           timerProvider
             .withTimer(
@@ -363,19 +360,11 @@ class Compilers(
               reportStatus = false,
               onlyIf = serverConfig.statistics.isDiagnostics,
             ) {
-              pc.didChange(
-                CompilerVirtualFileParams(
-                  path.toNIO.toUri,
-                  contents,
-                  EmptyCancelToken,
-                  outlineFilesProvider.getOutlineFiles(pc.buildTargetId()),
-                  shouldReturnDiagnostics =
-                    userConfig().presentationCompilerDiagnostics,
-                )
-              ).asScala
-                .map { result =>
-                  result.asScala.toList
-                }
+              didChangePc(
+                path,
+                shouldReturnDiagnostics =
+                  userConfig().presentationCompilerDiagnostics,
+              )
             }
             .map { case (timer, result) =>
               metrics.recordEvent(
@@ -403,32 +392,23 @@ class Compilers(
           futures =
             for {
               file <- changedFiles.distinct
-              pc <- this.loadCompiler(file).toList
-              contents <- buffers.get(file).toList
             } yield {
               val token = new CompletableCancelToken()
               inFlightDidChange.put(file, token).foreach { old =>
                 old.cancel()
               }
-              val params = CompilerVirtualFileParams(
-                file.toNIO.toUri,
-                contents,
-                token = token,
-                shouldReturnDiagnostics =
-                  userConfig().presentationCompilerDiagnostics,
-              )
               timerProvider
                 .withTimer(
                   "computed diagnostics",
                   reportStatus = false,
                   onlyIf = false,
                 ) {
-                  pc.didChange(params).asScala
+                  didChangePc(file)
                 }
                 .map { case (timer, reportedDiagnostics) =>
                   diagnostics.publishDiagnosticsNotAdjusted(
                     file,
-                    reportedDiagnostics.asScala.toList,
+                    reportedDiagnostics.toList,
                   )
                   metrics.recordEvent(
                     Event
@@ -482,9 +462,13 @@ class Compilers(
         )
 
         val input = path.toInputFromBuffers(buffers)
-        val params = Compilers.DidChangeCompilerFileParams(
+        val params = CompilerVirtualFileParams(
           path.toNIO.toUri(),
           input.value,
+          EmptyCancelToken,
+          outlineFilesProvider.getOutlineFiles(
+            Some(explainCompiler.buildTargetId)
+          ),
           shouldReturnDiagnostics = true,
         )
         explainCompiler.await
@@ -501,33 +485,14 @@ class Compilers(
     }
   }
 
-  private def didChangeBSPDiagnostics(
+  private def didChangePc(
       path: AbsolutePath,
-      shouldReturnDiagnostics: Boolean,
-      content: Option[String] = None,
+      shouldReturnDiagnostics: Boolean = false,
   ): Future[List[Diagnostic]] = {
-    def originInput =
-      content.map(Input.VirtualFile(path.toURI.toString(), _)).getOrElse {
-        path.toInputFromBuffers(buffers)
-      }
-
     loadCompiler(path)
       .map { pc =>
-        val inputAndAdjust =
-          if (
-            path.isWorksheet && ScalaVersions.isScala3Version(
-              pc.scalaVersion()
-            )
-          ) {
-            WorksheetProvider.worksheetScala3AdjustmentsForPC(originInput)
-          } else {
-            None
-          }
-
-        val (input, adjust) = inputAndAdjust.getOrElse(
-          originInput,
-          AdjustedLspData.default,
-        )
+        val (input, _, adjust) =
+          sourceMapper.pcMapping(path, pc.scalaVersion())
 
         outlineFilesProvider.didChange(pc.buildTargetId(), path)
 
@@ -535,10 +500,13 @@ class Compilers(
           ds <-
             pc
               .didChange(
-                Compilers.DidChangeCompilerFileParams(
-                  path.toNIO.toUri(),
+                CompilerVirtualFileParams(
+                  path.toNIO.toUri,
                   input.value,
-                  shouldReturnDiagnostics,
+                  EmptyCancelToken,
+                  outlineFilesProvider.getOutlineFiles(pc.buildTargetId()),
+                  shouldReturnDiagnostics =
+                    shouldReturnDiagnostics || userConfig().presentationCompilerDiagnostics,
                 )
               )
               .asScala
@@ -555,14 +523,13 @@ class Compilers(
       // Batch/debounce these requests since they can arrive in bursts
       fileDidChange(Seq(path))
     else
-      didChangeBSPDiagnostics(path, shouldReturnDiagnostics = false).ignoreValue
+      didChangePc(path, shouldReturnDiagnostics = false).ignoreValue
   }
 
   def didChangeWithDiagnostics(
-      path: AbsolutePath,
-      content: Option[String] = None,
+      path: AbsolutePath
   ): Future[List[Diagnostic]] = {
-    didChangeBSPDiagnostics(path, shouldReturnDiagnostics = true, content)
+    didChangePc(path, shouldReturnDiagnostics = true)
   }
 
   def didCompile(report: CompileReport): Unit = {
@@ -898,11 +865,11 @@ class Compilers(
         inlayHints.asScala
           .dropWhile { hint =>
             val adjusted =
-              adjust.adjustPos(hint.getPosition(), adjustToZero = false)
+              adjust.adjustPosition(hint.getPosition())
             adjusted.getLine() < 0 || adjusted.getCharacter() < 0
           }
           .map { hint =>
-            hint.setPosition(adjust.adjustPos(hint.getPosition()))
+            hint.setPosition(adjust.adjustPosition(hint.getPosition()))
             InlayHintCompat.maybeFixInlayHintData(
               hint,
               params.getTextDocument().getUri(),
@@ -1844,11 +1811,9 @@ class Compilers(
           buffers.open.filter(buf => sources.exists(buf.startWith)).toList
 
         modifiedFiles.foreach(path =>
-          pc.didChange(
-            CompilerVirtualFileParams(
-              path.toNIO.toUri,
-              buffers.get(path).get,
-            )
+          didChangePc(
+            path,
+            shouldReturnDiagnostics = false,
           )
         )
         pc
@@ -2192,25 +2157,49 @@ class Compilers(
         .flatMap(s => getCompiler(s).map(pc => (pc, s)))
         .groupBy(_._1)
     } yield {
-      val params = paths.map { case (_, s) =>
-        CompilerVirtualFileParams(
-          s.toURI,
-          s.toInputFromBuffers(buffers).text,
-          token = cancelToken,
-          shouldReturnDiagnostics = true,
-          shouldPruneSemanticdb = shouldPruneSemanticdb,
-        ): VirtualFileParams
+      val params: Seq[(VirtualFileParams, AdjustLspData)] = paths.map {
+        case (_, path) =>
+
+          val (input, _, adjust) =
+            sourceMapper.pcMapping(path, pc.scalaVersion())
+          val params = CompilerVirtualFileParams(
+            path.toURI,
+            input.value,
+            token = cancelToken,
+            shouldReturnDiagnostics = true,
+            shouldPruneSemanticdb = shouldPruneSemanticdb,
+          )
+          (params: VirtualFileParams, adjust)
       }
+
       if (pc.supportsBatchSemanticdbTextDocuments()) {
-        pc.batchSemanticdbTextDocuments(params.asJava, timeout)
+        val mapping = params.flatMap {
+          // noop for normal files
+          case (_, DefaultAdjustedData) =>
+            None
+          case (param, adjust) =>
+            Some(param.uri.toString() -> adjust)
+        }.toMap
+
+        pc.batchSemanticdbTextDocuments(params.map(_._1).asJava, timeout)
           .asScala
-          .map(bytes => s.TextDocuments.parseFrom(bytes).documents)
+          .map(bytes =>
+            s.TextDocuments.parseFrom(bytes).documents.map { case doc =>
+              mapping
+                .get(doc.uri.toString())
+                .map(adjust => adjust.adjustTextDocument(doc, doc.text))
+                .getOrElse(doc)
+            }
+          )
       } else {
         val all = for {
-          param <- params
+          (param, adjust) <- params
           doc = pc.semanticdbTextDocument(param)
-        } yield doc.asScala
-        Future.sequence(all).map { docs =>
+        } yield doc.asScala.map { d =>
+          val textDoc = s.TextDocument.parseFrom(d)
+          adjust.adjustTextDocument(textDoc, param.text)
+        }
+        Future.sequence(all).map { parsedDocs =>
           val targetRoot = buildTargets
             .jvmTarget(
               new BuildTargetIdentifier(pc.buildTargetId())
@@ -2218,7 +2207,6 @@ class Compilers(
             .flatMap(_.getTargetroot)
             .getOrElse(workspace)
 
-          val parsedDocs = docs.map(d => s.TextDocument.parseFrom(d))
           parsedDocs
             .map { d =>
               if (d.uri.startsWith("file:") || d.uri.startsWith("jar:"))
@@ -2242,23 +2230,14 @@ class Compilers(
   ): s.TextDocument = {
     val pc = loadCompiler(source).getOrElse(fallbackCompiler(source))
 
-    val (prependedLinesSize, modifiedText) =
-      Option
-        .when(source.isSbt)(
-          buildTargets
-            .sbtAutoImports(source)
-        )
-        .flatten
-        .fold((0, text))(imports =>
-          (imports.size, SbtBuildTool.prependAutoImports(text, imports))
-        )
+    val (input, _, adjust) = sourceMapper.pcMapping(source, pc.scalaVersion())
 
     // NOTE(olafur): it's unfortunate that we block on `semanticdbTextDocument`
     // here but to avoid it we would need to refactor the `Semanticdbs` trait,
     // which requires more effort than it's worth.
     val params = new CompilerVirtualFileParams(
       source.toURI,
-      modifiedText,
+      input.value,
       token = EmptyCancelToken,
       outlineFiles = outlineFilesProvider.getOutlineFiles(pc.buildTargetId()),
     )
@@ -2273,61 +2252,7 @@ class Compilers(
       if (doc.text.isEmpty()) doc.withText(text)
       else doc
     }
-    if (prependedLinesSize > 0)
-      cleanupAutoImports(textDocument, text, prependedLinesSize)
-    else textDocument
-  }
-
-  private def cleanupAutoImports(
-      document: s.TextDocument,
-      originalText: String,
-      linesSize: Int,
-  ): s.TextDocument = {
-
-    def adjustRange(range: s.Range): Option[s.Range] = {
-      val nextStartLine = range.startLine - linesSize
-      val nextEndLine = range.endLine - linesSize
-      if (nextEndLine >= 0) {
-        val nextRange = range.copy(
-          startLine = nextStartLine,
-          endLine = nextEndLine,
-        )
-        Some(nextRange)
-      } else None
-    }
-
-    val adjustedOccurences =
-      document.occurrences.flatMap { occurence =>
-        occurence.range
-          .flatMap(adjustRange)
-          .map(r => occurence.copy(range = Some(r)))
-      }
-
-    val adjustedDiagnostic =
-      document.diagnostics.flatMap { diagnostic =>
-        diagnostic.range
-          .flatMap(adjustRange)
-          .map(r => diagnostic.copy(range = Some(r)))
-      }
-
-    val adjustedSynthetic =
-      document.synthetics.flatMap { synthetic =>
-        synthetic.range
-          .flatMap(adjustRange)
-          .map(r => synthetic.copy(range = Some(r)))
-      }
-
-    s.TextDocument(
-      schema = document.schema,
-      uri = document.uri,
-      text = originalText,
-      md5 = MD5.compute(originalText),
-      language = document.language,
-      symbols = document.symbols,
-      occurrences = adjustedOccurences,
-      diagnostics = adjustedDiagnostic,
-      synthetics = adjustedSynthetic,
-    )
+    adjust.adjustTextDocument(textDocument, text)
   }
 
 }
@@ -2350,15 +2275,4 @@ object Compilers {
     final case class Default(language: s.Language)
         extends PresentationCompilerKey
   }
-
-  // To be removed in the future after:
-  // - https://github.com/scalameta/metals/pull/7430
-  // - https://github.com/scala/scala3/pull/22259
-  case class DidChangeCompilerFileParams(
-      uri: URI,
-      text: String,
-      override val shouldReturnDiagnostics: Boolean,
-      token: CancelToken = EmptyCancelToken,
-  ) extends VirtualFileParams
-
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -19,6 +19,7 @@ import scala.meta.infra.Event
 import scala.meta.inputs.Input
 import scala.meta.internal.bsp.BspSession
 import scala.meta.internal.builds.WorkspaceReload
+import scala.meta.internal.metals.AdjustedLspData.LineColumn
 import scala.meta.internal.metals.Indexer.BackgroundJob
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.SemanticdbDefinition
@@ -397,12 +398,9 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
           topWrapperLineCount + scPos.getLine,
           scPos.getCharacter,
         )
-    val fromScala: Position => Position =
-      scalaPos =>
-        new Position(
-          scalaPos.getLine - topWrapperLineCount,
-          scalaPos.getCharacter,
-        )
+    val fromScala: LineColumn => LineColumn = { case (line, column) =>
+      (line - topWrapperLineCount, column)
+    }
 
     new TargetData.MappedSource {
       def path = generatedPath

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsPasteProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsPasteProvider.scala
@@ -33,10 +33,7 @@ class MetalsPasteProvider(
 
     val MissingSymbol = new MissingSymbolDiagnostic(isScala3, path)
     compilers
-      .didChangeWithDiagnostics(
-        path,
-        content = Some(params.text),
-      )
+      .didChangeWithDiagnostics(path)
       .flatMap { diagnostics =>
         val imports = diagnostics.collect {
           case d @ MissingSymbol(name, _)

--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
@@ -721,7 +721,7 @@ object SemanticTokensProvider {
           if (lineDelta == 0) character + charDelta
           else charDelta
 
-        val adjustedTokenPos = adjust.adjustPos(
+        val adjustedTokenPos = adjust.adjustPosition(
           new LspPosition(line + lineDelta, newCharacter),
           adjustToZero = false,
         )

--- a/metals/src/main/scala/scala/meta/internal/metals/SourceMapper.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SourceMapper.scala
@@ -48,7 +48,7 @@ final case class SourceMapper(
       } else if (
         path.isWorksheet && ScalaVersions.isScala3Version(scalaVersion)
       ) {
-        WorksheetProvider.worksheetScala3Adjustments(input)
+        Some(WorksheetProvider.worksheetScala3Adjustments(input))
       } else if (path.isTwirlTemplate) {
         val playVersion = buildTargets
           .inverseSources(path)

--- a/metals/src/main/scala/scala/meta/internal/metals/TwirlAdjustments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TwirlAdjustments.scala
@@ -7,6 +7,7 @@ import scala.io.Codec
 import scala.util.matching.Regex
 
 import scala.meta.inputs.Input.VirtualFile
+import scala.meta.internal.metals.AdjustedLspData.LineColumn
 
 import org.eclipse.lsp4j.Position
 import play.twirl.compiler.GeneratedSourceVirtual
@@ -107,6 +108,11 @@ object TwirlAdjustments {
     new Position(lines.length - 1, lines.last.length)
   }
 
+  private def getLineColumnFromIndex(text: String, index: Int): LineColumn = {
+    val lines = text.substring(0, index).split("\n", -1)
+    (lines.length - 1, lines.last.length)
+  }
+
   /**
    * Converts an LSP `Position` (0 based - line number and character offset) into a character index.
    *
@@ -114,12 +120,16 @@ object TwirlAdjustments {
    * @param pos the LSP `Position` to convert (line and character)
    * @return the absolute character index in the string corresponding to the position
    */
-  private def getIndexFromPosition(text: String, pos: Position): Int = {
+  private def getIndexFromPosition(
+      text: String,
+      line: Int,
+      character: Int,
+  ): Int = {
     val lines = text.split("\n", -1)
     lines
-      .take(pos.getLine)
+      .take(line)
       .map(_.length + 1)
-      .sum + pos.getCharacter
+      .sum + character
   }
 
   private val pattern: Regex = """(\d+)->(\d+)""".r
@@ -171,7 +181,11 @@ object TwirlAdjustments {
      * Position in the compiled Scala output
      */
     def mapPosition(originalPos: Position): Position = {
-      val originalIndex = getIndexFromPosition(originalTwirl, originalPos)
+      val originalIndex = getIndexFromPosition(
+        originalTwirl,
+        originalPos.getLine(),
+        originalPos.getCharacter(),
+      )
       val idx = matrix.indexWhere(_._1 >= originalIndex)
       if (matrix.isEmpty) {
         return originalPos
@@ -192,19 +206,22 @@ object TwirlAdjustments {
     /**
      * Maps a Position in the compiled Scala output back to the original
      */
-    def reverseMapPosition(compiledPos: Position): Position = {
-      val compiledIndex = getIndexFromPosition(compiledTwirl, compiledPos)
+    def reverseMapPosition(line: Int, column: Int): LineColumn = {
+      val compiledIndex =
+        getIndexFromPosition(compiledTwirl, line, column)
       val mappedIndex = math.min(
         originalTwirl.length,
         math.max(0, compiledSource.mapPosition(compiledIndex)),
       )
-      getPositionFromIndex(originalTwirl, mappedIndex)
+      getLineColumnFromIndex(originalTwirl, mappedIndex)
     }
 
     (
       newVirtualFile,
       mapPosition,
-      AdjustedLspData.create(reverseMapPosition),
+      AdjustedLspData.create { case (line, column) =>
+        reverseMapPosition(line, column)
+      },
     )
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -569,34 +569,34 @@ object WorksheetProvider {
   }
   final case class MdocRef(scalaVersion: String, value: Mdoc)
 
-  def worksheetScala3AdjustmentsForPC(
+  private def worksheetScala3AdjustmentsForPC(
       originInput: Input.VirtualFile
-  ): Option[(Input.VirtualFile, AdjustLspData)] = {
+  ): (Input.VirtualFile, AdjustLspData) = {
     val ident = "  "
     val withOuter =
       s"""object worksheet{\n$ident${originInput.value.replace("\n", "\n" + ident)}\n}"""
     val modifiedInput =
       originInput.copy(value = withOuter)
     val adjustLspData = AdjustedLspData.create(
-      pos => {
-        new Position(pos.getLine() - 1, pos.getCharacter() - ident.size)
+      {
+        case (line, column) => {
+          (line - 1, column - ident.size)
+        }
       },
       filterOutLocations = { loc => !loc.getUri().isWorksheet },
     )
-    Some((modifiedInput, adjustLspData))
+    (modifiedInput, adjustLspData)
   }
 
   def worksheetScala3Adjustments(
       originInput: Input.VirtualFile
-  ): Option[(Input.VirtualFile, Position => Position, AdjustLspData)] = {
-    worksheetScala3AdjustmentsForPC(originInput).map { case (input, adjust) =>
-      def adjustRequest(position: Position) = new Position(
-        position.getLine() + 1,
-        position.getCharacter() + 2,
-      )
-      (input, adjustRequest, adjust)
-
-    }
+  ): (Input.VirtualFile, Position => Position, AdjustLspData) = {
+    val (input, adjust) = worksheetScala3AdjustmentsForPC(originInput)
+    def adjustRequest(position: Position) = new Position(
+      position.getLine() + 1,
+      position.getCharacter() + 2,
+    )
+    (input, adjustRequest, adjust)
   }
 }
 

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetPcLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetPcLspSuite.scala
@@ -1,0 +1,66 @@
+package tests.worksheets
+
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import tests.BaseLspSuite
+
+class WorksheetPcLspSuite extends BaseLspSuite(s"worksheet-pc") {
+
+  override def userConfig: UserConfiguration = super.userConfig.copy(
+    presentationCompilerDiagnostics = true,
+    fallbackScalaVersion = Some(V.latestScala3Next),
+  )
+
+  test("diagnostics") {
+    cleanWorkspace()
+    val path = "a/src/main/scala/hi.worksheet.sc"
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${V.latestScala3Next}"
+           |  }
+           |}
+           |/${path}
+           |211 + 122 // no errors
+           |211 + 122 // no errors
+           |object O:
+           |  def file: String = "a"
+           |
+           |O.file
+           |O.file
+           |""".stripMargin
+      )
+      _ <- server.didOpen(path)
+      _ <- server.didChange(path)(_.replace("122", "123"))
+      _ = assertNoDiff(
+        // separate issue, should be silcenced separately
+        client.workspaceDiagnostics,
+        """|a/src/main/scala/hi.worksheet.sc:1:1: warning: A pure expression does nothing in statement position
+           |211 + 123 // no errors
+           |^^^^^^^^^
+           |a/src/main/scala/hi.worksheet.sc:2:1: warning: A pure expression does nothing in statement position
+           |211 + 123 // no errors
+           |^^^^^^^^^
+           |""".stripMargin,
+      )
+      _ <- server.assertReferencesSubquery(
+        path,
+        "O.fil@@e",
+        """|a/src/main/scala/hi.worksheet.sc:4:7: reference
+           |  def file: String = "a"
+           |      ^^^^
+           |a/src/main/scala/hi.worksheet.sc:6:3: reference
+           |O.file
+           |  ^^^^
+           |a/src/main/scala/hi.worksheet.sc:7:3: reference
+           |O.file
+           |  ^^^^""".stripMargin,
+      )
+    } yield ()
+  }
+
+}


### PR DESCRIPTION
Otherwise we will get false positive errors.

Turns out this needed to be done for both semanticdb as well as diagnostics.

I also refactored and made it a bit more consistent. There is room for further improvements for sure.

Fixes https://github.com/scalameta/metals/issues/8840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics, semantic tokens, references, and source mappings for worksheets, scripts, Twirl files, and transformed sources.
  * Preserved diagnostics, occurrences, and synthetics without ranges.
  * Retained large line and character coordinates without truncation.
  * Improved cancellation handling during file updates.

* **Tests**
  * Added coverage for worksheet diagnostics and references through the presentation compiler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->