### PR TITLE
fix #8851: do not fail MCP requests on unknown JSON properties

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpTools.scala
@@ -44,6 +44,7 @@ import org.eclipse.lsp4j.ApplyWorkspaceEditParams
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.services.LanguageClient
 import reactor.core.publisher.Mono
+import tools.jackson.databind.DeserializationFeature
 import tools.jackson.databind.json.JsonMapper
 
 /**
@@ -78,7 +79,10 @@ trait MetalsMcpTools extends Cancelable {
   protected lazy val client: Client =
     Client.allClients.find(_.names.contains(clientName)).getOrElse(NoClient)
 
-  protected val objectMapper: JsonMapper = JsonMapper.builder().build()
+  protected val objectMapper: JsonMapper = JsonMapper
+    .builder()
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .build()
 
   protected val jsonMapper = new JacksonMcpJsonMapper(objectMapper)
 

--- a/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
@@ -1,5 +1,9 @@
 package tests.mcp
 
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.time.Duration
 
 import scala.compat.java8.FutureConverters._
@@ -29,6 +33,22 @@ class TestMcpClient(url: String, val port: Int)(implicit ec: ExecutionContext)
     .build()
   private val client =
     McpClient.async(transport).requestTimeout(Duration.ofMinutes(5)).build()
+
+  def sendRawInitialize(
+      requestBody: String
+  ): Future[HttpResponse[String]] = {
+    val httpClient = HttpClient.newHttpClient()
+    val httpRequest = HttpRequest
+      .newBuilder()
+      .uri(URI.create(s"$url${MetalsMcpServer.mcpEndpoint}"))
+      .header("Content-Type", "application/json")
+      .header("Accept", "application/json, text/event-stream")
+      .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+      .build()
+    httpClient
+      .sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString())
+      .toScala
+  }
 
   override protected def callTool(
       toolName: String,

--- a/tests/unit/src/main/scala/tests/mcp/McpTestUtils.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestUtils.scala
@@ -11,7 +11,7 @@ import tests.BaseLspSuite
 trait McpTestUtils {
   self: BaseLspSuite =>
 
-  def startMcpServer(): Future[TestMcpClient] =
+  def startMcpServer(initialize: Boolean = true): Future[TestMcpClient] =
     for {
       _ <- server.didChangeConfiguration(
         UserConfiguration(startMcpServer = true).toString
@@ -25,6 +25,6 @@ trait McpTestUtils {
       )
       _ = assert(port.isDefined, "MCP server port should be defined")
       client = new TestMcpClient(s"http://localhost:${port.get}", port.get)
-      _ <- client.initialize()
+      _ <- if (initialize) client.initialize() else Future.successful(())
     } yield client
 }

--- a/tests/unit/src/test/scala/tests/mcp/McpServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpServerLspSuite.scala
@@ -457,6 +457,51 @@ class McpServerLspSuite extends BaseLspSuite("mcp-server") with McpTestUtils {
     } yield ()
   }
 
+  test("initialize-with-unknown-properties") {
+    cleanWorkspace()
+    val requestBody =
+      """|{
+         |    "jsonrpc": "2.0",
+         |    "id": 2,
+         |    "method": "initialize",
+         |    "params": {
+         |        "clientInfo": {
+         |            "name": "antigravity-client (via mcp-remote 0.8.6)",
+         |            "version": "v1.0.0"
+         |        },
+         |        "protocolVersion": "2025-11-25",
+         |        "capabilities": {
+         |            "elicitation": {
+         |                "form": {},
+         |                "url": {}
+         |            }
+         |        },
+         |        "somethingUnknown": false
+         |    }
+         |}""".stripMargin
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/a/src/main/scala/com/example/Hello.scala
+           |package com.example
+           |
+           |object Hello { def main(args: Array[String]): Unit = println("Hello") }
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/example/Hello.scala")
+      client <- startMcpServer(initialize = false)
+      response <- client.sendRawInitialize(requestBody)
+      _ = assertEquals(response.statusCode(), 200)
+      _ = assert(
+        response.body().contains("root-metals"),
+        s"Expected response to contain server info, got: ${response.body()}",
+      )
+      _ <- client.shutdown()
+    } yield ()
+  }
+
   override def afterEach(context: AfterEach): Unit = {
     super.afterEach(context)
     assertEquals(


### PR DESCRIPTION
### Summary

This PR makes a change so that the MCP server doesn't fail requests on unknown JSON properties.

Fixes #8851. 

### Testing

* Added an automated test (sending a raw JSON initialize).
* Tested end-to-end by publishing metals locally using this PR's version and configured it in Google Antigravity extension settings in VS code. The initialization succeeded.

MCP configuration for reference:

```
    "scala-metals-io": {
      "args": [
        "-y",
        "mcp-remote",
        "http://127.0.0.1:52352/mcp"
      ],
      "command": "npx"
    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - MCP initialization now accepts requests containing unrecognized properties and extended client capabilities without failing.
  - Successful initialization requests return HTTP 200 responses that include server information.

- **Tests**
  - Added regression coverage for initialization with unknown request properties and extended capabilities.
  - Expanded test support for sending raw initialization requests and testing servers without automatic initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->