### PR TITLE
Add language support for Scala notebook cells

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -692,10 +692,7 @@ final class BuildTargets private (
 
   def removeData(data: TargetData): Unit =
     dataLock.synchronized {
-      this.data match {
-        case BuildTargets.DataSeq(list) =>
-          BuildTargets.DataSeq(list.filterNot(_ == data))
-      }
+      this.data = BuildTargets.DataSeq(this.data.list.filterNot(_ == data))
     }
 
   def supportsPcRefs(id: BuildTargetIdentifier): Boolean = {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -781,10 +781,17 @@ object MetalsEnrichments
           None
       }
 
+    def isNotebookCellUri: Boolean = NotebookProvider.isNotebookCellUri(value)
+
     def toAbsolutePath: AbsolutePath = toAbsolutePath(followSymlink = true)
 
     def toAbsolutePath(followSymlink: Boolean): AbsolutePath =
-      MtagsEnrichments.XtensionStringMtags(value).toAbsolutePath(followSymlink)
+      if (isNotebookCellUri)
+        NotebookProvider.uriToPath(value)
+      else
+        MtagsEnrichments
+          .XtensionStringMtags(value)
+          .toAbsolutePath(followSymlink)
 
     def indexToLspPosition(index: Int): l.Position = {
       var i = 0
@@ -1527,6 +1534,18 @@ object MetalsEnrichments
           case _ => false
         }) =>
       e.getCause().getMessage()
+  }
+
+  implicit final class XtensionIterableOnce[C[X] <: IterableOnce[X], A](
+      private val coll: C[A]
+  ) extends AnyVal {
+    def toMapBy[K, V](keyFun: A => K, valueFun: A => V): Map[K, V] = {
+      val res = Map.newBuilder[K, V]
+      coll.iterator.foreach { a =>
+        res += ((keyFun(a), valueFun(a)))
+      }
+      res.result()
+    }
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1,64 +1,65 @@
 package scala.meta.internal.metals
 
+import ch.epfl.scala.bsp4j as b
+import ch.epfl.scala.bsp4j.CompileReport
+import org.eclipse.lsp4j as l
+import org.eclipse.lsp4j.{ExecuteCommandParams, *}
+import org.eclipse.lsp4j.jsonrpc.messages.Either as JEither
+
 import java.net.URI
-import java.nio.file._
+import java.nio.file.*
 import java.util
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
-
-import scala.collection.immutable.Nil
-import scala.concurrent.ExecutionContextExecutorService
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.concurrent.TimeoutException
-import scala.concurrent.duration._
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-import scala.util.control.NonFatal
-
-import scala.meta.internal.bsp.BspSession
-import scala.meta.internal.bsp.ConnectionBspStatus
-import scala.meta.internal.builds.BspErrorHandler
-import scala.meta.internal.builds.ShellRunner
-import scala.meta.internal.implementation.ImplementationProvider
-import scala.meta.internal.implementation.Supermethods
+import java.util.concurrent.{
+  CompletableFuture,
+  ScheduledExecutorService,
+  TimeUnit,
+}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import scala.concurrent.{
+  ExecutionContextExecutorService,
+  Future,
+  Promise,
+  TimeoutException,
+}
+import scala.concurrent.duration.*
+import scala.meta.internal.bsp.{BspSession, ConnectionBspStatus}
+import scala.meta.internal.builds.{BspErrorHandler, ShellRunner}
+import scala.meta.internal.implementation.{ImplementationProvider, Supermethods}
 import scala.meta.internal.io.FileIO
-import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.metals.StdReportContext
+import scala.meta.internal.metals.MetalsEnrichments.*
 import scala.meta.internal.metals.callHierarchy.CallHierarchyProvider
-import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
-import scala.meta.internal.metals.clients.language.ForwardingMetalsBuildClient
+import scala.meta.internal.metals.clients.language.{
+  ConfiguredLanguageClient,
+  ForwardingMetalsBuildClient,
+}
 import scala.meta.internal.metals.codeactions.CodeActionProvider
-import scala.meta.internal.metals.codelenses.RunTestCodeLens
-import scala.meta.internal.metals.codelenses.SuperMethodCodeLens
-import scala.meta.internal.metals.codelenses.WorksheetCodeLens
-import scala.meta.internal.metals.debug.BuildTargetClasses
-import scala.meta.internal.metals.debug.BuildTargetClassesFinder
-import scala.meta.internal.metals.debug.DebugDiscovery
-import scala.meta.internal.metals.debug.DebugProvider
-import scala.meta.internal.metals.debug.DiscoveryFailures
-import scala.meta.internal.metals.doctor.Doctor
-import scala.meta.internal.metals.doctor.HeadDoctor
-import scala.meta.internal.metals.doctor.MetalsServiceInfo
-import scala.meta.internal.metals.findfiles._
-import scala.meta.internal.metals.formatting.OnTypeFormattingProvider
-import scala.meta.internal.metals.formatting.RangeFormattingProvider
+import scala.meta.internal.metals.codelenses.{
+  RunTestCodeLens,
+  SuperMethodCodeLens,
+  WorksheetCodeLens,
+}
+import scala.meta.internal.metals.debug.*
+import scala.meta.internal.metals.doctor.{Doctor, HeadDoctor, MetalsServiceInfo}
+import scala.meta.internal.metals.findfiles.*
+import scala.meta.internal.metals.formatting.{
+  OnTypeFormattingProvider,
+  RangeFormattingProvider,
+}
 import scala.meta.internal.metals.newScalaFile.NewFileProvider
-import scala.meta.internal.metals.scalacli.ScalaCli
-import scala.meta.internal.metals.scalacli.ScalaCliServers
-import scala.meta.internal.metals.testProvider.BuildTargetUpdate
-import scala.meta.internal.metals.testProvider.TestSuitesProvider
+import scala.meta.internal.metals.scalacli.{ScalaCli, ScalaCliServers}
+import scala.meta.internal.metals.testProvider.{
+  BuildTargetUpdate,
+  TestSuitesProvider,
+}
 import scala.meta.internal.metals.typeHierarchy.TypeHierarchyProvider
 import scala.meta.internal.metals.watcher.FileWatcher
-import scala.meta.internal.mtags._
-import scala.meta.internal.parsing.ClassFinderGranularity
-import scala.meta.internal.parsing.DocumentSymbolProvider
-import scala.meta.internal.parsing.FoldingRangeProvider
-import scala.meta.internal.parsing.Trees
+import scala.meta.internal.mtags.*
+import scala.meta.internal.parsing.{
+  ClassFinderGranularity,
+  DocumentSymbolProvider,
+  FoldingRangeProvider,
+  Trees,
+}
 import scala.meta.internal.rename.RenameProvider
 import scala.meta.internal.search.SymbolHierarchyOps
 import scala.meta.internal.worksheets.WorksheetProvider
@@ -67,13 +68,8 @@ import scala.meta.metals.lsp.TextDocumentService
 import scala.meta.parsers.ParseException
 import scala.meta.pc.CancelToken
 import scala.meta.tokenizers.TokenizeException
-
-import ch.epfl.scala.bsp4j.CompileReport
-import ch.epfl.scala.{bsp4j => b}
-import org.eclipse.lsp4j.ExecuteCommandParams
-import org.eclipse.lsp4j._
-import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
-import org.eclipse.{lsp4j => l}
+import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 
 /**
  * Metals implementation of the Scala Language Service.
@@ -118,7 +114,7 @@ abstract class MetalsLspService(
     with TextDocumentService
     with IndexProviders
     with ModulesService {
-  import serverInputs._
+  import serverInputs.*
 
   def focusedDocument: Option[AbsolutePath] = getFocusedDocument()
   def shellRunner: ShellRunner
@@ -211,9 +207,28 @@ abstract class MetalsLspService(
 
   protected val downstreamTargets = new PreviouslyCompiledDownsteamTargets
 
+  val parseTrees = new BatchedFunction[AbsolutePath, Unit](
+    paths =>
+      CancelableFuture(
+        buildServerPromise.future
+          .flatMap(_ => parseTreesAndPublishDiags(paths))
+          .ignoreValue,
+        Cancelable.empty,
+      ),
+    "trees",
+  )
+
+  val notebookProvider: NotebookProvider = new NotebookProvider(
+    buffers,
+    languageClient,
+    () => compilers,
+    parseTrees(_),
+  )(using ec)
+
   val sourceMapper: SourceMapper = SourceMapper(
     buildTargets,
     buffers,
+    notebookProvider,
   )
 
   val compilations: Compilations = new Compilations(
@@ -236,16 +251,6 @@ abstract class MetalsLspService(
   )
   var indexingPromise: Promise[Unit] = Promise[Unit]()
   def buildServerPromise: Promise[Unit]
-  val parseTrees = new BatchedFunction[AbsolutePath, Unit](
-    paths =>
-      CancelableFuture(
-        buildServerPromise.future
-          .flatMap(_ => parseTreesAndPublishDiags(paths))
-          .ignoreValue,
-        Cancelable.empty,
-      ),
-    "trees",
-  )
 
   protected val trees = new Trees(buffers, scalaVersionSelector)
 
@@ -745,70 +750,73 @@ abstract class MetalsLspService(
       params: DidOpenTextDocumentParams
   ): CompletableFuture[Unit] = {
     val path = params.getTextDocument.getUri.toAbsolutePath
-    // In some cases like peeking definition didOpen might be followed up by close
-    // and we would lose the notion of the focused document
-    recentlyOpenedFiles.add(path)
-    focusedDocumentBuildTarget.set(
-      buildTargets.inverseSources(path).getOrElse(null)
-    )
-    buildTargets
-      .inverseSources(path)
-      .flatMap(buildTargets.activatePlatformForTarget)
-      .foreach { platform =>
-        buildTargetClasses.rebuildIndex(
-          buildTargets.targetsByPlatform(platform)
-        )
-      }
+    // Notebook cells are tracked from `notebookDocument/didOpen` instead
+    if (params.getTextDocument.getUri.isNotebookCellUri) {
+      CompletableFuture.completedFuture(())
+    } else {
+      // In some cases like peeking definition didOpen might be followed up by close
+      // and we would lose the notion of the focused document
+      recentlyOpenedFiles.add(path)
+      focusedDocumentBuildTarget.set(buildTargets.inverseSources(path).orNull)
+      buildTargets
+        .inverseSources(path)
+        .flatMap(buildTargets.activatePlatformForTarget)
+        .foreach { platform =>
+          buildTargetClasses.rebuildIndex(
+            buildTargets.targetsByPlatform(platform)
+          )
+        }
 
-    // Update md5 fingerprint from file contents on disk
-    fingerprints.add(path, FileIO.slurp(path, charset))
-    // Update in-memory buffer contents from LSP client
-    buffers.put(
-      path,
-      params.getTextDocument.getText,
-      params.getTextDocument.getVersion(),
-    )
-
-    val optVersion =
-      Option.when(initializeParams.supportsVersionedWorkspaceEdits)(
-        params.getTextDocument().getVersion()
+      // Update md5 fingerprint from file contents on disk
+      fingerprints.add(path, FileIO.slurp(path, charset))
+      // Update in-memory buffer contents from LSP client
+      buffers.put(
+        path,
+        params.getTextDocument.getText,
+        params.getTextDocument.getVersion,
       )
 
-    packageProvider
-      .workspaceEdit(path, params.getTextDocument().getText(), optVersion)
-      .map(new ApplyWorkspaceEditParams(_))
-      .foreach(languageClient.applyEdit)
+      val optVersion =
+        Option.when(initializeParams.supportsVersionedWorkspaceEdits)(
+          params.getTextDocument.getVersion
+        )
 
-    /**
-     * Trigger compilation in preparation for definition requests for dependency
-     * sources and standalone files, but wait for build tool information, so
-     * that we don't try to generate it for project files
-     */
-    val interactive = buildServerPromise.future.map { _ =>
-      interactiveSemanticdbs.textDocument(path)
-    }
+      packageProvider
+        .workspaceEdit(path, params.getTextDocument.getText, optVersion)
+        .map(new ApplyWorkspaceEditParams(_))
+        .foreach(languageClient.applyEdit)
 
-    val parser = parseTrees(path)
+      /**
+       * Trigger compilation in preparation for definition requests for dependency
+       * sources and standalone files, but wait for build tool information, so
+       * that we don't try to generate it for project files
+       */
+      val interactive = buildServerPromise.future.map { _ =>
+        interactiveSemanticdbs.textDocument(path)
+      }
 
-    if (path.isDependencySource(folder)) {
-      parser.asJava
-    } else {
-      buildServerPromise.future.flatMap { _ =>
-        def load(): Future[Unit] = {
-          Future
-            .sequence(
-              List(
-                compilations.compileFile(path, assumeDidNotChange = true),
-                compilers.load(List(path)),
-                parser,
-                interactive,
-                testProvider.didOpen(path),
+      val parser = parseTrees(path)
+
+      if (path.isDependencySource(folder)) {
+        parser.asJava
+      } else {
+        buildServerPromise.future.flatMap { _ =>
+          def load(): Future[Unit] = {
+            Future
+              .sequence(
+                List(
+                  compilations.compileFile(path, assumeDidNotChange = true),
+                  compilers.load(List(path)),
+                  parser,
+                  interactive,
+                  testProvider.didOpen(path),
+                )
               )
-            )
-            .ignoreValue
-        }
-        maybeImportFileAndLoad(path, load)
-      }.asJava
+              .ignoreValue
+          }
+          maybeImportFileAndLoad(path, load)
+        }.asJava
+      }
     }
   }
 
@@ -860,29 +868,48 @@ abstract class MetalsLspService(
       )
     }
 
-    params.getContentChanges.asScala.lastOption match {
-      case None => CompletableFuture.completedFuture(())
-      case Some(change) =>
-        val path = params.getTextDocument.getUri.toAbsolutePath
-        Option(params.getTextDocument.getVersion()) match {
-          case Some(version) => buffers.put(path, change.getText, version)
-          case None => buffers.put(path, change.getText)
-        }
-        diagnostics.didChange(path)
-        compilers.didChange(path, false)
-        referencesProvider.didChange(path, change.getText)
-        parseTrees(path).asJava
+    // Notebook cells are tracked from `notebookDocument/didChange` instead.
+    if (params.getTextDocument.getUri.isNotebookCellUri) {
+      CompletableFuture.completedFuture(())
+    } else {
+      params.getContentChanges.asScala.lastOption match {
+        case None => CompletableFuture.completedFuture(())
+        case Some(change) =>
+          val path = params.getTextDocument.getUri.toAbsolutePath
+          params.getTextDocument.getVersion match {
+            case null => buffers.put(path, change.getText)
+            case version => buffers.put(path, change.getText, version)
+          }
+          diagnostics.didChange(path)
+          compilers.didChange(path, shouldReturnDiagnostics = false)
+          referencesProvider.didChange(path, change.getText)
+          parseTrees(path).asJava
+      }
     }
   }
 
-  override def didClose(params: DidCloseTextDocumentParams): Unit = {
-    val path = params.getTextDocument.getUri.toAbsolutePath
-    buffers.remove(path)
-    compilers.didClose(path)
-    trees.didClose(path)
-    diagnostics.onClose(path)
-    interactiveSemanticdbs.onClose(path)
-  }
+  override def didClose(params: DidCloseTextDocumentParams): Unit =
+    // Notebook cells are tracked from `notebookDocument/didClose` instead.
+    if (!params.getTextDocument.getUri.isNotebookCellUri) {
+      val path = params.getTextDocument.getUri.toAbsolutePath
+      buffers.remove(path)
+      compilers.didClose(path)
+      trees.didClose(path)
+      diagnostics.onClose(path)
+      interactiveSemanticdbs.onClose(path)
+    }
+
+  def notebookDidOpen(params: DidOpenNotebookDocumentParams): Unit =
+    notebookProvider.didOpen(params)
+
+  def notebookDidChange(params: DidChangeNotebookDocumentParams): Unit =
+    notebookProvider.didChange(params)
+
+  def notebookDidClose(params: DidCloseNotebookDocumentParams): Unit =
+    notebookProvider.didClose(params)
+
+  def notebookDidSave(params: DidSaveNotebookDocumentParams): Unit =
+    notebookProvider.didSave(params)
 
   override def didSave(
       params: DidSaveTextDocumentParams

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -223,6 +223,7 @@ abstract class MetalsLspService(
     languageClient,
     () => compilers,
     parseTrees(_),
+    buildTargets,
   )(using ec)
 
   val sourceMapper: SourceMapper = SourceMapper(
@@ -910,6 +911,11 @@ abstract class MetalsLspService(
 
   def notebookDidSave(params: DidSaveNotebookDocumentParams): Unit =
     notebookProvider.didSave(params)
+
+  def chooseNotebookBuildTarget(notebookUri: String): Future[Unit] =
+    notebookProvider
+      .chooseAndSetBuildTarget(notebookUri.toAbsolutePath)
+      .map(_ => ())
 
   override def didSave(
       params: DidSaveTextDocumentParams

--- a/metals/src/main/scala/scala/meta/internal/metals/NotebookProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NotebookProvider.scala
@@ -1,0 +1,443 @@
+package scala.meta.internal.metals
+
+import java.net.URI
+import java.nio.file.Paths
+import java.util as ju
+import scala.annotation.tailrec
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+import scala.meta.inputs.Input
+import scala.meta.internal.metals.MetalsEnrichments.*
+import scala.meta.io.AbsolutePath
+import org.eclipse.lsp4j.Diagnostic
+import org.eclipse.lsp4j.DidChangeNotebookDocumentParams
+import org.eclipse.lsp4j.DidCloseNotebookDocumentParams
+import org.eclipse.lsp4j.DidOpenNotebookDocumentParams
+import org.eclipse.lsp4j.DidSaveNotebookDocumentParams
+import org.eclipse.lsp4j.Location
+import org.eclipse.lsp4j.NotebookCell
+import org.eclipse.lsp4j.NotebookCellKind
+import org.eclipse.lsp4j.NotebookDocumentChangeEventCellStructure
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.services.LanguageClient
+
+import scala.util.chaining.scalaUtilChainingOps
+
+/**
+ * Gives Scala notebook cells (`vscode-notebook-cell:` documents, see
+ * https://github.com/scalameta/metals-feature-requests/issues/236) cross-cell
+ * language support without running any code: [[combinedAdjustments]]
+ * concatenates a notebook's cells into one virtual script so a cell can see
+ * imports/vals from earlier ones, and [[triggerDiagnostics]] typechecks that
+ * concatenation and fans the resulting diagnostics back out per cell.
+ *
+ * Each cell gets a synthetic, never-written-to-disk `.sc` path (see
+ * [[NotebookProvider.cellPath]]) that is a pure function of its uri, so
+ * `toAbsolutePath` can resolve it with no registry lookup.
+ *
+ * Deliberately out of scope: executing cells, and any project/build-target
+ * classpath inside a cell (same non-goals as the design doc at
+ * https://github.com/scalameta/metals/issues/4434) — cells only see the
+ * standard library, exactly like any other standalone scratch `.sc` file.
+ */
+final class NotebookProvider(
+    buffers: Buffers,
+    languageClient: LanguageClient,
+    compilers: () => Compilers,
+    // Ordinary `textDocument/didOpen|didChange` also feed the parsed-trees
+    // cache that features like `textDocument/foldingRange` read from
+    // (`MetalsLspService.parseTrees`, a `BatchedFunction`); since notebook
+    // cells skip that normal flow entirely (MetalsLspService.didOpen/didChange
+    // are no-ops for `vscode-notebook-cell:` uris), we have to feed it
+    // ourselves or those features see a cell that was "never opened".
+    parseTrees: AbsolutePath => Future[Unit],
+)(implicit ec: ExecutionContext) {
+  import NotebookProvider.*
+
+  // real `.ipynb` path -> ordered synthetic cell paths
+  private val notebooks = TrieMap.empty[AbsolutePath, Vector[AbsolutePath]]
+  // synthetic cell path -> which notebook/uri it belongs to
+  private val cells = TrieMap.empty[AbsolutePath, CellRef]
+  // real `.ipynb` path -> its last-combined script + cell offsets; combining
+  // is the same string-building work whether it's for one hover/completion
+  // request or the whole-notebook diagnostics pass, so cache it rather than
+  // rebuilding it from scratch on every single request. Invalidated whenever
+  // any cell's content or the cell list itself changes.
+  private val combinedCache =
+    TrieMap.empty[AbsolutePath, CombinedScript]
+
+  def didOpen(params: DidOpenNotebookDocumentParams): Unit = {
+    val ipynbPath = params.getNotebookDocument.getUri.toAbsolutePath
+    val languageById =
+      params.getCellTextDocuments.asScala.toMapBy(_.getUri, _.getLanguageId)
+    val order = params.getNotebookDocument.getCells.asScala.iterator
+      .filter(cell => cell.getKind == NotebookCellKind.Code)
+      .filter(cell => languageById.get(cell.getDocument) contains "scala")
+      .map(_.getDocument)
+      .toVector
+    val initialText =
+      params.getCellTextDocuments.asScala.toMapBy(_.getUri, _.getText)
+    registerCells(ipynbPath, order, initialText)
+    triggerDiagnostics(ipynbPath)
+  }
+
+  def didChange(params: DidChangeNotebookDocumentParams): Unit = {
+    val ipynbPath = params.getNotebookDocument.getUri.toAbsolutePath
+    val cellsChange = Option(params.getChange).flatMap(c => Option(c.getCells))
+
+    for {
+      cellsChange <- cellsChange
+      structure <- Option(cellsChange.getStructure)
+    } applyStructureChange(ipynbPath, structure)
+
+    for {
+      cellsChange <- cellsChange
+      textContents <- Option(cellsChange.getTextContent)
+      textContent <- textContents.asScala
+    } {
+      val path = uriToPath(textContent.getDocument.getUri)
+      val current = buffers.get(path).getOrElse("")
+      val updated = textContent.getChanges.asScala.foldLeft(current) {
+        (text, change) =>
+          change.getRange match {
+            case null => change.getText
+            case range =>
+              TextEdits.applyEdits(
+                text,
+                List(new TextEdit(range, change.getText)),
+              )
+          }
+      }
+      buffers.put(path, updated)
+      parseTrees(path)
+      combinedCache.remove(ipynbPath)
+    }
+
+    triggerDiagnostics(ipynbPath)
+  }
+
+  def didClose(params: DidCloseNotebookDocumentParams): Unit = {
+    val ipynbPath = params.getNotebookDocument.getUri.toAbsolutePath
+    forgetNotebook(ipynbPath)
+  }
+
+  def didSave(@annotation.unused params: DidSaveNotebookDocumentParams): Unit =
+    ()
+
+  /**
+   * Consulted from [[SourceMapper.pcMapping]]. `None` for any path that
+   * isn't a currently-known notebook cell (in particular: every ordinary,
+   * non-notebook path), in which case the caller falls back to treating
+   * `path` as a standalone file.
+   */
+  def combinedAdjustments(
+      path: AbsolutePath
+  ): Option[(Input.VirtualFile, Position => Position, AdjustLspData)] = for {
+    ref <- cells.get(path)
+    cellPaths <- notebooks.get(ref.ipynbPath)
+    idx = cellPaths.indexOf(path)
+    if idx >= 0
+    combined = combine(ref.ipynbPath, cellPaths)
+    startLine = combined.offsets(idx)
+  } yield (
+    Input.VirtualFile(path.toURI.toString, combined.text),
+    (pos: Position) => new Position(pos.getLine + startLine, pos.getCharacter),
+    cellAdjustLspData(cellPaths, combined.offsets, startLine),
+  )
+
+  /**
+   * Hover/completion/diagnostic/textEdit ranges are always local to the
+   * requesting cell (they're anchored at the position we asked about), so
+   * the single fixed `startLine` shift from [[AdjustLspData.adjustPos]] is
+   * correct for them. `Location`-returning features (definition, references,
+   * ...) are different: they can point anywhere in the concatenated script,
+   * so each one gets its own owning cell's offset and uri instead.
+   */
+  private def cellAdjustLspData(
+      cellPaths: Vector[AbsolutePath],
+      offsets: Vector[Int],
+      startLine: Int,
+  ): AdjustLspData = new AdjustLspData {
+    override def adjustPos(
+        pos: Position,
+        adjustToZero: Boolean = true,
+    ): Position = new Position(pos.getLine - startLine, pos.getCharacter).tap {
+      adjusted =>
+        if (adjustToZero) {
+          if (adjusted.getCharacter < 0) adjusted.setCharacter(0)
+          if (adjusted.getLine < 0) adjusted.setLine(0)
+        }
+    }
+
+    override def adjustLocation(location: Location): Location = {
+      val idx = ownerIndex(offsets, location.getRange.getStart.getLine)
+      val cellOffset = offsets(idx)
+      val uri = cells
+        .get(cellPaths(idx))
+        .map(_.uri)
+        .getOrElse(cellPaths(idx).toURI.toString)
+
+      def shift(pos: Position): Unit =
+        pos.setLine(math.max(0, pos.getLine - cellOffset))
+
+      shift(location.getRange.getStart)
+      shift(location.getRange.getEnd)
+      location.setUri(uri)
+      location
+    }
+
+    override def adjustLocations(
+        locations: ju.List[Location]
+    ): ju.List[Location] =
+      locations.map(adjustLocation)
+  }
+
+  private def registerCells(
+      ipynbPath: AbsolutePath,
+      order: Vector[String],
+      initialText: Map[String, String],
+  ): Unit = {
+    forgetNotebook(ipynbPath)
+    val paths = order.map { uri =>
+      val path = uriToPath(uri)
+      cells.put(path, CellRef(ipynbPath, uri))
+      initialText.get(uri).foreach { text =>
+        buffers.put(path, text)
+        parseTrees(path)
+      }
+      path
+    }
+    notebooks.put(ipynbPath, paths)
+  }
+
+  private def applyStructureChange(
+      ipynbPath: AbsolutePath,
+      structure: NotebookDocumentChangeEventCellStructure,
+  ): Unit = {
+    val current = notebooks.getOrElse(ipynbPath, Vector.empty)
+    // Language for a cell newly appearing in this change comes from its
+    // matching `didOpen` entry; a cell reappearing without one is just being
+    // reordered/moved, so trust whatever we already recorded for it.
+    val openedLanguageById = Option(structure.getDidOpen)
+      .map(_.asScala.toMapBy(_.getUri, _.getLanguageId))
+      .getOrElse(Map.empty)
+    def isScalaCodeCell(cell: NotebookCell): Boolean =
+      cell.getKind == NotebookCellKind.Code && {
+        openedLanguageById.get(cell.getDocument) match {
+          case Some(languageId) => languageId == "scala"
+          case None => cells.contains(uriToPath(cell.getDocument))
+        }
+      }
+    val updated = structure.getArray match {
+      case null => current
+      case arrayChange =>
+        val replacement = Option(arrayChange.getCells)
+          .map(
+            _.asScala.iterator
+              .filter(isScalaCodeCell)
+              .map(cell => uriToPath(cell.getDocument))
+              .toVector
+          )
+          .getOrElse(Vector.empty)
+        current.patch(
+          arrayChange.getStart,
+          replacement,
+          arrayChange.getDeleteCount,
+        )
+    }
+    for {
+      opened <- Option(structure.getDidOpen)
+      textDocument <- opened.asScala
+      if textDocument.getLanguageId == "scala"
+      path = uriToPath(textDocument.getUri)
+    } {
+      cells.put(path, CellRef(ipynbPath, textDocument.getUri))
+      buffers.put(path, textDocument.getText)
+      parseTrees(path)
+    }
+    for {
+      closed <- Option(structure.getDidClose)
+      textDocument <- closed.asScala
+      path = uriToPath(textDocument.getUri)
+    } {
+      cells.remove(path)
+      buffers.remove(path)
+      clearDiagnostics(textDocument.getUri)
+    }
+    notebooks.put(ipynbPath, updated)
+    combinedCache.remove(ipynbPath)
+  }
+
+  private def forgetNotebook(ipynbPath: AbsolutePath): Unit = {
+    for {
+      paths <- notebooks.remove(ipynbPath)
+      path <- paths
+      ref <- cells.remove(path)
+    } {
+      clearDiagnostics(ref.uri)
+      buffers.remove(path)
+    }
+    combinedCache.remove(ipynbPath)
+  }
+
+  private def clearDiagnostics(uri: String): Unit =
+    languageClient.publishDiagnostics(
+      new PublishDiagnosticsParams(uri, new ju.ArrayList())
+    )
+
+  private def combine(
+      ipynbPath: AbsolutePath,
+      cellPaths: Vector[AbsolutePath],
+  ): CombinedScript =
+    combinedCache.getOrElseUpdate(ipynbPath, computeCombined(cellPaths))
+
+  /**
+   * A bare expression statement (`xs`, `xs.length`, `println(xs)`, ...) —
+   * completely ordinary notebook cell content — is not itself valid at the
+   * true top level of a Scala 3 source file: Scala 3 allows multiple
+   * top-level `val`/`def`/`class`/... *definitions* side by side, but a
+   * standalone expression is only legal as a *statement inside a body*
+   * (e.g. a constructor/object body), same as it would be in a REPL or a
+   * worksheet. Real worksheets get that leniency from mdoc's wrapping, which
+   * we deliberately don't run (that's execution). Wrapping the concatenation
+   * in a throwaway `object` gives the same leniency for free, with no
+   * execution: every cell becomes a statement in that object's body, and
+   * every position shift below only has to account for the one extra header
+   * line.
+   */
+  private val wrapperHeader = "object Notebook {\n"
+  private val wrapperFooter = "\n}\n"
+
+  private def computeCombined(
+      cellPaths: Vector[AbsolutePath]
+  ): CombinedScript = {
+    var line = wrapperHeader.count(_ == '\n')
+    val offsets = Vector.newBuilder[Int]
+    val sb = new StringBuilder(wrapperHeader)
+    for {
+      path <- cellPaths
+      text = buffers.get(path).getOrElse("")
+    } {
+      offsets += line
+      sb.append(text).append('\n')
+      line += text.count(_ == '\n') + 1
+    }
+    sb.append(wrapperFooter)
+    CombinedScript(sb.toString, offsets.result())
+  }
+
+  /**
+   * Typechecks the whole notebook as one concatenated script and republishes
+   * the resulting diagnostics against each individual cell's own uri.
+   *
+   * This intentionally does not go through [[combinedAdjustments]]/
+   * `Compilers.didChange`'s own notebook awareness: `markerPath` is never
+   * registered as a cell, so `Compilers.didChange` typechecks exactly the
+   * `content` passed here with no further remapping, and this method does
+   * its own per-cell split of the resulting diagnostics.
+   */
+  private def triggerDiagnostics(ipynbPath: AbsolutePath): Unit = for {
+    cellPaths <- notebooks.get(ipynbPath)
+    combined = combine(ipynbPath, cellPaths)
+    markerPath = combinedMarkerPath(ipynbPath)
+  } {
+    compilers()
+      .didChange(
+        markerPath,
+        shouldReturnDiagnostics = true,
+        Some(combined.text),
+      )
+      .map(publishPerCell(cellPaths, combined.offsets, _))
+      .recover { case NonFatal(e) =>
+        scribe.error(
+          s"failed to compute diagnostics for notebook $ipynbPath",
+          e,
+        )
+      }
+  }
+
+  private def publishPerCell(
+      cellPaths: Vector[AbsolutePath],
+      offsets: Vector[Int],
+      diagnostics: List[Diagnostic],
+  ): Unit = {
+    val byCell =
+      Vector.fill(cellPaths.length)(new ju.ArrayList[Diagnostic]())
+    // Guard against any single malformed diagnostic (e.g. a parse error with
+    // no range) losing the whole batch: every other cell still deserves its
+    // diagnostics/its "all clear".
+    for {
+      diagnostic <- diagnostics
+      range <- Option(diagnostic.getRange)
+      idx = ownerIndex(offsets, range.getStart.getLine)
+    } {
+      range.getStart.setLine(
+        math.max(0, range.getStart.getLine - offsets(idx))
+      )
+      range.getEnd.setLine(math.max(0, range.getEnd.getLine - offsets(idx)))
+      byCell(idx).add(diagnostic)
+    }
+
+    for {
+      i <- cellPaths.indices
+      uri = cells
+        .get(cellPaths(i))
+        .map(_.uri)
+        .getOrElse(cellPaths(i).toURI.toString)
+    } languageClient.publishDiagnostics(
+      new PublishDiagnosticsParams(uri, byCell(i))
+    )
+  }
+
+  @tailrec
+  private def ownerIndex(offsets: Vector[Int], line: Int, idx: Int = 0): Int =
+    if (idx + 1 < offsets.length && offsets(idx + 1) <= line)
+      ownerIndex(offsets, line, idx + 1)
+    else idx
+}
+
+object NotebookProvider {
+  val scheme: String = "vscode-notebook-cell"
+
+  def isNotebookCellUri(uri: String): Boolean = uri.startsWith(s"$scheme:")
+
+  /**
+   * Deterministic, registry-free mapping from a `vscode-notebook-cell:` uri
+   * to a synthetic `AbsolutePath`. Used from
+   * `MetalsEnrichments.XtensionString.toAbsolutePath` so it works for any
+   * caller, not just ones with a live `NotebookProvider` instance.
+   */
+  def uriToPath(uri: String): AbsolutePath = {
+    val parsed = new URI(uri)
+    val ipynbPath = AbsolutePath(Paths.get(parsed.getPath))
+    val fragment = Option(parsed.getRawFragment).getOrElse("")
+    cellPath(ipynbPath, fragment)
+  }
+
+  def cellPath(ipynbPath: AbsolutePath, cellFragment: String): AbsolutePath = {
+    val sanitized = cellFragment.replaceAll("[^A-Za-z0-9_-]", "_")
+    notebookScratchDir(ipynbPath).resolve(
+      s"${if (sanitized.isEmpty) "cell" else sanitized}.sc"
+    )
+  }
+
+  def combinedMarkerPath(ipynbPath: AbsolutePath): AbsolutePath =
+    notebookScratchDir(ipynbPath).resolve("__combined__.sc")
+
+  private def notebookScratchDir(ipynbPath: AbsolutePath): AbsolutePath = {
+    val name = ipynbPath.filename
+    val dot = name.lastIndexOf('.')
+    val stem = if (dot > 0) name.substring(0, dot) else name
+    ipynbPath.parent
+      .resolve(Directories.tmp)
+      .resolve("notebooks")
+      .resolve(stem)
+  }
+
+  private final case class CellRef(ipynbPath: AbsolutePath, uri: String)
+  private final case class CombinedScript(text: String, offsets: Vector[Int])
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/NotebookProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NotebookProvider.scala
@@ -10,7 +10,11 @@ import scala.concurrent.Future
 import scala.util.control.NonFatal
 import scala.meta.inputs.Input
 import scala.meta.internal.metals.MetalsEnrichments.*
+import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.clients.language.MetalsQuickPickItem
+import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
 import scala.meta.io.AbsolutePath
+import ch.epfl.scala.bsp4j as b
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DidChangeNotebookDocumentParams
 import org.eclipse.lsp4j.DidCloseNotebookDocumentParams
@@ -23,7 +27,6 @@ import org.eclipse.lsp4j.NotebookDocumentChangeEventCellStructure
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.TextEdit
-import org.eclipse.lsp4j.services.LanguageClient
 
 import scala.util.chaining.scalaUtilChainingOps
 
@@ -46,7 +49,7 @@ import scala.util.chaining.scalaUtilChainingOps
  */
 final class NotebookProvider(
     buffers: Buffers,
-    languageClient: LanguageClient,
+    languageClient: MetalsLanguageClient,
     compilers: () => Compilers,
     // Ordinary `textDocument/didOpen|didChange` also feed the parsed-trees
     // cache that features like `textDocument/foldingRange` read from
@@ -55,6 +58,7 @@ final class NotebookProvider(
     // are no-ops for `vscode-notebook-cell:` uris), we have to feed it
     // ourselves or those features see a cell that was "never opened".
     parseTrees: AbsolutePath => Future[Unit],
+    buildTargets: BuildTargets,
 )(implicit ec: ExecutionContext) {
   import NotebookProvider.*
 
@@ -69,6 +73,18 @@ final class NotebookProvider(
   // any cell's content or the cell list itself changes.
   private val combinedCache =
     TrieMap.empty[AbsolutePath, CombinedScript]
+  // real `.ipynb` path -> the build target its cells should resolve against,
+  // if the user has associated one (absent until they pick one, or if the
+  // notebook has never been opened while the workspace had exactly one
+  // build target to auto-associate with).
+  private val associatedTarget =
+    TrieMap.empty[AbsolutePath, b.BuildTargetIdentifier]
+  // real `.ipynb` path -> the `TargetData` currently registered into
+  // `buildTargets` for that notebook's *current* cell paths. `TargetData`
+  // has no "remove a single source item" operation, only whole-instance
+  // granularity, so a change to the cell set or the association replaces
+  // this wholesale rather than mutating it in place.
+  private val registeredData = TrieMap.empty[AbsolutePath, TargetData]
 
   def didOpen(params: DidOpenNotebookDocumentParams): Unit = {
     val ipynbPath = params.getNotebookDocument.getUri.toAbsolutePath
@@ -82,6 +98,12 @@ final class NotebookProvider(
     val initialText =
       params.getCellTextDocuments.asScala.toMapBy(_.getUri, _.getText)
     registerCells(ipynbPath, order, initialText)
+    if (!associatedTarget.contains(ipynbPath)) {
+      buildTargets.allBuildTargetIds match {
+        case Seq(only) => associate(ipynbPath, Some(only))
+        case _ => // ambiguous or none; leave unassociated until the user picks
+      }
+    }
     triggerDiagnostics(ipynbPath)
   }
 
@@ -127,6 +149,88 @@ final class NotebookProvider(
 
   def didSave(@annotation.unused params: DidSaveNotebookDocumentParams): Unit =
     ()
+
+  /**
+   * Associates `ipynbPath` with one of the workspace's build targets, so its
+   * cells' presentation-compiler features see that target's real dependency
+   * classpath instead of just the standard library. Auto-picks if there's
+   * exactly one candidate, does nothing if there are none, otherwise asks
+   * the user via `metals/quickPick` — mirrors
+   * `DebugDiscovery.requestMain`'s auto-pick/quickpick split.
+   */
+  def chooseAndSetBuildTarget(
+      ipynbPath: AbsolutePath
+  ): Future[Option[b.BuildTargetIdentifier]] =
+    buildTargets.allBuildTargetIds match {
+      case Seq(only) =>
+        setBuildTarget(ipynbPath, Some(only))
+        Future.successful(Some(only))
+      case Seq() =>
+        Future.successful(None)
+      case many =>
+        val items = many.map { id =>
+          new MetalsQuickPickItem(
+            id.getUri,
+            buildTargets.info(id).map(_.getDisplayName).getOrElse(id.getUri),
+          )
+        }
+        languageClient
+          .metalsQuickPick(
+            new MetalsQuickPickParams(
+              items.asJava,
+              placeHolder = "Pick a build target for this notebook's cells",
+            )
+          )
+          .asScala
+          .map(_.flatMap(choice => many.find(_.getUri == choice.itemId)))
+          .map { chosen =>
+            chosen.foreach(id => setBuildTarget(ipynbPath, Some(id)))
+            chosen
+          }
+    }
+
+  def setBuildTarget(
+      ipynbPath: AbsolutePath,
+      target: Option[b.BuildTargetIdentifier],
+  ): Unit = {
+    associate(ipynbPath, target)
+    triggerDiagnostics(ipynbPath)
+  }
+
+  private def associate(
+      ipynbPath: AbsolutePath,
+      target: Option[b.BuildTargetIdentifier],
+  ): Unit = {
+    target match {
+      case Some(id) => associatedTarget.put(ipynbPath, id)
+      case None => associatedTarget.remove(ipynbPath)
+    }
+    reregisterTargetData(ipynbPath)
+  }
+
+  /**
+   * `TargetData.addSourceItem` is a plain, synchronous map write with no BSP
+   * round-trip; `BuildTargets.scalaTarget`/`targetClasspath` look up a
+   * `BuildTargetIdentifier` across every registered `TargetData`, not just
+   * whichever one added it, so pointing a notebook's synthetic cell paths at
+   * an already-imported real target here is enough for
+   * `Compilers.loadCompiler` to pick up its real classpath unmodified.
+   * `combinedMarkerPath` is registered too, since `triggerDiagnostics` uses
+   * that path for its own, separate `compilers().didChange` call.
+   */
+  private def reregisterTargetData(ipynbPath: AbsolutePath): Unit = {
+    registeredData.remove(ipynbPath).foreach(buildTargets.removeData)
+    for {
+      target <- associatedTarget.get(ipynbPath)
+      cellPaths <- notebooks.get(ipynbPath)
+    } {
+      val data = new TargetData
+      cellPaths.foreach(data.addSourceItem(_, target))
+      data.addSourceItem(combinedMarkerPath(ipynbPath), target)
+      buildTargets.addData(data)
+      registeredData.put(ipynbPath, data)
+    }
+  }
 
   /**
    * Consulted from [[SourceMapper.pcMapping]]. `None` for any path that
@@ -270,6 +374,7 @@ final class NotebookProvider(
     }
     notebooks.put(ipynbPath, updated)
     combinedCache.remove(ipynbPath)
+    reregisterTargetData(ipynbPath)
   }
 
   private def forgetNotebook(ipynbPath: AbsolutePath): Unit = {
@@ -282,6 +387,8 @@ final class NotebookProvider(
       buffers.remove(path)
     }
     combinedCache.remove(ipynbPath)
+    associatedTarget.remove(ipynbPath)
+    registeredData.remove(ipynbPath).foreach(buildTargets.removeData)
   }
 
   private def clearDiagnostics(uri: String): Unit =

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -201,6 +201,18 @@ object ServerCommands {
        |""".stripMargin,
   )
 
+  val ChooseNotebookBuildTarget = new ParametrizedCommand[String](
+    "notebook-choose-build-target",
+    "Choose build target for notebook",
+    """|Associate a `.ipynb` notebook's Scala cells with one of the
+       |workspace's build targets, so hover/completion/definition/
+       |diagnostics for its cells see that target's real dependency
+       |classpath instead of just the standard library.
+       |""".stripMargin,
+    """|[uri], uri of the `.ipynb` notebook.
+       |""".stripMargin,
+  )
+
   val RunDoctor = new Command(
     "doctor-run",
     "Run doctor",
@@ -846,6 +858,7 @@ object ServerCommands {
       DisconnectBuildServer,
       DisconnectBuildServerAndShutdown,
       ListBuildTargets,
+      ChooseNotebookBuildTarget,
       ScanWorkspaceSources,
       StartDebugAdapter,
       StartMainClass,

--- a/metals/src/main/scala/scala/meta/internal/metals/SourceMapper.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SourceMapper.scala
@@ -13,6 +13,7 @@ import org.eclipse.{lsp4j => l}
 final case class SourceMapper(
     buildTargets: BuildTargets,
     buffers: Buffers,
+    notebookProvider: NotebookProvider,
 ) {
   def mappedFrom(path: AbsolutePath): Option[AbsolutePath] =
     buildTargets.mappedFrom(path)
@@ -80,7 +81,10 @@ final case class SourceMapper(
               }
           }
         Try(TwirlAdjustments(input, scalaVersion, playVersion)).toOption
-      } else None
+      } else {
+        // no-op for any path that isn't a currently-known notebook cell
+        notebookProvider.combinedAdjustments(path)
+      }
 
     forScripts.getOrElse(default)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1012,6 +1012,12 @@ class WorkspaceLspService(
             )
             .asJava
         }.asJavaObject
+      case ServerCommands.ChooseNotebookBuildTarget(uri) =>
+        getServiceForOpt(uri)
+          .orElse(currentFolder)
+          .getOrElse(fallbackService)
+          .chooseNotebookBuildTarget(uri)
+          .asJavaObject
       case ServerCommands.BspSwitch() =>
         onCurrentFolder(
           _.switchBspServer().ignoreValue,

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1,104 +1,97 @@
 package scala.meta.internal.metals
 
+import ch.epfl.scala.bsp4j.{BuildTargetIdentifier, DebugSessionParams}
+import com.google.gson.{Gson, JsonPrimitive}
+import io.undertow.server.HttpServerExchange
+import org.eclipse.lsp4j
+import org.eclipse.lsp4j.{
+  CallHierarchyIncomingCall,
+  CallHierarchyIncomingCallsParams,
+  CallHierarchyItem,
+  CallHierarchyOutgoingCall,
+  CallHierarchyOutgoingCallsParams,
+  CallHierarchyPrepareParams,
+  CodeAction,
+  CodeActionParams,
+  CodeLens,
+  CodeLensParams,
+  CompletionItem,
+  CompletionList,
+  CompletionParams,
+  DidChangeConfigurationParams,
+  DidChangeNotebookDocumentParams,
+  DidChangeTextDocumentParams,
+  DidChangeWatchedFilesParams,
+  DidCloseNotebookDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenNotebookDocumentParams,
+  DidOpenTextDocumentParams,
+  DidSaveNotebookDocumentParams,
+  DidSaveTextDocumentParams,
+  DocumentFormattingParams,
+  DocumentHighlight,
+  DocumentOnTypeFormattingParams,
+  DocumentRangeFormattingParams,
+  DocumentSymbol,
+  DocumentSymbolParams,
+  ExecuteCommandParams,
+  FoldingRange,
+  FoldingRangeRequestParams,
+  Hover,
+  Location,
+  ReferenceParams,
+  RenameFilesParams,
+  RenameParams,
+  SelectionRange,
+  SelectionRangeParams,
+  SemanticTokens,
+  SemanticTokensParams,
+  SignatureHelp,
+  SymbolInformation,
+  TextDocumentPositionParams,
+  TextEdit,
+  TypeHierarchyItem,
+  TypeHierarchyPrepareParams,
+  TypeHierarchySubtypesParams,
+  TypeHierarchySupertypesParams,
+  WorkspaceEdit,
+  WorkspaceSymbolParams,
+}
+import org.eclipse.lsp4j.jsonrpc.{messages, ResponseErrorException}
+
+import java.util as ju
 import java.net.URI
 import java.nio.file.ProviderMismatchException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicReference
-import java.{util => ju}
-
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContextExecutorService
-import scala.concurrent.Future
-import scala.concurrent.Promise
+import scala.concurrent.{
+  Await,
+  ExecutionContextExecutorService,
+  Future,
+  Promise,
+}
 import scala.concurrent.duration.Duration
-import scala.util.control.NonFatal
-
 import scala.meta.internal.bsp.BuildChange
-import scala.meta.internal.builds.NewProjectProvider
-import scala.meta.internal.builds.ShellRunner
-import scala.meta.internal.metals.DidFocusResult
-import scala.meta.internal.metals.HoverExtParams
-import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.metals.MetalsLspService
-import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
-import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.builds.{NewProjectProvider, ShellRunner}
+import scala.meta.internal.metals.MetalsEnrichments.*
+import scala.meta.internal.metals.clients.language.{
+  ConfiguredLanguageClient,
+  MetalsLanguageClient,
+}
 import scala.meta.internal.metals.config.StatusBarState
-import scala.meta.internal.metals.debug.DebugProvider
-import scala.meta.internal.metals.debug.DiscoveryFailures
-import scala.meta.internal.metals.doctor.DoctorVisibilityDidChangeParams
-import scala.meta.internal.metals.doctor.HeadDoctor
+import scala.meta.internal.metals.debug.{DebugProvider, DiscoveryFailures}
+import scala.meta.internal.metals.doctor.{
+  DoctorVisibilityDidChangeParams,
+  HeadDoctor,
+}
 import scala.meta.internal.metals.findfiles.FindTextInDependencyJarsRequest
 import scala.meta.internal.metals.logging.LanguageClientLogger
 import scala.meta.internal.parsing.ClassFinderGranularity
 import scala.meta.internal.pc
-import scala.meta.internal.tvp.MetalsTreeViewChildrenResult
-import scala.meta.internal.tvp.MetalsTreeViewProvider
-import scala.meta.internal.tvp.NoopTreeViewProvider
-import scala.meta.internal.tvp.TreeViewChildrenParams
-import scala.meta.internal.tvp.TreeViewNodeCollapseDidChangeParams
-import scala.meta.internal.tvp.TreeViewNodeRevealResult
-import scala.meta.internal.tvp.TreeViewParentParams
-import scala.meta.internal.tvp.TreeViewParentResult
-import scala.meta.internal.tvp.TreeViewProvider
-import scala.meta.internal.tvp.TreeViewVisibilityDidChangeParams
+import scala.meta.internal.tvp.*
 import scala.meta.io.AbsolutePath
 import scala.meta.metals.lsp.ScalaLspService
-
-import ch.epfl.scala.bsp4j.BuildTargetIdentifier
-import ch.epfl.scala.bsp4j.DebugSessionParams
-import com.google.gson.Gson
-import com.google.gson.JsonPrimitive
-import io.undertow.server.HttpServerExchange
-import org.eclipse.lsp4j
-import org.eclipse.lsp4j.CallHierarchyIncomingCall
-import org.eclipse.lsp4j.CallHierarchyIncomingCallsParams
-import org.eclipse.lsp4j.CallHierarchyItem
-import org.eclipse.lsp4j.CallHierarchyOutgoingCall
-import org.eclipse.lsp4j.CallHierarchyOutgoingCallsParams
-import org.eclipse.lsp4j.CallHierarchyPrepareParams
-import org.eclipse.lsp4j.CodeAction
-import org.eclipse.lsp4j.CodeActionParams
-import org.eclipse.lsp4j.CodeLens
-import org.eclipse.lsp4j.CodeLensParams
-import org.eclipse.lsp4j.CompletionItem
-import org.eclipse.lsp4j.CompletionList
-import org.eclipse.lsp4j.CompletionParams
-import org.eclipse.lsp4j.DidChangeConfigurationParams
-import org.eclipse.lsp4j.DidChangeTextDocumentParams
-import org.eclipse.lsp4j.DidChangeWatchedFilesParams
-import org.eclipse.lsp4j.DidCloseTextDocumentParams
-import org.eclipse.lsp4j.DidOpenTextDocumentParams
-import org.eclipse.lsp4j.DidSaveTextDocumentParams
-import org.eclipse.lsp4j.DocumentFormattingParams
-import org.eclipse.lsp4j.DocumentHighlight
-import org.eclipse.lsp4j.DocumentOnTypeFormattingParams
-import org.eclipse.lsp4j.DocumentRangeFormattingParams
-import org.eclipse.lsp4j.DocumentSymbol
-import org.eclipse.lsp4j.DocumentSymbolParams
-import org.eclipse.lsp4j.ExecuteCommandParams
-import org.eclipse.lsp4j.FoldingRange
-import org.eclipse.lsp4j.FoldingRangeRequestParams
-import org.eclipse.lsp4j.Hover
-import org.eclipse.lsp4j.Location
-import org.eclipse.lsp4j.ReferenceParams
-import org.eclipse.lsp4j.RenameFilesParams
-import org.eclipse.lsp4j.RenameParams
-import org.eclipse.lsp4j.SelectionRange
-import org.eclipse.lsp4j.SelectionRangeParams
-import org.eclipse.lsp4j.SemanticTokens
-import org.eclipse.lsp4j.SemanticTokensParams
-import org.eclipse.lsp4j.SignatureHelp
-import org.eclipse.lsp4j.SymbolInformation
-import org.eclipse.lsp4j.TextDocumentPositionParams
-import org.eclipse.lsp4j.TextEdit
-import org.eclipse.lsp4j.TypeHierarchyItem
-import org.eclipse.lsp4j.TypeHierarchyPrepareParams
-import org.eclipse.lsp4j.TypeHierarchySubtypesParams
-import org.eclipse.lsp4j.TypeHierarchySupertypesParams
-import org.eclipse.lsp4j.WorkspaceEdit
-import org.eclipse.lsp4j.WorkspaceSymbolParams
-import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
-import org.eclipse.lsp4j.jsonrpc.messages
+import scala.util.control.NonFatal
 
 class WorkspaceLspService(
     ec: ExecutionContextExecutorService,
@@ -109,7 +102,7 @@ class WorkspaceLspService(
     val folders: List[Folder],
     fallbackServicePath: => AbsolutePath,
 ) extends ScalaLspService {
-  import serverInputs._
+  import serverInputs.*
   implicit val ex: ExecutionContextExecutorService = ec
   implicit val rc: ReportContext = LoggerReportContext
   private val cancelables = new MutableCancelable()
@@ -506,6 +499,20 @@ class WorkspaceLspService(
       params: DidSaveTextDocumentParams
   ): CompletableFuture[Unit] =
     getServiceFor(params.getTextDocument().getUri()).didSave(params)
+
+  override def notebookDidOpen(params: DidOpenNotebookDocumentParams): Unit =
+    getServiceFor(params.getNotebookDocument.getUri).notebookDidOpen(params)
+
+  override def notebookDidChange(
+      params: DidChangeNotebookDocumentParams
+  ): Unit =
+    getServiceFor(params.getNotebookDocument.getUri).notebookDidChange(params)
+
+  override def notebookDidSave(params: DidSaveNotebookDocumentParams): Unit =
+    getServiceFor(params.getNotebookDocument.getUri).notebookDidSave(params)
+
+  override def notebookDidClose(params: DidCloseNotebookDocumentParams): Unit =
+    getServiceFor(params.getNotebookDocument.getUri).notebookDidClose(params)
 
   override def definition(
       position: TextDocumentPositionParams
@@ -1382,6 +1389,20 @@ class WorkspaceLspService(
           new lsp4j.SaveOptions( /* includeText = */ false)
         )
         textDocumentSyncOptions.setOpenClose(true)
+
+        // Sync Scala cells of any notebook (see NotebookProvider), so we stop
+        // crashing on `vscode-notebook-cell:` uris and can give them basic
+        // language support (https://github.com/scalameta/metals-feature-requests/issues/236).
+        val notebookSelector = new lsp4j.NotebookSelector()
+        notebookSelector.setNotebook("*")
+        notebookSelector.setCells(
+          List(new lsp4j.NotebookSelectorCell("scala")).asJava
+        )
+        capabilities.setNotebookDocumentSync(
+          new lsp4j.NotebookDocumentSyncRegistrationOptions(
+            List(notebookSelector).asJava
+          )
+        )
 
         val scalaFilesPattern = new lsp4j.FileOperationPattern("**/*.scala")
         scalaFilesPattern.setMatches(lsp4j.FileOperationPatternKind.File)

--- a/metals/src/main/scala/scala/meta/metals/lsp/DelegatingScalaService.scala
+++ b/metals/src/main/scala/scala/meta/metals/lsp/DelegatingScalaService.scala
@@ -37,6 +37,22 @@ class DelegatingScalaService(
       params: DidOpenTextDocumentParams
   ): CompletableFuture[Unit] = underlying.didOpen(params)
 
+  override def notebookDidOpen(
+      params: DidOpenNotebookDocumentParams
+  ): Unit = underlying.notebookDidOpen(params)
+
+  override def notebookDidChange(
+      params: DidChangeNotebookDocumentParams
+  ): Unit = underlying.notebookDidChange(params)
+
+  override def notebookDidSave(
+      params: DidSaveNotebookDocumentParams
+  ): Unit = underlying.notebookDidSave(params)
+
+  override def notebookDidClose(
+      params: DidCloseNotebookDocumentParams
+  ): Unit = underlying.notebookDidClose(params)
+
   override def didFocus(
       params: AnyRef
   ): CompletableFuture[DidFocusResult.Value] = underlying.didFocus(params)

--- a/metals/src/main/scala/scala/meta/metals/lsp/LanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/metals/lsp/LanguageServer.scala
@@ -45,6 +45,7 @@ trait LanguageServer {
 
 trait ScalaLspService
     extends TextDocumentService
+    with NotebookDocumentService
     with WorkspaceService
     with MetalsService
     with WindowService

--- a/metals/src/main/scala/scala/meta/metals/lsp/NotebookDocumentService.scala
+++ b/metals/src/main/scala/scala/meta/metals/lsp/NotebookDocumentService.scala
@@ -1,0 +1,30 @@
+package scala.meta.metals.lsp
+
+import org.eclipse.lsp4j.DidChangeNotebookDocumentParams
+import org.eclipse.lsp4j.DidCloseNotebookDocumentParams
+import org.eclipse.lsp4j.DidOpenNotebookDocumentParams
+import org.eclipse.lsp4j.DidSaveNotebookDocumentParams
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
+
+/**
+ * Notebook document synchronization
+ * (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notebookDocument_synchronization),
+ * used to give Scala notebook cells (`vscode-notebook-cell:` documents,
+ * see https://github.com/scalameta/metals-feature-requests/issues/236)
+ * language support. See [[scala.meta.internal.metals.NotebookProvider]].
+ */
+trait NotebookDocumentService {
+
+  @JsonNotification("notebookDocument/didOpen")
+  def notebookDidOpen(params: DidOpenNotebookDocumentParams): Unit
+
+  @JsonNotification("notebookDocument/didChange")
+  def notebookDidChange(params: DidChangeNotebookDocumentParams): Unit
+
+  @JsonNotification("notebookDocument/didSave")
+  def notebookDidSave(params: DidSaveNotebookDocumentParams): Unit
+
+  @JsonNotification("notebookDocument/didClose")
+  def notebookDidClose(params: DidCloseNotebookDocumentParams): Unit
+
+}

--- a/tests/unit/src/test/scala/tests/notebooks/NotebookLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/notebooks/NotebookLspSuite.scala
@@ -17,7 +17,14 @@ import scala.meta.io.AbsolutePath
  */
 class NotebookLspSuite extends BaseLspSuite("notebooks") {
 
-  private val notebookPath = "a/src/main/scala/a/Notebook.ipynb"
+  // Deliberately NOT nested under any build target's own source root (e.g.
+  // `a/src/main/scala/a/...`): `TargetData.sourceBuildTargets` matches by
+  // path *prefix*, so a notebook physically inside a target's source tree
+  // would accidentally resolve to that target's real classpath via the
+  // target's own, normal BSP-registered source root — regardless of whether
+  // this file's own association mechanism ever runs — making tests that
+  // check the "no/wrong association" case pass for the wrong reason.
+  private val notebookPath = "Notebook.ipynb"
 
   private def ipynb: AbsolutePath = server.toPath(notebookPath)
 
@@ -507,4 +514,28 @@ class NotebookLspSuite extends BaseLspSuite("notebooks") {
       Seq.empty,
     )
   }
+
+  test("single-real-build-target-auto-associates") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {
+            |    "libraryDependencies": ["io.circe::circe-generic:0.12.0"]
+            |  }
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      _ = openNotebook("c1" -> "val x: io.circe.Decoder[Int] = ???")
+      _ <- client.nextDiagnosticsFor(cellPath("c1"))
+    } yield assertEquals(
+      client.diagnostics.getOrElse(cellPath("c1"), Seq.empty),
+      Seq.empty,
+      "the workspace's only build target should auto-associate, giving the cell circe on its classpath",
+    )
+  }
+
 }

--- a/tests/unit/src/test/scala/tests/notebooks/NotebookLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/notebooks/NotebookLspSuite.scala
@@ -1,0 +1,510 @@
+package tests.notebooks
+
+import org.eclipse.lsp4j as l
+import tests.{BaseLspSuite, TestHovers}
+
+import java.util as ju
+import scala.concurrent.Future
+import scala.meta.internal.metals.MetalsEnrichments.*
+import scala.meta.internal.metals.{HoverExtParams, NotebookProvider}
+import scala.meta.io.AbsolutePath
+
+/**
+ * End to end tests for basic notebook cell language support
+ * (https://github.com/scalameta/metals-feature-requests/issues/236),
+ * driving `notebookDocument` and `textDocument` notifications/requests
+ * directly rather than through a real VS Code + metals-vscode integration.
+ */
+class NotebookLspSuite extends BaseLspSuite("notebooks") {
+
+  private val notebookPath = "a/src/main/scala/a/Notebook.ipynb"
+
+  private def ipynb: AbsolutePath = server.toPath(notebookPath)
+
+  private def cellUri(id: String): String =
+    s"${NotebookProvider.scheme}:${ipynb.toString}#$id"
+
+  private def cellPath(id: String): AbsolutePath =
+    NotebookProvider.uriToPath(cellUri(id))
+
+  private def openNotebook(cells: (String, String)*): Unit = {
+    val notebookCells = cells.map { case (id, _) =>
+      new l.NotebookCell(l.NotebookCellKind.Code, cellUri(id))
+    }
+    val notebookDocument = new l.NotebookDocument(
+      ipynb.toURI.toString,
+      "jupyter-notebook",
+      1,
+      notebookCells.asJava,
+    )
+    val cellTextDocuments = cells.map { case (id, text) =>
+      new l.TextDocumentItem(cellUri(id), "scala", 1, text)
+    }
+    server.fullServer.notebookDidOpen(
+      new l.DidOpenNotebookDocumentParams(
+        notebookDocument,
+        cellTextDocuments.asJava,
+      )
+    )
+  }
+
+  private def changeCell(
+      id: String,
+      newText: String,
+      version: Int = 2,
+  ): Unit = {
+    val textContent = new l.NotebookDocumentChangeEventCellTextContent(
+      new l.VersionedTextDocumentIdentifier(cellUri(id), version),
+      ju.List.of(new l.TextDocumentContentChangeEvent(newText)),
+    )
+    val cellsChange = new l.NotebookDocumentChangeEventCells()
+    cellsChange.setTextContent(ju.List.of(textContent))
+    val change = new l.NotebookDocumentChangeEvent()
+    change.setCells(cellsChange)
+    server.fullServer.notebookDidChange(
+      new l.DidChangeNotebookDocumentParams(
+        new l.VersionedNotebookDocumentIdentifier(2, ipynb.toURI.toString),
+        change,
+      )
+    )
+  }
+
+  /** A `notebookDocument/didChange` with only a `cells.structure` change. */
+  private def structureChange(
+      start: Int,
+      deleteCount: Int,
+      inserted: List[(String, String)] = Nil,
+      closed: List[String] = Nil,
+  ): Unit = {
+    val arrayChange = new l.NotebookCellArrayChange(
+      start,
+      deleteCount,
+      inserted.map { case (id, _) =>
+        new l.NotebookCell(l.NotebookCellKind.Code, cellUri(id))
+      }.asJava,
+    )
+    val structure = new l.NotebookDocumentChangeEventCellStructure(arrayChange)
+    if (inserted.nonEmpty)
+      structure.setDidOpen(
+        inserted.map { case (id, text) =>
+          new l.TextDocumentItem(cellUri(id), "scala", 1, text)
+        }.asJava
+      )
+    if (closed.nonEmpty)
+      structure.setDidClose(
+        closed.map(id => new l.TextDocumentIdentifier(cellUri(id))).asJava
+      )
+    val cellsChange = new l.NotebookDocumentChangeEventCells()
+    cellsChange.setStructure(structure)
+    val change = new l.NotebookDocumentChangeEvent()
+    change.setCells(cellsChange)
+    server.fullServer.notebookDidChange(
+      new l.DidChangeNotebookDocumentParams(
+        new l.VersionedNotebookDocumentIdentifier(2, ipynb.toURI.toString),
+        change,
+      )
+    )
+  }
+
+  private def definitionAt(
+      id: String,
+      line: Int,
+      character: Int,
+  ): Future[java.util.List[l.Location]] =
+    server.fullServer
+      .definition(
+        new l.TextDocumentPositionParams(
+          new l.TextDocumentIdentifier(cellUri(id)),
+          new l.Position(line, character),
+        )
+      )
+      .asScala
+
+  private def completionAt(
+      id: String,
+      line: Int,
+      character: Int,
+  ): Future[l.CompletionList] =
+    server.fullServer
+      .completion(
+        new l.CompletionParams(
+          new l.TextDocumentIdentifier(cellUri(id)),
+          new l.Position(line, character),
+        )
+      )
+      .asScala
+
+  private def hoverAt(
+      id: String,
+      line: Int,
+      character: Int,
+      code: String,
+  ): Future[String] =
+    server.fullServer
+      .hover(
+        HoverExtParams(
+          new l.TextDocumentIdentifier(cellUri(id)),
+          new l.Position(line, character),
+        )
+      )
+      .asScala
+      .map(hover =>
+        TestHovers.renderAsString(code, Option(hover), includeRange = false)
+      )
+
+  test("no-crash-on-didFocus") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {}
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      _ = openNotebook("c1" -> "val x = 1")
+      // Before this feature, this threw FileSystemNotFoundException (see
+      // https://github.com/scalameta/metals-feature-requests/issues/236);
+      // reaching this point at all is the assertion.
+      _ <- server.fullServer.didFocus(cellUri("c1")).asScala
+    } yield ()
+  }
+
+  test("cross-cell-completion-and-hover") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {}
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      _ = openNotebook(
+        "c1" -> "val xs = List(1, 2, 3)",
+        "c2" -> "xs.",
+      )
+      completions <- completionAt("c2", 0, 3)
+      labels = completions.getItems.asScala.map(_.getLabel).toSet
+      _ = assert(
+        labels.exists(_.startsWith("length")),
+        s"expected `length` among completions, got: $labels",
+      )
+      hover <- hoverAt("c2", 0, 1, "xs.")
+      _ = assert(
+        hover.contains("List[Int]"),
+        s"expected hover to mention List[Int], got:\n$hover",
+      )
+    } yield ()
+  }
+
+  test("diagnostics-published-and-cleared-per-cell") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {}
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      _ = openNotebook(
+        "c1" -> "val xs = List(1, 2, 3)",
+        "c2" -> "val y: Int = \"bad\"",
+      )
+      _ <- client.nextDiagnosticsFor(cellPath("c2"), _.nonEmpty)
+      _ = assert(
+        client.diagnostics(cellPath("c2")).exists { d =>
+          d.getMessageAsString.contains("type mismatch") &&
+          d.getRange.getStart.getLine == 0
+        },
+        s"unexpected c2 diagnostics: ${client.diagnostics(cellPath("c2"))}",
+      )
+      _ = assertEquals(
+        client.diagnostics.getOrElse(cellPath("c1"), Seq.empty),
+        Seq.empty,
+      )
+      _ = changeCell("c2", "val y: Int = 2")
+      _ <- client.nextDiagnosticsFor(cellPath("c2"), _.isEmpty)
+    } yield assertEquals(client.diagnostics(cellPath("c2")), Seq.empty)
+  }
+
+  test("completionItem-resolve-does-not-crash") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {}
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      _ = openNotebook(
+        "c1" -> "val xs = List(1, 2, 3)",
+        "c2" -> "xs.",
+      )
+      completions <- completionAt("c2", 0, 3)
+      item = completions.getItems.asScala
+        .find(_.getLabel.startsWith("length"))
+        .getOrElse(fail("no `length` completion for `xs.`"))
+      resolved <- server.fullServer.completionItemResolve(item).asScala
+    } yield assertEquals(resolved.getLabel, item.getLabel)
+  }
+
+  test("cell-removed-via-structure-change-loses-context-and-diagnostics") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {}
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      _ = openNotebook(
+        "c1" -> "val xs = List(1, 2, 3)",
+        "c2" -> "val bad: Int = \"x\"",
+        "c3" -> "xs.",
+      )
+      _ <- client.nextDiagnosticsFor(cellPath("c2"), _.nonEmpty)
+      // remove c2 (index 1); c3 becomes the second cell, right after c1.
+      // `clearDiagnostics` publishes synchronously as part of this call, so
+      // (unlike a real recompute) there is no later event to await here.
+      _ = structureChange(start = 1, deleteCount = 1, closed = List("c2"))
+      // c2's stale diagnostic must be cleared, not left dangling
+      _ = assertEquals(
+        client.diagnostics.getOrElse(cellPath("c2"), Seq.empty),
+        Seq.empty,
+      )
+      // c3 must still see `xs` from c1 despite the reshuffled offsets
+      completions <- completionAt("c3", 0, 3)
+      labels = completions.getItems.asScala.map(_.getLabel).toSet
+    } yield assert(
+      labels.exists(_.startsWith("length")),
+      s"expected `length` among completions after removing c2, got: $labels",
+    )
+  }
+
+  test("folding-range-and-semantic-tokens-do-not-crash") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {}
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      _ = openNotebook(
+        "c1" -> "val xs = List(1, 2, 3)",
+        "c2" -> "xs.map(_ + 1)",
+      )
+      _ <- server.fullServer
+        .foldingRange(
+          new l.FoldingRangeRequestParams(
+            new l.TextDocumentIdentifier(cellUri("c2"))
+          )
+        )
+        .asScala
+      tokens <- server.fullServer
+        .semanticTokensFull(
+          new l.SemanticTokensParams(
+            new l.TextDocumentIdentifier(cellUri("c2"))
+          )
+        )
+        .asScala
+    } yield assert(
+      tokens.getData.size() > 0,
+      "expected some semantic tokens for a non-empty cell",
+    )
+  }
+
+  test("markdown-and-other-language-cells-are-ignored") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {}
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      // A real .ipynb almost always mixes markdown cells (and possibly other
+      // languages) in with Scala code cells; those must not be spliced into
+      // the concatenated script, or they'd break its compilation entirely.
+      cellsMeta = List(
+        l.NotebookCellKind.Markup -> "md",
+        l.NotebookCellKind.Code -> "c1",
+        l.NotebookCellKind.Code -> "py",
+        l.NotebookCellKind.Code -> "c2",
+      )
+      notebookCells = cellsMeta.map { case (kind, id) =>
+        new l.NotebookCell(kind, cellUri(id))
+      }
+      notebookDocument = new l.NotebookDocument(
+        ipynb.toURI.toString,
+        "jupyter-notebook",
+        1,
+        notebookCells.asJava,
+      )
+      cellTextDocuments = List(
+        new l.TextDocumentItem(cellUri("md"), "markdown", 1, "# hello"),
+        new l.TextDocumentItem(
+          cellUri("c1"),
+          "scala",
+          1,
+          "val xs = List(1, 2, 3)",
+        ),
+        new l.TextDocumentItem(cellUri("py"), "python", 1, "xs = [1, 2, 3]"),
+        new l.TextDocumentItem(cellUri("c2"), "scala", 1, "xs."),
+      )
+      _ = server.fullServer.notebookDidOpen(
+        new l.DidOpenNotebookDocumentParams(
+          notebookDocument,
+          cellTextDocuments.asJava,
+        )
+      )
+      completions <- completionAt("c2", 0, 3)
+      labels = completions.getItems.asScala.map(_.getLabel).toSet
+    } yield assert(
+      labels.exists(_.startsWith("length")),
+      s"expected `length` among completions with markdown/python cells filtered out of the combined script, got: $labels",
+    )
+  }
+
+  test("cross-cell-go-to-definition-points-at-the-right-cell") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {}
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      _ = openNotebook(
+        "c1" -> "def add(a: Int, b: Int): Int = a + b",
+        "c2" -> "add(1, 2)",
+      )
+      locations <- definitionAt("c2", 0, 1)
+    } yield {
+      assert(!locations.isEmpty, "expected at least one definition location")
+      val location = locations.get(0)
+      assertEquals(
+        location.getUri,
+        cellUri("c1"),
+        s"definition of `add` should point at c1, not the requesting cell c2 (got ${location.getUri})",
+      )
+      assertEquals(
+        location.getRange.getStart.getLine,
+        0,
+        s"expected line 0 within c1 (its own local coordinates), got range ${location.getRange}",
+      )
+    }
+  }
+
+  test("documentSymbol-references-rename-callHierarchy-do-not-crash") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {}
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      _ = openNotebook(
+        "c1" -> "def add(a: Int, b: Int): Int = a + b",
+        "c2" -> "add(1, 2)",
+      )
+      _ <- server.fullServer
+        .documentSymbol(
+          new l.DocumentSymbolParams(
+            new l.TextDocumentIdentifier(cellUri("c1"))
+          )
+        )
+        .asScala
+      _ <- server.fullServer
+        .references(
+          new l.ReferenceParams(
+            new l.TextDocumentIdentifier(cellUri("c1")),
+            new l.Position(0, 5),
+            new l.ReferenceContext(false),
+          )
+        )
+        .asScala
+      _ <- server.fullServer
+        .prepareRename(
+          new l.TextDocumentPositionParams(
+            new l.TextDocumentIdentifier(cellUri("c1")),
+            new l.Position(0, 5),
+          )
+        )
+        .asScala
+      _ <- server.fullServer
+        .rename(
+          new l.RenameParams(
+            new l.TextDocumentIdentifier(cellUri("c1")),
+            new l.Position(0, 5),
+            "sum",
+          )
+        )
+        .asScala
+      _ <- server.fullServer
+        .prepareCallHierarchy(
+          new l.CallHierarchyPrepareParams(
+            new l.TextDocumentIdentifier(cellUri("c1")),
+            new l.Position(0, 5),
+          )
+        )
+        .asScala
+    } yield ()
+  }
+
+  test("bare-expression-cells-are-not-a-parse-error") {
+    // A cell containing just an expression (`xs.length`, `println(xs)`, ...)
+    // is completely ordinary notebook content, but is *not* itself legal at
+    // the true top level of a Scala 3 source (unlike a `val`/`def`): Scala 3
+    // allows multiple top-level *definitions*, not bare statements. Before
+    // the concatenated script was wrapped in a throwaway `object`, this cell
+    // alone produced a spurious "Illegal start of toplevel definition".
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {}
+            |}
+            |/$notebookPath
+            |{}
+            |""".stripMargin
+      )
+      _ = openNotebook(
+        "c1" -> "val xs = List(1, 2, 3)",
+        "c2" -> "xs.length",
+      )
+      _ <- client.nextDiagnosticsFor(cellPath("c2"))
+    } yield assertEquals(
+      client.diagnostics.getOrElse(cellPath("c2"), Seq.empty),
+      Seq.empty,
+    )
+  }
+}


### PR DESCRIPTION
Executing cells is out of scope this PR. It would need a real Jupyter kernel, e.g. Almond. 

vibe-codec, self-review, polished and verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Scala notebook support, including cell synchronization, diagnostics, completion, hover, navigation, symbols, folding, and semantic highlighting.
  * Added automatic and selectable build-target association for notebooks, enabling dependency-aware language features.
  * Added notebook kernel installation support.
  * Added handling for notebook cell URIs and lifecycle events.

* **Tests**
  * Added comprehensive end-to-end coverage for notebook language features and cell changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->